### PR TITLE
Add within-form duplicate field validation (closes #6)

### DIFF
--- a/src/renderer/src/contacts/AddContactModal.css
+++ b/src/renderer/src/contacts/AddContactModal.css
@@ -213,10 +213,13 @@
 }
 
 .ac-collision-warn {
-  font-size: 11px;
-  color: #b45309;
+  font-size: 10px;
+  color: var(--color-danger);
   margin-top: 3px;
   margin-bottom: 4px;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
 }
 
 .ac-field-hint {

--- a/src/renderer/src/contacts/AddContactModal.tsx
+++ b/src/renderer/src/contacts/AddContactModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, type FormEvent } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef, type FormEvent } from 'react';
 import type { ContactListItem, CreateContactInput, Project } from '@shared/types';
 import { useClickOutside } from '../hooks/useClickOutside';
 import './AddContactModal.css';
@@ -35,6 +35,11 @@ function isValidUrl(raw: string): boolean {
 // notation letters (e, x, t for "ext", # for US-style extensions).
 function hasDisallowedPhoneChars(raw: string): boolean {
   return /[^0-9+\-(). \t#extEXT]/.test(raw);
+}
+
+// Strip separators so spacing variants of the same number compare equal.
+function normalizePhoneForComparison(raw: string): string {
+  return raw.trim().replace(/[\s\-().]/g, '');
 }
 
 function DynamicList({
@@ -107,10 +112,53 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
   const [emailFormatWarnings, setEmailFormatWarnings] = useState<Record<string, true>>({});
   const [phoneFormatWarnings, setPhoneFormatWarnings] = useState<Record<string, true>>({});
   const [urlFormatWarnings, setUrlFormatWarnings] = useState<Record<string, true>>({});
+
+  // Computed within-form duplicate sets — derived from state, no extra state needed.
+  const emailDuplicates = useMemo(() => {
+    const seen = new Map<string, number>();
+    for (const e of emails) {
+      const v = e.email.trim().toLowerCase();
+      if (!v) continue;
+      seen.set(v, (seen.get(v) ?? 0) + 1);
+    }
+    const dupes = new Set<string>();
+    for (const [v, count] of seen) if (count > 1) dupes.add(v);
+    return dupes;
+  }, [emails]);
+
+  const phoneDuplicates = useMemo(() => {
+    const seen = new Map<string, number>();
+    for (const p of phones) {
+      const v = normalizePhoneForComparison(p.phone);
+      if (!v) continue;
+      seen.set(v, (seen.get(v) ?? 0) + 1);
+    }
+    const dupes = new Set<string>();
+    for (const [v, count] of seen) if (count > 1) dupes.add(v);
+    return dupes;
+  }, [phones]);
+
+  const urlDuplicates = useMemo(() => {
+    const seen = new Map<string, number>();
+    const allUrls = [
+      ...websites,
+      ...SOCIAL_TYPES.flatMap((t) => socials[t]),
+    ];
+    for (const url of allUrls) {
+      const v = url.trim();
+      if (!v) continue;
+      seen.set(v, (seen.get(v) ?? 0) + 1);
+    }
+    const dupes = new Set<string>();
+    for (const [v, count] of seen) if (count > 1) dupes.add(v);
+    return dupes;
+  }, [websites, socials]);
+
   const [projects, setProjects] = useState<Project[]>([]);
   const [selectedProjectIds, setSelectedProjectIds] = useState<Set<string>>(new Set());
   const [projectQuery, setProjectQuery] = useState('');
   const [projectDropdownOpen, setProjectDropdownOpen] = useState(false);
+  const formRef = useRef<HTMLFormElement>(null);
   const projectInputRef = useRef<HTMLInputElement>(null);
   const projectWrapRef = useRef<HTMLDivElement>(null);
 
@@ -185,6 +233,10 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     if (!name.trim()) return;
+    if (emailDuplicates.size > 0 || phoneDuplicates.size > 0 || urlDuplicates.size > 0) {
+      formRef.current?.querySelector<HTMLElement>('.ac-collision-warn')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      return;
+    }
     setSubmitting(true);
 
     const links = [
@@ -219,7 +271,7 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
           <button className="ac-close" onClick={onCancel}>×</button>
         </div>
 
-        <form onSubmit={handleSubmit} className="ac-form">
+        <form ref={formRef} onSubmit={handleSubmit} className="ac-form">
           <div className="ac-field">
             <label htmlFor="ac-name" className="ac-label">
               Name <span className="ac-required">*</span>
@@ -291,7 +343,10 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
                     ⚠ Invalid email address
                   </div>
                 )}
-                {entry.email.trim() && !emailFormatWarnings[entry.email.trim()] && emailCollisions[entry.email.trim()] && (
+                {entry.email.trim() && !emailFormatWarnings[entry.email.trim()] && emailDuplicates.has(entry.email.trim().toLowerCase()) && (
+                  <div className="ac-collision-warn">⚠ Already added</div>
+                )}
+                {entry.email.trim() && !emailFormatWarnings[entry.email.trim()] && !emailDuplicates.has(entry.email.trim().toLowerCase()) && emailCollisions[entry.email.trim()] && (
                   <div className="ac-collision-warn">
                     Already on: <strong>{emailCollisions[entry.email.trim()]}</strong>
                   </div>
@@ -356,7 +411,10 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
                       : '⚠ Invalid phone number'}
                   </div>
                 )}
-                {entry.phone.trim() && !phoneFormatWarnings[entry.phone.trim()] && phoneCollisions[entry.phone.trim()] && (
+                {entry.phone.trim() && !phoneFormatWarnings[entry.phone.trim()] && phoneDuplicates.has(normalizePhoneForComparison(entry.phone)) && (
+                  <div className="ac-collision-warn">⚠ Already added</div>
+                )}
+                {entry.phone.trim() && !phoneFormatWarnings[entry.phone.trim()] && !phoneDuplicates.has(normalizePhoneForComparison(entry.phone)) && phoneCollisions[entry.phone.trim()] && (
                   <div className="ac-collision-warn">
                     Already on: <strong>{phoneCollisions[entry.phone.trim()]}</strong>
                   </div>
@@ -390,7 +448,11 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
               });
             }}
             warnings={Object.fromEntries(
-              websites.map((v) => v.trim()).filter((v) => v && urlFormatWarnings[v]).map((v) => [v, '⚠ Invalid URL'])
+              websites.map((v) => v.trim()).filter(Boolean).flatMap((v) => {
+                if (urlFormatWarnings[v]) return [[v, '⚠ Invalid URL']];
+                if (urlDuplicates.has(v)) return [[v, '⚠ Already added']];
+                return [];
+              })
             )}
           />
 
@@ -414,7 +476,11 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
                 });
               }}
               warnings={Object.fromEntries(
-                socials[type].map((v) => v.trim()).filter((v) => v && urlFormatWarnings[v]).map((v) => [v, '⚠ Invalid URL'])
+                socials[type].map((v) => v.trim()).filter(Boolean).flatMap((v) => {
+                  if (urlFormatWarnings[v]) return [[v, '⚠ Invalid URL']];
+                  if (urlDuplicates.has(v)) return [[v, '⚠ Already added']];
+                  return [];
+                })
               )}
             />
           ))}

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { ContactDetail as ContactDetailType, ContactAlertRss, ContactScreenshot, Project } from '@shared/types';
 import './AddContactModal.css';
@@ -37,6 +37,11 @@ function isValidEmail(raw: string): boolean {
 // notation letters (e, x, t for "ext", # for US-style extensions).
 function hasDisallowedPhoneChars(raw: string): boolean {
   return /[^0-9+\-(). \t#extEXT]/.test(raw);
+}
+
+// Strip separators so spacing variants of the same number compare equal.
+function normalizePhoneForComparison(raw: string): string {
+  return raw.trim().replace(/[\s\-().]/g, '');
 }
 
 const OTHER_LABEL_MAX = 40;
@@ -128,6 +133,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
   const [zoomMode, setZoomMode] = useState<'fit' | 'actual'>('fit');
   const viewerRef = useRef<HTMLDivElement>(null);
   const imageAreaRef = useRef<HTMLDivElement>(null);
+  const formRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
   const dragStart = useRef({ x: 0, y: 0, scrollLeft: 0, scrollTop: 0 });
 
@@ -155,6 +161,48 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
   const [emailFormatWarnings, setEmailFormatWarnings] = useState<Record<string, true>>({});
   const [phoneFormatWarnings, setPhoneFormatWarnings] = useState<Record<string, true>>({});
   const [urlFormatWarnings, setUrlFormatWarnings] = useState<Record<string, true>>({});
+
+  // Computed within-form duplicate sets — derived from state, no extra state needed.
+  const emailDuplicates = useMemo(() => {
+    const seen = new Map<string, number>();
+    for (const e of editEmails) {
+      const v = e.email.trim().toLowerCase();
+      if (!v) continue;
+      seen.set(v, (seen.get(v) ?? 0) + 1);
+    }
+    const dupes = new Set<string>();
+    for (const [v, count] of seen) if (count > 1) dupes.add(v);
+    return dupes;
+  }, [editEmails]);
+
+  const phoneDuplicates = useMemo(() => {
+    const seen = new Map<string, number>();
+    for (const p of editPhones) {
+      const v = normalizePhoneForComparison(p.phone);
+      if (!v) continue;
+      seen.set(v, (seen.get(v) ?? 0) + 1);
+    }
+    const dupes = new Set<string>();
+    for (const [v, count] of seen) if (count > 1) dupes.add(v);
+    return dupes;
+  }, [editPhones]);
+
+  const urlDuplicates = useMemo(() => {
+    const seen = new Map<string, number>();
+    const allUrls = [
+      ...editWebsites,
+      ...NON_OTHER_SOCIAL_TYPES.flatMap((t) => editSocials[t]),
+      ...editOtherSocials.map((e) => e.url),
+    ];
+    for (const url of allUrls) {
+      const v = url.trim();
+      if (!v) continue;
+      seen.set(v, (seen.get(v) ?? 0) + 1);
+    }
+    const dupes = new Set<string>();
+    for (const [v, count] of seen) if (count > 1) dupes.add(v);
+    return dupes;
+  }, [editWebsites, editSocials, editOtherSocials]);
 
   useEffect(() => {
     window.sourcerer.getAlertRss(contact.id).then(setAlertRss);
@@ -261,6 +309,10 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
 
   async function handleSave() {
     if (!editName.trim()) return;
+    if (emailDuplicates.size > 0 || phoneDuplicates.size > 0 || urlDuplicates.size > 0) {
+      formRef.current?.querySelector<HTMLElement>('.ac-collision-warn')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      return;
+    }
     setSaving(true);
     try {
       const links = [
@@ -330,7 +382,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
 
   if (editing) {
     return (
-      <div className="detail-body">
+      <div className="detail-body" ref={formRef}>
         <div className="ac-field">
           <label className="ac-label">Name <span className="ac-required">*</span></label>
           <input className="ac-input" value={editName} onChange={(e) => setEditName(e.target.value)} autoFocus />
@@ -397,7 +449,10 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                   ⚠ Invalid email address
                 </div>
               )}
-              {entry.email.trim() && !emailFormatWarnings[entry.email.trim()] && emailCollisions[entry.email.trim()] && (
+              {entry.email.trim() && !emailFormatWarnings[entry.email.trim()] && emailDuplicates.has(entry.email.trim().toLowerCase()) && (
+                <div className="ac-collision-warn">⚠ Already added</div>
+              )}
+              {entry.email.trim() && !emailFormatWarnings[entry.email.trim()] && !emailDuplicates.has(entry.email.trim().toLowerCase()) && emailCollisions[entry.email.trim()] && (
                 <div className="ac-collision-warn">
                   Already on: <strong>{emailCollisions[entry.email.trim()]}</strong>
                 </div>
@@ -469,7 +524,10 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                     : '⚠ Invalid phone number'}
                 </div>
               )}
-              {entry.phone.trim() && !phoneFormatWarnings[entry.phone.trim()] && phoneCollisions[entry.phone.trim()] && (
+              {entry.phone.trim() && !phoneFormatWarnings[entry.phone.trim()] && phoneDuplicates.has(normalizePhoneForComparison(entry.phone)) && (
+                <div className="ac-collision-warn">⚠ Already added</div>
+              )}
+              {entry.phone.trim() && !phoneFormatWarnings[entry.phone.trim()] && !phoneDuplicates.has(normalizePhoneForComparison(entry.phone)) && phoneCollisions[entry.phone.trim()] && (
                 <div className="ac-collision-warn">
                   Already on: <strong>{phoneCollisions[entry.phone.trim()]}</strong>
                 </div>
@@ -507,8 +565,12 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
               warnings={Object.fromEntries(
                 editSocials[type]
                   .map((v) => v.trim())
-                  .filter((v) => v && urlFormatWarnings[v])
-                  .map((v) => [v, '⚠ Invalid URL'])
+                  .filter(Boolean)
+                  .flatMap((v) => {
+                    if (urlFormatWarnings[v]) return [[v, '⚠ Invalid URL']];
+                    if (urlDuplicates.has(v)) return [[v, '⚠ Already added']];
+                    return [];
+                  })
               )}
             />
           </div>
@@ -567,6 +629,9 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
               {entry.url.trim() && urlFormatWarnings[entry.url.trim()] && (
                 <div className="ac-collision-warn">⚠ Invalid URL</div>
               )}
+              {entry.url.trim() && !urlFormatWarnings[entry.url.trim()] && urlDuplicates.has(entry.url.trim()) && (
+                <div className="ac-collision-warn">⚠ Already added</div>
+              )}
             </div>
           ))}
           <button
@@ -599,8 +664,12 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
             warnings={Object.fromEntries(
               editWebsites
                 .map((v) => v.trim())
-                .filter((v) => v && urlFormatWarnings[v])
-                .map((v) => [v, '⚠ Invalid URL'])
+                .filter(Boolean)
+                .flatMap((v) => {
+                  if (urlFormatWarnings[v]) return [[v, '⚠ Invalid URL']];
+                  if (urlDuplicates.has(v)) return [[v, '⚠ Already added']];
+                  return [];
+                })
             )}
           />
           <p className="ac-field-hint">Wayback Machine archiving can be enabled or disabled in Settings.</p>


### PR DESCRIPTION
GlobalTab (edit form) and AddContactModal (create form):
- Compute emailDuplicates, phoneDuplicates, urlDuplicates via useMemo derived from current form state — no IPC calls, instant feedback
- Show '⚠ Already added' inline under any field whose value appears more than once in the same form
- Phones normalised before comparison (strip spaces, dashes, dots, parens) so spacing variants like '+54 11 5555 3891' and '+54 11 55553891' are correctly caught as duplicates
- URL duplicate detection is cross-type (websites + all social fields share one urlDuplicates set)
- Save / Submit allowed with duplicates present; on click, scrolls to first warning and returns early rather than silently no-oping
- Format-error warnings (invalid email/phone/URL) still block save
- Cross-contact collision warnings suppressed when a within-form duplicate is present on the same field (avoid double-warning)