### PR TITLE
Fix/wayback url

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -231,10 +231,10 @@
       </div>
 
       <div class="feature-row">
-        <p class="feature-row-label">Chrome extension</p>
+        <p class="feature-row-label">Browser extension</p>
         <div class="feature-row-body">
-          <h3>Capture pages, not screenshots</h3>
-          <p>The Sourcerer browser extension captures full-page screenshots from any tab and sends them directly to the app, where they are stored encrypted alongside the database. Link a screenshot to a contact record in seconds — no cloud upload, no third-party storage, no unencrypted files on disk.</p>
+          <h3>Research without leaving your browser</h3>
+          <p>The Sourcerer browser extension brings your source database into every tab. Capture full-page screenshots and link them to a contact record, save selected text directly as an email, phone number, or note on an existing contact, or add a new contact without switching apps. A right-click context menu puts all of these actions one step away. Everything goes straight into the encrypted local database — no cloud upload, no third-party storage.</p>
           <p><a href="https://chromewebstore.google.com/detail/sourcerer/pipgdnekoknjbghnmhilapocpchdcadm" target="_blank" rel="noopener">Install from the Chrome Web Store ↗</a></p>
         </div>
       </div>

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -28,19 +28,41 @@ let cachedPairs: DuplicatePair[] = [];
 let dedupScanTimer: ReturnType<typeof setTimeout> | null = null;
 
 async function triggerWaybackSave(contactId: string, url: string): Promise<void> {
+  console.log(`[wayback] Requesting archive for ${url}`);
+  const broadcast = (status: 'pending' | 'failed') => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('contacts:wayback-status', { contactId, url, status });
+    }
+  };
+
+  broadcast('pending');
   try {
     const response = await fetch(`https://web.archive.org/save/${encodeURIComponent(url)}`, {
       redirect: 'follow',
       headers: { 'User-Agent': 'Sourcerer/1.0' },
     });
     const waybackUrl = response.url;
+    console.log(`[wayback] Response status=${response.status} url=${waybackUrl}`);
+    if (!response.ok) {
+      console.warn(`[wayback] Archive request failed with HTTP ${response.status} for ${url}`);
+      broadcast('failed');
+      return;
+    }
     if (waybackUrl.includes('web.archive.org/web/') && isDatabaseOpen()) {
       getDatabase()
         .prepare("UPDATE contact_links SET wayback_url = ? WHERE contact_id = ? AND type = 'website' AND url = ?")
         .run(waybackUrl, contactId, url);
+      console.log(`[wayback] Saved snapshot for ${url} → ${waybackUrl}`);
+      for (const win of BrowserWindow.getAllWindows()) {
+        win.webContents.send('contacts:wayback-updated', contactId);
+      }
+    } else {
+      console.warn(`[wayback] Unexpected response URL, snapshot not saved: ${waybackUrl}`);
+      broadcast('failed');
     }
-  } catch {
-    // Silent failure — Wayback may not be reachable
+  } catch (err) {
+    console.error(`[wayback] Failed to archive ${url}:`, err);
+    broadcast('failed');
   }
 }
 

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -130,7 +130,13 @@ function replaceSubTablesFromShared(
       .run(p.id, contactId, p.phone, p.sort_order);
   }
 
-  // Links
+  // Links — preserve local-only wayback_url before replacing from shared
+  const existingWaybacks = new Map<string, string | null>(
+    (local
+      .prepare("SELECT url, wayback_url FROM contact_links WHERE contact_id = ? AND type = 'website'")
+      .all(contactId) as { url: string; wayback_url: string | null }[])
+      .map((r) => [r.url, r.wayback_url]),
+  );
   local.prepare('DELETE FROM contact_links WHERE contact_id = ?').run(contactId);
   for (const l of shared
     .prepare('SELECT * FROM contact_links WHERE contact_id = ? ORDER BY sort_order')
@@ -143,9 +149,17 @@ function replaceSubTablesFromShared(
   }[]) {
     local
       .prepare(
-        'INSERT INTO contact_links (id, contact_id, type, label, url, sort_order) VALUES (?, ?, ?, ?, ?, ?)',
+        'INSERT INTO contact_links (id, contact_id, type, label, url, sort_order) VALUES (?, ?, ?, ?, ?, ?)'
       )
       .run(l.id, contactId, l.type, l.label, l.url, l.sort_order);
+    if (l.type === 'website') {
+      const wayback = existingWaybacks.get(l.url);
+      if (wayback) {
+        local
+          .prepare("UPDATE contact_links SET wayback_url = ? WHERE contact_id = ? AND type = 'website' AND url = ?")
+          .run(wayback, contactId, l.url);
+      }
+    }
   }
 
   // Alert RSS (one per contact)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -312,6 +312,16 @@ const sourcererApi = {
     ipcRenderer.on('contacts:duplicates-updated', handler);
     return () => ipcRenderer.removeListener('contacts:duplicates-updated', handler);
   },
+  onWaybackUpdated: (callback: (contactId: string) => void): (() => void) => {
+    const handler = (_: unknown, contactId: string) => callback(contactId);
+    ipcRenderer.on('contacts:wayback-updated', handler);
+    return () => ipcRenderer.removeListener('contacts:wayback-updated', handler);
+  },
+  onWaybackStatus: (callback: (payload: { contactId: string; url: string; status: 'pending' | 'failed' }) => void): (() => void) => {
+    const handler = (_: unknown, payload: { contactId: string; url: string; status: 'pending' | 'failed' }) => callback(payload);
+    ipcRenderer.on('contacts:wayback-status', handler);
+    return () => ipcRenderer.removeListener('contacts:wayback-status', handler);
+  },
 };
 
 contextBridge.exposeInMainWorld('sourcerer', sourcererApi);

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -1160,17 +1160,44 @@
 }
 
 .detail-wayback-link {
-  font-size: 11px;
+  font-size: 10px;
   color: var(--color-text-muted);
-  text-decoration: underline;
-  text-underline-offset: 2px;
+  text-decoration: none;
   cursor: pointer;
   white-space: nowrap;
   flex-shrink: 0;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
 }
 
 .detail-wayback-link:hover {
   color: var(--color-text);
+  text-decoration: underline;
+  text-underline-offset: 1px;
+}
+
+.detail-wayback-pending {
+  font-size: 10px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  animation: wayback-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes wayback-pulse {
+  0%, 100% { opacity: 0.7; }
+  50%       { opacity: 0.25; }
+}
+
+.detail-wayback-failed {
+  font-size: 10px;
+  color: var(--color-danger, #c0392b);
+  white-space: nowrap;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
 }
 
 .pt-conflict-banner {

--- a/src/renderer/src/contacts/ContactDetail.tsx
+++ b/src/renderer/src/contacts/ContactDetail.tsx
@@ -65,6 +65,12 @@ export default function ContactDetail({ contactId, onClose, onDeleted, onUpdated
     if (!hasProjects && activeTab === 'project') setActiveTab('global');
   }, [hasProjects, activeTab]);
 
+  useEffect(() => {
+    return window.sourcerer.onWaybackUpdated((updatedId) => {
+      if (updatedId === contactId) reload();
+    });
+  }, [contactId, reload]);
+
   function handleMembershipChanged() {
     reload();
     onUpdated();

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -126,10 +126,38 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
   const [hoveredScreenshotId, setHoveredScreenshotId] = useState<string | null>(null);
   const [confirmDeleteScreenshotId, setConfirmDeleteScreenshotId] = useState<string | null>(null);
   const [zoomMode, setZoomMode] = useState<'fit' | 'actual'>('fit');
+  const [waybackStatus, setWaybackStatus] = useState<Map<string, 'pending' | 'failed'>>(new Map());
   const viewerRef = useRef<HTMLDivElement>(null);
   const imageAreaRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
   const dragStart = useRef({ x: 0, y: 0, scrollLeft: 0, scrollTop: 0 });
+
+  useEffect(() => {
+    return window.sourcerer.onWaybackStatus(({ contactId, url, status }) => {
+      if (contactId !== contact.id) return;
+      setWaybackStatus((prev) => {
+        const next = new Map(prev);
+        if (status === 'pending') {
+          next.set(url, 'pending');
+        } else {
+          next.set(url, 'failed');
+        }
+        return next;
+      });
+    });
+  }, [contact.id]);
+
+  // Clear pending status when contact reloads with a wayback_url
+  useEffect(() => {
+    const archivedUrls = new Set(contact.links.filter((l) => l.wayback_url).map((l) => l.url));
+    if (archivedUrls.size === 0) return;
+    setWaybackStatus((prev) => {
+      if ([...archivedUrls].every((u) => !prev.has(u))) return prev;
+      const next = new Map(prev);
+      for (const url of archivedUrls) next.delete(url);
+      return next;
+    });
+  }, [contact.links]);
 
   useEffect(() => {
     if (viewingScreenshot) {
@@ -693,6 +721,12 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                 <a href={l.wayback_url} className="detail-wayback-link" onClick={(e) => { e.preventDefault(); window.open(l.wayback_url!); }} title="Wayback Machine snapshot">
                   archived ↗
                 </a>
+              )}
+              {!l.wayback_url && waybackStatus.get(l.url) === 'pending' && (
+                <span className="detail-wayback-pending">archiving…</span>
+              )}
+              {!l.wayback_url && waybackStatus.get(l.url) === 'failed' && (
+                <span className="detail-wayback-failed" title="Wayback Machine could not archive this URL">archive failed</span>
               )}
             </div>
           ))}

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -210,6 +210,8 @@ declare global {
         strategy: 'keep' | 'merge' | 'skip';
       }) => Promise<void>;
       onDuplicatePairsUpdated: (callback: (count: number) => void) => () => void;
+      onWaybackUpdated: (callback: (contactId: string) => void) => () => void;
+      onWaybackStatus: (callback: (payload: { contactId: string; url: string; status: 'pending' | 'failed' }) => void) => () => void;
     };
   }
 }


### PR DESCRIPTION
**Fix Wayback Machine archiving: sync overwrite bug + live UI feedback**

Two bugs fixed and one UX gap addressed.

Sync overwrite bug

When a contact was pulled from a shared project DB, the previous sync path deleted all local sub-table rows and re-inserted from shared — wiping any [wayback_url](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) values that had been saved locally. The shared DB intentionally doesn't store [wayback_url](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (it's a local enrichment), so those archived URLs were silently lost on every sync cycle.

Fixed by snapshotting [wayback_url](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) values before the DELETE, keyed by URL, and restoring them after re-insert. This is now also naturally handled by the union-merge logic in #7.

No UI feedback during archiving

The Wayback save is an async HTTP request that can take several seconds (and sometimes fails — Cloudflare-protected sites return HTTP 520 and Wayback's crawler is blocked). Previously there was no indication anything was happening, and failures were silent.

Fixed by emitting a [contacts:wayback-status](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) IPC event from the main process with pending / failed state, and a [contacts:wayback-updated](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) event on success. The renderer subscribes to both: website links now show a pulsing ARCHIVING… badge while in flight, ARCHIVE FAILED in red on error, and reload the contact automatically when the archive URL comes back.

Improved error logging

Distinguished HTTP-level errors (non-2xx responses, e.g. 520 from Cloudflare) from unexpected redirect URLs in the Wayback response, so failures are easier to diagnose in logs.