### PR TITLE
Add print contact sheet (closes #4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "electron-vite build",
     "preview": "electron-vite preview",
     "typecheck": "tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.web.json --noEmit",
-  "rebuild": "electron-rebuild -f -w better-sqlite3-multiple-ciphers,argon2",
+    "rebuild": "electron-rebuild -f -w better-sqlite3-multiple-ciphers,argon2",
     "rebuild:node": "npm rebuild better-sqlite3-multiple-ciphers argon2",
     "dist:mac": "electron-builder --mac --arm64",
     "dist:win": "electron-builder --win --x64",

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -1395,3 +1395,29 @@
   user-select: none;
   -webkit-user-drag: none;
 }
+
+/* ── Print button ───────────────────────────────── */
+
+.detail-print-btn {
+  height: 28px;
+  padding: 0 10px;
+  background: none;
+  border: 1px solid var(--color-border-strong);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.detail-print-btn:hover {
+  background: var(--color-bg);
+  color: var(--color-text);
+  border-color: var(--color-text);
+}
+
+/* Print layout is handled entirely by ContactPrintSheet.css */

--- a/src/renderer/src/contacts/ContactDetail.tsx
+++ b/src/renderer/src/contacts/ContactDetail.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { ContactDetail as ContactDetailType, Project, StatusOption, PriorityOption, User } from '@shared/types';
+import type { ContactDetail as ContactDetailType, InteractionLogEntry, Project, StatusOption, PriorityOption, User } from '@shared/types';
 import { fmtDateFull } from '../utils/fmtDate';
 import GlobalTab from './GlobalTab';
 import ProjectTab from './ProjectTab';
+import ContactPrintSheet from './ContactPrintSheet';
 import '../views/View.css';
 import './ContactDetail.css';
 
@@ -25,6 +26,7 @@ export default function ContactDetail({ contactId, onClose, onDeleted, onUpdated
   const [activeTab, setActiveTab] = useState<Tab>('global');
   const [isEditing, setIsEditing] = useState(false);
   const [interactionCount, setInteractionCount] = useState<number | null>(null);
+  const [printLogs, setPrintLogs] = useState<Array<{ projectName: string; entries: InteractionLogEntry[] }>>([]);
 
   // Keep stable refs so the event listener never needs to re-register
   const onCloseRef = useRef(onClose);
@@ -52,6 +54,7 @@ export default function ContactDetail({ contactId, onClose, onDeleted, onUpdated
     setContact(null);
     setActiveTab('global');
     setInteractionCount(null);
+    setPrintLogs([]);
     reload();
     window.sourcerer.listProjects().then(setAllProjects);
     window.sourcerer.listStatusOptions().then(setStatusOptions);
@@ -70,6 +73,18 @@ export default function ContactDetail({ contactId, onClose, onDeleted, onUpdated
       if (updatedId === contactId) reload();
     });
   }, [contactId, reload]);
+
+  useEffect(() => {
+    if (!contact) return;
+    Promise.all(
+      contact.projects.map((p) =>
+        window.sourcerer.listInteractionLog(p.membership_id).then((entries) => ({
+          projectName: p.name,
+          entries,
+        }))
+      )
+    ).then(setPrintLogs);
+  }, [contact]);
 
   function handleMembershipChanged() {
     reload();
@@ -141,6 +156,9 @@ export default function ContactDetail({ contactId, onClose, onDeleted, onUpdated
               currentUser={user ? { email: user.email, firstName: user.first_name, lastName: user.last_name, outreachRemindersEnabled: user.outreach_reminders_enabled !== 0 } : null}
             />
           )}
+
+          {/* Rendered always when contact is loaded, visible only on print */}
+          <ContactPrintSheet contact={contact} logs={printLogs} />
         </>
       )}
     </div>

--- a/src/renderer/src/contacts/ContactPrintSheet.css
+++ b/src/renderer/src/contacts/ContactPrintSheet.css
@@ -1,0 +1,211 @@
+/*
+ * ContactPrintSheet.css
+ *
+ * Styles for the printable contact summary sheet.
+ * This file owns all print-related CSS:
+ *   1. Screen: hide the sheet entirely (it renders as a portal to body).
+ *   2. Print: show the sheet, hide the rest of the app (#root).
+ *
+ * Edit this file to adjust the print layout without touching the app UI.
+ */
+
+/* ── Hide the sheet on screen ─────────────────────── */
+
+.cps-root {
+  display: none;
+}
+
+/* ── Print layout ─────────────────────────────────── */
+
+@media print {
+  /* Release the fixed-height, overflow:hidden root constraints */
+  html,
+  body,
+  #root {
+    height: auto !important;
+    overflow: visible !important;
+  }
+
+  /* Hide the entire app; the portal sheet is a sibling of #root */
+  #root {
+    display: none !important;
+  }
+
+  .cps-root {
+    display: block;
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: 11pt;
+    color: #000;
+    background: #fff;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+  }
+
+  /* Header */
+  .cps-header {
+    border-bottom: 2pt solid #000;
+    padding-bottom: 10pt;
+    margin-bottom: 16pt;
+  }
+
+  .cps-meta {
+    font-family: 'Courier New', monospace;
+    font-size: 8pt;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: #000;
+    margin-bottom: 4pt;
+  }
+
+  .cps-name {
+    font-size: 22pt;
+    font-weight: bold;
+    margin: 0 0 2pt;
+    line-height: 1.1;
+    color: #000;
+  }
+
+  .cps-org {
+    font-size: 13pt;
+    color: #000;
+    margin: 0;
+  }
+
+  /* Section */
+  .cps-section {
+    margin-bottom: 12pt;
+    break-inside: avoid;
+  }
+
+  .cps-section-label {
+    font-family: 'Courier New', monospace;
+    font-size: 7.5pt;
+    font-weight: bold;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: #000;
+    border-bottom: 0.75pt solid #000;
+    padding-bottom: 2pt;
+    margin-bottom: 5pt;
+  }
+
+  /* Field rows */
+  .cps-row {
+    display: flex;
+    gap: 8pt;
+    align-items: baseline;
+    margin-bottom: 2pt;
+  }
+
+  .cps-value {
+    font-size: 10pt;
+    color: #000;
+  }
+
+  .cps-label {
+    font-family: 'Courier New', monospace;
+    font-size: 8pt;
+    color: #000;
+  }
+
+  .cps-link-type {
+    font-family: 'Courier New', monospace;
+    font-size: 8pt;
+    color: #000;
+    min-width: 64pt;
+    flex-shrink: 0;
+  }
+
+  /* Notes */
+  .cps-section--notes .cps-notes {
+    font-size: 10pt;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    color: #000;
+  }
+
+  /* Projects table */
+  .cps-projects-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 9.5pt;
+  }
+
+  .cps-projects-table th {
+    font-family: 'Courier New', monospace;
+    font-size: 7.5pt;
+    font-weight: bold;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    text-align: left;
+    padding: 2pt 4pt;
+    border-bottom: 0.75pt solid #000;
+    color: #000;
+  }
+
+  .cps-projects-table td {
+    padding: 3pt 4pt;
+    border-bottom: 0.5pt solid #000;
+    vertical-align: top;
+    color: #000;
+  }
+
+  .cps-projects-table tr:last-child td {
+    border-bottom: none;
+  }
+
+  /* Interaction log */
+  .cps-log-project {
+    margin-bottom: 8pt;
+  }
+
+  .cps-log-project-name {
+    font-family: 'Courier New', monospace;
+    font-size: 8pt;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: #000;
+    margin-bottom: 4pt;
+  }
+
+  .cps-log-entry {
+    margin-bottom: 6pt;
+    break-inside: avoid;
+    padding-left: 8pt;
+    border-left: 1pt solid #000;
+  }
+
+  .cps-log-meta {
+    display: flex;
+    gap: 8pt;
+    font-family: 'Courier New', monospace;
+    font-size: 8pt;
+    color: #000;
+    margin-bottom: 2pt;
+  }
+
+  .cps-log-date {
+    font-weight: bold;
+  }
+
+  .cps-log-body {
+    font-size: 10pt;
+    line-height: 1.4;
+    white-space: pre-wrap;
+    color: #000;
+  }
+
+  /* Footer */
+  .cps-footer {
+    margin-top: 20pt;
+    padding-top: 6pt;
+    border-top: 0.75pt solid #000;
+    display: flex;
+    justify-content: space-between;
+    font-family: 'Courier New', monospace;
+    font-size: 7.5pt;
+    color: #000;
+  }
+}

--- a/src/renderer/src/contacts/ContactPrintSheet.tsx
+++ b/src/renderer/src/contacts/ContactPrintSheet.tsx
@@ -1,0 +1,168 @@
+import { createPortal } from 'react-dom';
+import type { ContactDetail, InteractionLogEntry } from '@shared/types';
+import { fmtDateFull } from '../utils/fmtDate';
+import './ContactPrintSheet.css';
+
+interface ProjectLog {
+  projectName: string;
+  entries: InteractionLogEntry[];
+}
+
+interface Props {
+  contact: ContactDetail;
+  logs: ProjectLog[];
+}
+
+const SOCIAL_LABELS: Record<string, string> = {
+  linkedin: 'LinkedIn',
+  x: 'X / Twitter',
+  instagram: 'Instagram',
+  facebook: 'Facebook',
+  other: 'Other',
+};
+
+export default function ContactPrintSheet({ contact, logs }: Props) {
+  const websites = contact.links.filter((l) => l.type === 'website');
+  const socials = contact.links.filter((l) => l.type !== 'website');
+
+  return createPortal(
+    <div className="cps-root">
+      {/* ── Header ── */}
+      <header className="cps-header">
+        <div className="cps-meta">Added {fmtDateFull(contact.created_at)}</div>
+        <h1 className="cps-name">{contact.name}</h1>
+        {contact.organization && (
+          <p className="cps-org">{contact.organization}</p>
+        )}
+      </header>
+
+      <div className="cps-body">
+        {/* ── Emails ── */}
+        {contact.emails.length > 0 && (
+          <section className="cps-section">
+            <h2 className="cps-section-label">Email</h2>
+            {contact.emails.map((e) => (
+              <div key={e.id} className="cps-row">
+                <span className="cps-value">{e.email}</span>
+                {e.label && <span className="cps-label">{e.label}</span>}
+              </div>
+            ))}
+          </section>
+        )}
+
+        {/* ── Phones ── */}
+        {contact.phones.length > 0 && (
+          <section className="cps-section">
+            <h2 className="cps-section-label">Phone</h2>
+            {contact.phones.map((p) => (
+              <div key={p.id} className="cps-row">
+                <span className="cps-value">{p.phone}</span>
+                {p.label && <span className="cps-label">{p.label}</span>}
+              </div>
+            ))}
+          </section>
+        )}
+
+        {/* ── Social links ── */}
+        {socials.length > 0 && (
+          <section className="cps-section">
+            <h2 className="cps-section-label">Links</h2>
+            {socials.map((l) => (
+              <div key={l.id} className="cps-row">
+                <span className="cps-link-type">
+                  {l.type === 'other' && l.label ? l.label : SOCIAL_LABELS[l.type] ?? l.type}
+                </span>
+                <span className="cps-value">{l.url}</span>
+              </div>
+            ))}
+          </section>
+        )}
+
+        {/* ── Websites ── */}
+        {websites.length > 0 && (
+          <section className="cps-section">
+            <h2 className="cps-section-label">Website</h2>
+            {websites.map((l) => (
+              <div key={l.id} className="cps-row">
+                <span className="cps-value">{l.url}</span>
+                {l.wayback_url && (
+                  <span className="cps-label">archived: {l.wayback_url}</span>
+                )}
+              </div>
+            ))}
+          </section>
+        )}
+
+        {/* ── Notes ── */}
+        {contact.notes && (
+          <section className="cps-section cps-section--notes">
+            <h2 className="cps-section-label">Notes</h2>
+            <p className="cps-notes">{contact.notes}</p>
+          </section>
+        )}
+
+        {/* ── Projects ── */}
+        {contact.projects.length > 0 && (
+          <section className="cps-section">
+            <h2 className="cps-section-label">Projects</h2>
+            <table className="cps-projects-table">
+              <thead>
+                <tr>
+                  <th>Project</th>
+                  <th>Status</th>
+                  <th>Priority</th>
+                  <th>Reporter</th>
+                </tr>
+              </thead>
+              <tbody>
+                {contact.projects.map((p) => (
+                  <tr key={p.id}>
+                    <td>{p.name}</td>
+                    <td>{p.status ?? '—'}</td>
+                    <td>{p.priority ?? '—'}</td>
+                    <td>{p.reporter_name}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </section>
+        )}
+
+        {/* ── Interaction log ── */}
+        {logs.some((l) => l.entries.length > 0) && (
+          <section className="cps-section">
+            <h2 className="cps-section-label">Interaction Log</h2>
+            {logs
+              .filter((l) => l.entries.length > 0)
+              .map((l) => (
+                <div key={l.projectName} className="cps-log-project">
+                  {logs.filter((x) => x.entries.length > 0).length > 1 && (
+                    <div className="cps-log-project-name">{l.projectName}</div>
+                  )}
+                  {l.entries.map((e) => (
+                    <div key={e.id} className="cps-log-entry">
+                      <div className="cps-log-meta">
+                        <span className="cps-log-date">{fmtDateFull(e.created_at)}</span>
+                        <span className="cps-log-reporter">{e.reporter_name}</span>
+                      </div>
+                      <div className="cps-log-body">{e.body}</div>
+                    </div>
+                  ))}
+                </div>
+              ))}
+          </section>
+        )}
+      </div>
+
+      <footer className="cps-footer">
+        <span>Printed from Sourcerer</span>
+        <span>
+          {new Date().toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' })}
+          {' · '}
+          {new Date().toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
+        </span>
+      </footer>
+    </div>,
+    document.body
+  );
+}

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -897,7 +897,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
       </div>
 
       {screenshots.length > 0 && (
-        <div className="detail-section">
+        <div className="detail-section detail-section--screenshots">
           <div className="detail-section-label">Screenshots</div>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 6 }}>
             {screenshots.map((s) => (
@@ -1031,6 +1031,13 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         ) : (
           <div className="detail-bottom-actions">
             <div className="detail-bottom-left">
+              <button
+                className="detail-print-btn"
+                onClick={() => window.print()}
+                title="Print contact sheet"
+              >
+                Print
+              </button>
               <button
                 className="detail-vcard-btn"
                 onClick={() => window.sourcerer.exportVCardContact(contact.id)}


### PR DESCRIPTION
- Add ContactPrintSheet component with dedicated CSS (portal to body)
- Print layout: name, org, emails, phones, links, websites, notes, projects table, interaction log grouped by project
- Footer shows printed date + time
- Move Print button to bottom-left action bar (left of vCard)
- @media print hides #root, shows only the sheet
- All styles are pure black & white