### PR TITLE
Add screenshot storage size warning in Settings (closes #2)

### DIFF
--- a/src/main/ipc/screenshots.ts
+++ b/src/main/ipc/screenshots.ts
@@ -1,4 +1,4 @@
-import { ipcMain, app, dialog, BrowserWindow } from 'electron';
+import { ipcMain, app, dialog, shell, BrowserWindow } from 'electron';
 import { randomUUID } from 'crypto';
 import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 import fs from 'fs/promises';
@@ -160,4 +160,31 @@ export function registerScreenshotHandlers(): void {
       }
     },
   );
+
+  ipcMain.handle('screenshots:get-folder-size', async (): Promise<number> => {
+    const dir = screenshotsDir();
+    let total = 0;
+    try {
+      const entries = await fs.readdir(dir);
+      await Promise.all(
+        entries.map(async (name) => {
+          try {
+            const stat = await fs.stat(path.join(dir, name));
+            if (stat.isFile()) total += stat.size;
+          } catch {
+            // ignore files that disappeared between readdir and stat
+          }
+        }),
+      );
+    } catch {
+      // folder doesn't exist yet — size is 0
+    }
+    return total;
+  });
+
+  ipcMain.handle('screenshots:open-folder', async (): Promise<void> => {
+    const dir = screenshotsDir();
+    await fs.mkdir(dir, { recursive: true });
+    shell.openPath(dir);
+  });
 }

--- a/src/main/ipc/screenshots.ts
+++ b/src/main/ipc/screenshots.ts
@@ -165,17 +165,16 @@ export function registerScreenshotHandlers(): void {
     const dir = screenshotsDir();
     let total = 0;
     try {
-      const entries = await fs.readdir(dir);
-      await Promise.all(
-        entries.map(async (name) => {
-          try {
-            const stat = await fs.stat(path.join(dir, name));
-            if (stat.isFile()) total += stat.size;
-          } catch {
-            // ignore files that disappeared between readdir and stat
-          }
-        }),
-      );
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isFile()) continue;
+        try {
+          const stat = await fs.stat(path.join(dir, entry.name));
+          total += stat.size;
+        } catch {
+          // ignore files that disappeared between readdir and stat
+        }
+      }
     } catch {
       // folder doesn't exist yet — size is 0
     }
@@ -185,6 +184,7 @@ export function registerScreenshotHandlers(): void {
   ipcMain.handle('screenshots:open-folder', async (): Promise<void> => {
     const dir = screenshotsDir();
     await fs.mkdir(dir, { recursive: true });
-    shell.openPath(dir);
+    const err = await shell.openPath(dir);
+    if (err) throw new Error(`Failed to open screenshots folder: ${err}`);
   });
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -214,6 +214,10 @@ const sourcererApi = {
     ipcRenderer.invoke('screenshots:delete', screenshotId),
   saveScreenshot: (screenshotId: string): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('screenshots:save', screenshotId),
+  getScreenshotFolderSize: (): Promise<number> =>
+    ipcRenderer.invoke('screenshots:get-folder-size'),
+  openScreenshotFolder: (): Promise<void> =>
+    ipcRenderer.invoke('screenshots:open-folder'),
   onScreenshotAssigned: (callback: (contactId: string) => void): (() => void) => {
     const handler = (_: Electron.IpcRendererEvent, contactId: string) => callback(contactId);
     ipcRenderer.on('screenshots:assigned', handler);

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -198,6 +198,8 @@ declare global {
       loadScreenshot: (screenshotId: string) => Promise<{ data: string } | { error: string }>;
       deleteScreenshot: (screenshotId: string) => Promise<void>;
       saveScreenshot: (screenshotId: string) => Promise<{ success: boolean; error?: string }>;
+      getScreenshotFolderSize: () => Promise<number>;
+      openScreenshotFolder: () => Promise<void>;
       onScreenshotAssigned: (callback: (contactId: string) => void) => () => void;
 
       // Panic wipe

--- a/src/renderer/src/views/SettingsView.css
+++ b/src/renderer/src/views/SettingsView.css
@@ -364,6 +364,32 @@
   margin-bottom: 10px;
 }
 
+.sv-storage-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.sv-storage-row .sv-add-btn {
+  align-self: auto;
+  margin-top: 0;
+}
+
+.sv-storage-size {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--color-text);
+}
+
+.sv-storage-warning {
+  font-size: 12px;
+  color: var(--color-danger, #c0392b);
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  letter-spacing: 0.02em;
+}
+
 .sv-calendar-url {
   flex: 1;
   font-size: 13px;

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -567,7 +567,7 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
                 ? `${(screenshotFolderBytes / (1024 * 1024)).toFixed(1)} MB`
                 : `${(screenshotFolderBytes / 1024).toFixed(0)} KB`}
             </span>
-            <button className="sv-add-btn" onClick={() => window.sourcerer.openScreenshotFolder()}>
+            <button className="sv-add-btn" onClick={async () => { try { await window.sourcerer.openScreenshotFolder(); } catch (err) { console.error('Failed to open screenshot folder:', err); } }}>
               Open folder
             </button>
           </div>

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -77,6 +77,7 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
   const [panicWipeConfirm, setPanicWipeConfirm] = useState(false);
   const [panicWipeInput, setPanicWipeInput] = useState('');
   const [panicWiping, setPanicWiping] = useState(false);
+  const [screenshotFolderBytes, setScreenshotFolderBytes] = useState<number>(0);
 
   const countryOptions = useMemo(() => {
     const names = new Intl.DisplayNames([navigator.language], { type: 'region' });
@@ -107,6 +108,7 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
     }
     window.sourcerer.getIdleTimeout().then(setIdleTimeout);
     window.sourcerer.getCalendarUrl().then(setCalendarUrl);
+    window.sourcerer.getScreenshotFolderSize().then(setScreenshotFolderBytes);
   }, [user?.id]);
 
   async function handleProfileSave() {
@@ -548,6 +550,31 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
             <button className="sv-add-btn" onClick={() => setCalendarRegenConfirm(true)}>
               Regenerate token
             </button>
+          )}
+        </div>
+
+        {/* Screenshots storage */}
+        <div className="sv-section">
+          <div className="sv-section-title">Screenshot storage</div>
+          <p className="sv-hint">
+            Encrypted screenshots are stored locally on this machine. The folder is separate from the database.
+          </p>
+          <div className="sv-storage-row">
+            <span className="sv-storage-size">
+              {screenshotFolderBytes >= 1024 * 1024 * 1024
+                ? `${(screenshotFolderBytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+                : screenshotFolderBytes >= 1024 * 1024
+                ? `${(screenshotFolderBytes / (1024 * 1024)).toFixed(1)} MB`
+                : `${(screenshotFolderBytes / 1024).toFixed(0)} KB`}
+            </span>
+            <button className="sv-add-btn" onClick={() => window.sourcerer.openScreenshotFolder()}>
+              Open folder
+            </button>
+          </div>
+          {screenshotFolderBytes >= 1024 * 1024 * 1024 && (
+            <div className="sv-storage-warning">
+              ⚠ Screenshot folder exceeds 1 GB. Open the folder to review and delete files manually.
+            </div>
           )}
         </div>
 


### PR DESCRIPTION
- screenshots.ts: add screenshots:get-folder-size IPC handler (async recursive stat sum, returns 0 if folder absent) and screenshots:open-folder (creates dir if needed, opens in Finder)
- preload/index.ts: expose getScreenshotFolderSize() and openScreenshotFolder()
- env.d.ts: add types for both new methods
- SettingsView: new 'Screenshot storage' section showing folder size (formatted KB/MB/GB), 'Open folder' button, and a ⚠ warning banner when folder exceeds 1 GB; size fetched on Settings mount
- SettingsView.css: .sv-storage-row, .sv-storage-size, .sv-storage-warning styles; override sv-add-btn alignment inside row