### PR TITLE
Add in-app auto-updater (closes #15)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,13 @@
     "": {
       "name": "sourcerer",
       "version": "0.1.7",
+      "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/utils": "^3.0.0",
         "argon2": "^0.41.1",
         "better-sqlite3-multiple-ciphers": "^12.9.0",
+        "electron-updater": "^6.8.3",
         "libphonenumber-js": "^1.12.42",
         "qrcode": "^1.5.4",
         "rss-parser": "^3.13.0",
@@ -2643,7 +2645,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/assert-plus": {
@@ -3427,7 +3428,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3783,6 +3783,35 @@
       "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/builder-util-runtime": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+      "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/electron-vite": {
       "version": "2.3.0",
@@ -4198,7 +4227,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -4435,7 +4463,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -4834,7 +4861,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4895,7 +4921,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -4918,7 +4943,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/libphonenumber-js": {
@@ -5205,6 +5229,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -5541,7 +5578,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6985,6 +7021,12 @@
         "fs-extra": "^10.0.0"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -7144,7 +7186,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@electron-toolkit/utils": "^3.0.0",
     "argon2": "^0.41.1",
     "better-sqlite3-multiple-ciphers": "^12.9.0",
+    "electron-updater": "^6.8.3",
     "libphonenumber-js": "^1.12.42",
     "qrcode": "^1.5.4",
     "rss-parser": "^3.13.0",
@@ -58,6 +59,12 @@
     "appId": "com.sourcerer.app",
     "productName": "Sourcerer",
     "npmRebuild": false,
+    "publish": {
+      "provider": "github",
+      "owner": "tomcardoso",
+      "repo": "sourcerer",
+      "releaseType": "release"
+    },
     "directories": {
       "buildResources": "build",
       "output": "dist-electron"

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,6 +18,7 @@ import { registerImportHandlers } from './ipc/import';
 import { registerBackupHandlers } from './ipc/backup';
 import { registerScreenshotHandlers } from './ipc/screenshots';
 import { registerSearchHandlers } from './ipc/search';
+import { registerUpdaterHandlers, triggerUpdateCheck } from './ipc/updater';
 import { autoLock } from './auto-lock';
 import { closeDatabase } from './database';
 import { closeAllSharedDbs } from './database/shared-db';
@@ -160,6 +161,11 @@ function buildMenu(): void {
           label: 'Report an issue',
           click: () => shell.openExternal('https://github.com/tomcardoso/sourcerer/issues'),
         },
+        { type: 'separator' as const },
+        {
+          label: 'Check for Updates\u2026',
+          click: triggerUpdateCheck,
+        },
         ...(!isMac
           ? [
               { type: 'separator' as const },
@@ -191,7 +197,8 @@ app.whenReady().then(() => {
   registerScreenshotHandlers();
   registerSearchHandlers();
   startHttpServer();
-  createWindow();
+  const win = createWindow();
+  registerUpdaterHandlers(win);
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -197,8 +197,8 @@ app.whenReady().then(() => {
   registerScreenshotHandlers();
   registerSearchHandlers();
   startHttpServer();
-  const win = createWindow();
-  registerUpdaterHandlers(win);
+  createWindow();
+  registerUpdaterHandlers();
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -196,9 +196,9 @@ app.whenReady().then(() => {
   registerBackupHandlers();
   registerScreenshotHandlers();
   registerSearchHandlers();
+  registerUpdaterHandlers();
   startHttpServer();
   createWindow();
-  registerUpdaterHandlers();
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/src/main/ipc/updater.ts
+++ b/src/main/ipc/updater.ts
@@ -1,0 +1,56 @@
+import { app, BrowserWindow, ipcMain } from 'electron';
+import { is } from '@electron-toolkit/utils';
+import { autoUpdater } from 'electron-updater';
+
+/**
+ * Call this from the Help > "Check for Updates…" menu item.
+ * Safe to call before registerUpdaterHandlers — the listeners are set up
+ * during app.whenReady() and any user-triggered check happens after that.
+ */
+export function triggerUpdateCheck(): void {
+  if (!app.isPackaged) return;
+  autoUpdater.checkForUpdates().catch(() => {});
+}
+
+export function registerUpdaterHandlers(win: BrowserWindow): void {
+  // Dev simulation: fire a fake update-available banner after 3s so UI states can be tested.
+  // The IPC handlers below are also registered in dev so the Download/Restart buttons work.
+  if (is.dev) {
+    ipcMain.handle('update:check', () => {});
+    ipcMain.handle('update:download', () => {
+      win.webContents.send('update:downloaded', { version: '99.0.0' });
+    });
+    ipcMain.handle('update:quit-and-install', () => {});
+    // Trigger from DevTools console: window.sourcerer.simulateUpdate()
+    ipcMain.handle('update:dev-simulate', () => {
+      win.webContents.send('update:available', { version: '99.0.0' });
+    });
+    return;
+  }
+
+  autoUpdater.autoDownload = false;
+  autoUpdater.autoInstallOnAppQuit = false;
+
+  autoUpdater.on('update-available', (info) => {
+    win.webContents.send('update:available', { version: info.version });
+  });
+
+  autoUpdater.on('download-progress', (progress) => {
+    win.webContents.send('update:download-progress', { percent: Math.round(progress.percent) });
+  });
+
+  autoUpdater.on('update-downloaded', (info) => {
+    win.webContents.send('update:downloaded', { version: info.version });
+  });
+
+  ipcMain.handle('update:check', () => autoUpdater.checkForUpdates());
+  ipcMain.handle('update:download', () => autoUpdater.downloadUpdate());
+  ipcMain.handle('update:quit-and-install', () => {
+    autoUpdater.quitAndInstall(false, true);
+  });
+
+  // Check for updates 10 s after launch so it doesn't block startup
+  setTimeout(() => {
+    autoUpdater.checkForUpdates().catch(() => {});
+  }, 10_000);
+}

--- a/src/main/ipc/updater.ts
+++ b/src/main/ipc/updater.ts
@@ -5,7 +5,12 @@ import { autoUpdater } from 'electron-updater';
 // Cache the latest update event so renderers that mount after the event fires
 // (e.g. the user was on the lock screen when the 10 s auto-check fired) can
 // replay it via update:get-state on mount.
-let cachedUpdateInfo: { event: 'available' | 'downloaded'; version: string } | null = null;
+let cachedUpdateInfo: { event: 'available' | 'downloading' | 'downloaded'; version: string; percent?: number } | null = null;
+
+// Set to true when the user explicitly invokes Help > Check for Updates.
+// Used to show "up to date" / error feedback on user-initiated checks only;
+// background auto-checks (the 10 s timer) are always silent.
+let userInitiatedCheck = false;
 
 function sendToWindow(channel: string, ...args: unknown[]): void {
   // Resolve the active window at send time — avoids stale reference if the
@@ -34,6 +39,7 @@ export function triggerUpdateCheck(): void {
     });
     return;
   }
+  userInitiatedCheck = true;
   autoUpdater.checkForUpdates().catch(() => {});
 }
 
@@ -47,18 +53,23 @@ export function registerUpdaterHandlers(): void {
       // download is in progress would fire interleaved progress sequences.
       if (devDownloadInProgress) return;
       devDownloadInProgress = true;
-      // Simulate download progress (25 → 50 → 75 → 100 %) then fire update:downloaded.
-      [25, 50, 75, 100].forEach((percent, i) => {
-        setTimeout(() => {
-          sendToWindow('update:download-progress', { percent });
-          if (percent === 100) {
-            setTimeout(() => {
-              devDownloadInProgress = false;
-              cachedUpdateInfo = { event: 'downloaded', version: '99.0.0' };
-              sendToWindow('update:downloaded', { version: '99.0.0' });
-            }, 300);
-          }
-        }, (i + 1) * 500);
+      // Return a Promise that resolves after the simulated download completes,
+      // matching production semantics where downloadUpdate() resolves post-download.
+      return new Promise<void>((resolve) => {
+        [25, 50, 75, 100].forEach((percent, i) => {
+          setTimeout(() => {
+            cachedUpdateInfo = { event: 'downloading', version: '99.0.0', percent };
+            sendToWindow('update:download-progress', { percent });
+            if (percent === 100) {
+              setTimeout(() => {
+                devDownloadInProgress = false;
+                cachedUpdateInfo = { event: 'downloaded', version: '99.0.0' };
+                sendToWindow('update:downloaded', { version: '99.0.0' });
+                resolve();
+              }, 300);
+            }
+          }, (i + 1) * 500);
+        });
       });
     });
     ipcMain.handle('update:quit-and-install', () => {});
@@ -67,6 +78,14 @@ export function registerUpdaterHandlers(): void {
     ipcMain.handle('update:dev-simulate', () => {
       cachedUpdateInfo = { event: 'available', version: '99.0.0' };
       sendToWindow('update:available', { version: '99.0.0' });
+    });
+    ipcMain.handle('update:show-error', (_event, message: string) => {
+      return dialog.showMessageBox({
+        type: 'error',
+        title: 'Update failed',
+        message: 'The update could not be downloaded. Please try again.',
+        detail: message,
+      });
     });
     return;
   }
@@ -78,12 +97,30 @@ export function registerUpdaterHandlers(): void {
   autoUpdater.autoInstallOnAppQuit = false;
 
   autoUpdater.on('update-available', (info) => {
+    userInitiatedCheck = false;
     cachedUpdateInfo = { event: 'available', version: info.version };
     sendToWindow('update:available', { version: info.version });
   });
 
+  // Only fires for user-initiated checks (the 10 s auto-check result is silent).
+  autoUpdater.on('update-not-available', () => {
+    if (userInitiatedCheck) {
+      userInitiatedCheck = false;
+      dialog.showMessageBox({
+        type: 'info',
+        title: 'No updates available',
+        message: 'Sourcerer is up to date.',
+      });
+    }
+  });
+
   autoUpdater.on('download-progress', (progress) => {
-    sendToWindow('update:download-progress', { percent: Math.round(progress.percent) });
+    const percent = Math.round(progress.percent);
+    // Also update the cache so a remount during download can restore 'downloading' state.
+    if (cachedUpdateInfo) {
+      cachedUpdateInfo = { event: 'downloading', version: cachedUpdateInfo.version, percent };
+    }
+    sendToWindow('update:download-progress', { percent });
   });
 
   autoUpdater.on('update-downloaded', (info) => {
@@ -94,13 +131,35 @@ export function registerUpdaterHandlers(): void {
   // electron-updater reports download/check failures through the error event,
   // not by rejecting the promise — so this is the only reliable failure path.
   autoUpdater.on('error', (err) => {
-    // If we had a fully-downloaded update, its artefacts are now suspect.
-    if (cachedUpdateInfo?.event === 'downloaded') {
+    const wasUserCheck = userInitiatedCheck;
+    userInitiatedCheck = false;
+    const message = err instanceof Error ? err.message : String(err);
+
+    // Capture prior state before mutating cache.
+    const priorState = cachedUpdateInfo?.event ?? null;
+    const priorVersion = cachedUpdateInfo?.version ?? null;
+
+    if (priorState === 'downloaded') {
       cachedUpdateInfo = null;
+    } else if (priorState === 'downloading' && priorVersion) {
+      // Revert to 'available' so the user can retry.
+      cachedUpdateInfo = { event: 'available', version: priorVersion };
     }
-    sendToWindow('update:error', {
-      message: err instanceof Error ? err.message : String(err),
-    });
+
+    if (priorState === 'downloading' || priorState === 'downloaded') {
+      // Download-phase error: tell the renderer so it can revert its UI.
+      sendToWindow('update:error', { message });
+    } else if (wasUserCheck) {
+      // Check-phase error from a user-initiated check: show directly from main
+      // (the renderer may still be on the lock screen with no listener attached).
+      dialog.showMessageBox({
+        type: 'error',
+        title: 'Update check failed',
+        message: 'Unable to check for updates. Please try again later.',
+        detail: message,
+      });
+    }
+    // Background auto-check errors are silently ignored.
   });
 
   ipcMain.handle('update:check', () => autoUpdater.checkForUpdates());
@@ -109,6 +168,14 @@ export function registerUpdaterHandlers(): void {
     autoUpdater.quitAndInstall(false, true);
   });
   ipcMain.handle('update:get-state', () => cachedUpdateInfo);
+  ipcMain.handle('update:show-error', (_event, message: string) => {
+    return dialog.showMessageBox({
+      type: 'error',
+      title: 'Update failed',
+      message: 'The update could not be downloaded. Please try again.',
+      detail: message,
+    });
+  });
 
   // Check for updates 10 s after launch so it doesn't block startup
   setTimeout(() => {

--- a/src/main/ipc/updater.ts
+++ b/src/main/ipc/updater.ts
@@ -37,7 +37,10 @@ export function registerUpdaterHandlers(): void {
         setTimeout(() => {
           sendToWindow('update:download-progress', { percent });
           if (percent === 100) {
-            setTimeout(() => sendToWindow('update:downloaded', { version: '99.0.0' }), 300);
+            setTimeout(() => {
+              cachedUpdateInfo = { event: 'downloaded', version: '99.0.0' };
+              sendToWindow('update:downloaded', { version: '99.0.0' });
+            }, 300);
           }
         }, (i + 1) * 500);
       });
@@ -46,10 +49,14 @@ export function registerUpdaterHandlers(): void {
     ipcMain.handle('update:get-state', () => cachedUpdateInfo);
     // Trigger from DevTools console: window.sourcerer.simulateUpdate()
     ipcMain.handle('update:dev-simulate', () => {
+      cachedUpdateInfo = { event: 'available', version: '99.0.0' };
       sendToWindow('update:available', { version: '99.0.0' });
     });
     return;
   }
+
+  // No-op in production so simulateUpdate() from DevTools doesn't reject.
+  ipcMain.handle('update:dev-simulate', () => {});
 
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = false;

--- a/src/main/ipc/updater.ts
+++ b/src/main/ipc/updater.ts
@@ -2,6 +2,12 @@ import { app, BrowserWindow, ipcMain } from 'electron';
 import { is } from '@electron-toolkit/utils';
 import { autoUpdater } from 'electron-updater';
 
+function sendToWindow(channel: string, ...args: unknown[]): void {
+  // Resolve the active window at send time — avoids stale reference if the
+  // window is closed and re-created on macOS while the app stays running.
+  BrowserWindow.getAllWindows()[0]?.webContents.send(channel, ...args);
+}
+
 /**
  * Call this from the Help > "Check for Updates…" menu item.
  * Safe to call before registerUpdaterHandlers — the listeners are set up
@@ -12,18 +18,18 @@ export function triggerUpdateCheck(): void {
   autoUpdater.checkForUpdates().catch(() => {});
 }
 
-export function registerUpdaterHandlers(win: BrowserWindow): void {
+export function registerUpdaterHandlers(): void {
   // Dev simulation: fire a fake update-available banner after 3s so UI states can be tested.
   // The IPC handlers below are also registered in dev so the Download/Restart buttons work.
   if (is.dev) {
     ipcMain.handle('update:check', () => {});
     ipcMain.handle('update:download', () => {
-      win.webContents.send('update:downloaded', { version: '99.0.0' });
+      sendToWindow('update:downloaded', { version: '99.0.0' });
     });
     ipcMain.handle('update:quit-and-install', () => {});
     // Trigger from DevTools console: window.sourcerer.simulateUpdate()
     ipcMain.handle('update:dev-simulate', () => {
-      win.webContents.send('update:available', { version: '99.0.0' });
+      sendToWindow('update:available', { version: '99.0.0' });
     });
     return;
   }
@@ -32,15 +38,15 @@ export function registerUpdaterHandlers(win: BrowserWindow): void {
   autoUpdater.autoInstallOnAppQuit = false;
 
   autoUpdater.on('update-available', (info) => {
-    win.webContents.send('update:available', { version: info.version });
+    sendToWindow('update:available', { version: info.version });
   });
 
   autoUpdater.on('download-progress', (progress) => {
-    win.webContents.send('update:download-progress', { percent: Math.round(progress.percent) });
+    sendToWindow('update:download-progress', { percent: Math.round(progress.percent) });
   });
 
   autoUpdater.on('update-downloaded', (info) => {
-    win.webContents.send('update:downloaded', { version: info.version });
+    sendToWindow('update:downloaded', { version: info.version });
   });
 
   ipcMain.handle('update:check', () => autoUpdater.checkForUpdates());

--- a/src/main/ipc/updater.ts
+++ b/src/main/ipc/updater.ts
@@ -2,6 +2,11 @@ import { app, BrowserWindow, ipcMain } from 'electron';
 import { is } from '@electron-toolkit/utils';
 import { autoUpdater } from 'electron-updater';
 
+// Cache the latest update event so renderers that mount after the event fires
+// (e.g. the user was on the lock screen when the 10 s auto-check fired) can
+// replay it via update:get-state on mount.
+let cachedUpdateInfo: { event: 'available' | 'downloaded'; version: string } | null = null;
+
 function sendToWindow(channel: string, ...args: unknown[]): void {
   // Resolve the active window at send time — avoids stale reference if the
   // window is closed and re-created on macOS while the app stays running.
@@ -10,23 +15,35 @@ function sendToWindow(channel: string, ...args: unknown[]): void {
 
 /**
  * Call this from the Help > "Check for Updates…" menu item.
- * Safe to call before registerUpdaterHandlers — the listeners are set up
- * during app.whenReady() and any user-triggered check happens after that.
+ * In dev, fires the simulated update banner immediately so the menu item is
+ * testable. In production, delegates to autoUpdater.checkForUpdates().
  */
 export function triggerUpdateCheck(): void {
+  if (is.dev) {
+    sendToWindow('update:available', { version: '99.0.0' });
+    return;
+  }
   if (!app.isPackaged) return;
   autoUpdater.checkForUpdates().catch(() => {});
 }
 
 export function registerUpdaterHandlers(): void {
-  // Dev simulation: fire a fake update-available banner after 3s so UI states can be tested.
-  // The IPC handlers below are also registered in dev so the Download/Restart buttons work.
+  // Dev simulation path: register stub handlers so the full UI flow is exercisable.
   if (is.dev) {
     ipcMain.handle('update:check', () => {});
     ipcMain.handle('update:download', () => {
-      sendToWindow('update:downloaded', { version: '99.0.0' });
+      // Simulate download progress (25 → 50 → 75 → 100 %) then fire update:downloaded.
+      [25, 50, 75, 100].forEach((percent, i) => {
+        setTimeout(() => {
+          sendToWindow('update:download-progress', { percent });
+          if (percent === 100) {
+            setTimeout(() => sendToWindow('update:downloaded', { version: '99.0.0' }), 300);
+          }
+        }, (i + 1) * 500);
+      });
     });
     ipcMain.handle('update:quit-and-install', () => {});
+    ipcMain.handle('update:get-state', () => cachedUpdateInfo);
     // Trigger from DevTools console: window.sourcerer.simulateUpdate()
     ipcMain.handle('update:dev-simulate', () => {
       sendToWindow('update:available', { version: '99.0.0' });
@@ -38,6 +55,7 @@ export function registerUpdaterHandlers(): void {
   autoUpdater.autoInstallOnAppQuit = false;
 
   autoUpdater.on('update-available', (info) => {
+    cachedUpdateInfo = { event: 'available', version: info.version };
     sendToWindow('update:available', { version: info.version });
   });
 
@@ -46,6 +64,7 @@ export function registerUpdaterHandlers(): void {
   });
 
   autoUpdater.on('update-downloaded', (info) => {
+    cachedUpdateInfo = { event: 'downloaded', version: info.version };
     sendToWindow('update:downloaded', { version: info.version });
   });
 
@@ -54,6 +73,7 @@ export function registerUpdaterHandlers(): void {
   ipcMain.handle('update:quit-and-install', () => {
     autoUpdater.quitAndInstall(false, true);
   });
+  ipcMain.handle('update:get-state', () => cachedUpdateInfo);
 
   // Check for updates 10 s after launch so it doesn't block startup
   setTimeout(() => {

--- a/src/main/ipc/updater.ts
+++ b/src/main/ipc/updater.ts
@@ -139,10 +139,9 @@ export function registerUpdaterHandlers(): void {
     const priorState = cachedUpdateInfo?.event ?? null;
     const priorVersion = cachedUpdateInfo?.version ?? null;
 
-    if (priorState === 'downloaded') {
-      cachedUpdateInfo = null;
-    } else if (priorState === 'downloading' && priorVersion) {
-      // Revert to 'available' so the user can retry.
+    if ((priorState === 'downloaded' || priorState === 'downloading') && priorVersion) {
+      // Revert to 'available' so the user can retry and so a remount after
+      // the error (e.g. lock/unlock) can still replay the banner correctly.
       cachedUpdateInfo = { event: 'available', version: priorVersion };
     }
 

--- a/src/main/ipc/updater.ts
+++ b/src/main/ipc/updater.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain } from 'electron';
 import { is } from '@electron-toolkit/utils';
 import { autoUpdater } from 'electron-updater';
 
@@ -23,21 +23,36 @@ export function triggerUpdateCheck(): void {
     sendToWindow('update:available', { version: '99.0.0' });
     return;
   }
-  if (!app.isPackaged) return;
+  if (!app.isPackaged) {
+    // Running from a built but non-installed bundle — auto-updates require a
+    // signed, packaged app. Inform the user rather than silently doing nothing.
+    dialog.showMessageBox({
+      type: 'info',
+      title: 'Updates not available',
+      message: 'Updates are only available in installed builds of Sourcerer.',
+    });
+    return;
+  }
   autoUpdater.checkForUpdates().catch(() => {});
 }
 
 export function registerUpdaterHandlers(): void {
   // Dev simulation path: register stub handlers so the full UI flow is exercisable.
   if (is.dev) {
+    let devDownloadInProgress = false;
     ipcMain.handle('update:check', () => {});
     ipcMain.handle('update:download', () => {
+      // Guard against re-entry: clicking the button twice while a simulated
+      // download is in progress would fire interleaved progress sequences.
+      if (devDownloadInProgress) return;
+      devDownloadInProgress = true;
       // Simulate download progress (25 → 50 → 75 → 100 %) then fire update:downloaded.
       [25, 50, 75, 100].forEach((percent, i) => {
         setTimeout(() => {
           sendToWindow('update:download-progress', { percent });
           if (percent === 100) {
             setTimeout(() => {
+              devDownloadInProgress = false;
               cachedUpdateInfo = { event: 'downloaded', version: '99.0.0' };
               sendToWindow('update:downloaded', { version: '99.0.0' });
             }, 300);
@@ -73,6 +88,18 @@ export function registerUpdaterHandlers(): void {
   autoUpdater.on('update-downloaded', (info) => {
     cachedUpdateInfo = { event: 'downloaded', version: info.version };
     sendToWindow('update:downloaded', { version: info.version });
+  });
+
+  // electron-updater reports download/check failures through the error event,
+  // not by rejecting the promise — so this is the only reliable failure path.
+  autoUpdater.on('error', (err) => {
+    // If we had a fully-downloaded update, its artefacts are now suspect.
+    if (cachedUpdateInfo?.event === 'downloaded') {
+      cachedUpdateInfo = null;
+    }
+    sendToWindow('update:error', {
+      message: err instanceof Error ? err.message : String(err),
+    });
   });
 
   ipcMain.handle('update:check', () => autoUpdater.checkForUpdates());

--- a/src/main/ipc/updater.ts
+++ b/src/main/ipc/updater.ts
@@ -20,6 +20,7 @@ function sendToWindow(channel: string, ...args: unknown[]): void {
  */
 export function triggerUpdateCheck(): void {
   if (is.dev) {
+    cachedUpdateInfo = { event: 'available', version: '99.0.0' };
     sendToWindow('update:available', { version: '99.0.0' });
     return;
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -330,6 +330,11 @@ const sourcererApi = {
     ipcRenderer.on('update:download-progress', handler);
     return () => ipcRenderer.removeListener('update:download-progress', handler);
   },
+  onUpdateError: (callback: (info: { message: string }) => void): (() => void) => {
+    const handler = (_: Electron.IpcRendererEvent, info: { message: string }) => callback(info);
+    ipcRenderer.on('update:error', handler);
+    return () => ipcRenderer.removeListener('update:error', handler);
+  },
   downloadUpdate: (): Promise<void> => ipcRenderer.invoke('update:download'),
   quitAndInstall: (): Promise<void> => ipcRenderer.invoke('update:quit-and-install'),
   simulateUpdate: (): Promise<void> => ipcRenderer.invoke('update:dev-simulate'),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -338,8 +338,9 @@ const sourcererApi = {
   downloadUpdate: (): Promise<void> => ipcRenderer.invoke('update:download'),
   quitAndInstall: (): Promise<void> => ipcRenderer.invoke('update:quit-and-install'),
   simulateUpdate: (): Promise<void> => ipcRenderer.invoke('update:dev-simulate'),
-  getUpdateState: (): Promise<{ event: 'available' | 'downloaded'; version: string } | null> =>
+  getUpdateState: (): Promise<{ event: 'available' | 'downloading' | 'downloaded'; version: string; percent?: number } | null> =>
     ipcRenderer.invoke('update:get-state'),
+  showUpdateError: (message: string): Promise<void> => ipcRenderer.invoke('update:show-error', message),
 };
 
 contextBridge.exposeInMainWorld('sourcerer', sourcererApi);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -325,9 +325,16 @@ const sourcererApi = {
     ipcRenderer.on('update:downloaded', handler);
     return () => ipcRenderer.removeListener('update:downloaded', handler);
   },
+  onUpdateDownloadProgress: (callback: (info: { percent: number }) => void): (() => void) => {
+    const handler = (_: Electron.IpcRendererEvent, info: { percent: number }) => callback(info);
+    ipcRenderer.on('update:download-progress', handler);
+    return () => ipcRenderer.removeListener('update:download-progress', handler);
+  },
   downloadUpdate: (): Promise<void> => ipcRenderer.invoke('update:download'),
   quitAndInstall: (): Promise<void> => ipcRenderer.invoke('update:quit-and-install'),
   simulateUpdate: (): Promise<void> => ipcRenderer.invoke('update:dev-simulate'),
+  getUpdateState: (): Promise<{ event: 'available' | 'downloaded'; version: string } | null> =>
+    ipcRenderer.invoke('update:get-state'),
 };
 
 contextBridge.exposeInMainWorld('sourcerer', sourcererApi);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -313,6 +313,21 @@ const sourcererApi = {
     ipcRenderer.on('contacts:wayback-status', handler);
     return () => ipcRenderer.removeListener('contacts:wayback-status', handler);
   },
+
+  // Updater
+  onUpdateAvailable: (callback: (info: { version: string }) => void): (() => void) => {
+    const handler = (_: Electron.IpcRendererEvent, info: { version: string }) => callback(info);
+    ipcRenderer.on('update:available', handler);
+    return () => ipcRenderer.removeListener('update:available', handler);
+  },
+  onUpdateDownloaded: (callback: (info: { version: string }) => void): (() => void) => {
+    const handler = (_: Electron.IpcRendererEvent, info: { version: string }) => callback(info);
+    ipcRenderer.on('update:downloaded', handler);
+    return () => ipcRenderer.removeListener('update:downloaded', handler);
+  },
+  downloadUpdate: (): Promise<void> => ipcRenderer.invoke('update:download'),
+  quitAndInstall: (): Promise<void> => ipcRenderer.invoke('update:quit-and-install'),
+  simulateUpdate: (): Promise<void> => ipcRenderer.invoke('update:dev-simulate'),
 };
 
 contextBridge.exposeInMainWorld('sourcerer', sourcererApi);

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -213,6 +213,7 @@ declare global {
       onUpdateAvailable: (callback: (info: { version: string }) => void) => () => void;
       onUpdateDownloaded: (callback: (info: { version: string }) => void) => () => void;
       onUpdateDownloadProgress: (callback: (info: { percent: number }) => void) => () => void;
+      onUpdateError: (callback: (info: { message: string }) => void) => () => void;
       downloadUpdate: () => Promise<void>;
       quitAndInstall: () => Promise<void>;
       simulateUpdate: () => Promise<void>;

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -208,6 +208,13 @@ declare global {
       onDuplicatePairsUpdated: (callback: (count: number) => void) => () => void;
       onWaybackUpdated: (callback: (contactId: string) => void) => () => void;
       onWaybackStatus: (callback: (payload: { contactId: string; url: string; status: 'pending' | 'failed' }) => void) => () => void;
+
+      // Updater
+      onUpdateAvailable: (callback: (info: { version: string }) => void) => () => void;
+      onUpdateDownloaded: (callback: (info: { version: string }) => void) => () => void;
+      downloadUpdate: () => Promise<void>;
+      quitAndInstall: () => Promise<void>;
+      simulateUpdate: () => Promise<void>;
     };
   }
 }

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -212,9 +212,11 @@ declare global {
       // Updater
       onUpdateAvailable: (callback: (info: { version: string }) => void) => () => void;
       onUpdateDownloaded: (callback: (info: { version: string }) => void) => () => void;
+      onUpdateDownloadProgress: (callback: (info: { percent: number }) => void) => () => void;
       downloadUpdate: () => Promise<void>;
       quitAndInstall: () => Promise<void>;
       simulateUpdate: () => Promise<void>;
+      getUpdateState: () => Promise<{ event: 'available' | 'downloaded'; version: string } | null>;
     };
   }
 }

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -217,7 +217,8 @@ declare global {
       downloadUpdate: () => Promise<void>;
       quitAndInstall: () => Promise<void>;
       simulateUpdate: () => Promise<void>;
-      getUpdateState: () => Promise<{ event: 'available' | 'downloaded'; version: string } | null>;
+      getUpdateState: () => Promise<{ event: 'available' | 'downloading' | 'downloaded'; version: string; percent?: number } | null>;
+      showUpdateError: (message: string) => Promise<void>;
     };
   }
 }

--- a/src/renderer/src/shell/AppShell.css
+++ b/src/renderer/src/shell/AppShell.css
@@ -58,6 +58,41 @@
   background: var(--color-surface);
 }
 
+.app-update-btn {
+  -webkit-app-region: no-drag;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 3px;
+  border: 1px solid var(--color-primary);
+  cursor: pointer;
+  background: none;
+  color: var(--color-primary);
+  transition: opacity 0.15s;
+  flex-shrink: 0;
+}
+
+.app-update-btn:hover {
+  opacity: 0.7;
+}
+
+.app-update-btn--ready {
+  background: var(--color-primary);
+  color: var(--color-bg);
+}
+
+.app-update-downloading {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
 /* Sidebar + content row */
 .app-body {
   display: flex;

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -166,10 +166,12 @@ export default function AppShell() {
             <button
               className="app-update-btn"
               onClick={async () => {
+                setUpdatePercent(null);
                 setUpdateState('downloading');
                 try {
                   await window.sourcerer.downloadUpdate();
                 } catch {
+                  setUpdatePercent(null);
                   setUpdateState('available');
                 }
               }}

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -42,6 +42,7 @@ export default function AppShell() {
   const [importRefreshTrigger, setImportRefreshTrigger] = useState(0);
   const [updateState, setUpdateState] = useState<'idle' | 'available' | 'downloading' | 'ready'>('idle');
   const [updateVersion, setUpdateVersion] = useState<string | null>(null);
+  const [updatePercent, setUpdatePercent] = useState<number | null>(null);
 
   const refreshOverdue = useCallback(async () => {
     const now = Math.floor(Date.now() / 1000);
@@ -95,12 +96,27 @@ export default function AppShell() {
       setUpdateVersion(version);
       setUpdateState('available');
     });
+    const offProgress = window.sourcerer.onUpdateDownloadProgress(({ percent }) => {
+      setUpdatePercent(percent);
+    });
     const offDownloaded = window.sourcerer.onUpdateDownloaded(({ version }) => {
       setUpdateVersion(version);
       setUpdateState('ready');
     });
+    // Replay any update event that fired before AppShell mounted (e.g. the
+    // 10 s auto-check completed while the user was still on the lock screen).
+    window.sourcerer.getUpdateState().then((state) => {
+      if (state?.event === 'available') {
+        setUpdateVersion(state.version);
+        setUpdateState('available');
+      } else if (state?.event === 'downloaded') {
+        setUpdateVersion(state.version);
+        setUpdateState('ready');
+      }
+    });
     return () => {
       offAvailable();
+      offProgress();
       offDownloaded();
     };
   }, []);
@@ -149,16 +165,22 @@ export default function AppShell() {
           {updateState === 'available' && (
             <button
               className="app-update-btn"
-              onClick={() => {
+              onClick={async () => {
                 setUpdateState('downloading');
-                window.sourcerer.downloadUpdate();
+                try {
+                  await window.sourcerer.downloadUpdate();
+                } catch {
+                  setUpdateState('available');
+                }
               }}
             >
               Update available ({updateVersion})
             </button>
           )}
           {updateState === 'downloading' && (
-            <span className="app-update-downloading">Downloading update&hellip;</span>
+            <span className="app-update-downloading">
+              Downloading update{updatePercent !== null ? ` ${updatePercent}%` : '\u2026'}
+            </span>
           )}
           {updateState === 'ready' && (
             <button

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ImportResult, Project, User } from '@shared/types';
 import Sidebar from './Sidebar';
 import SearchModal from './SearchModal';
@@ -43,6 +43,10 @@ export default function AppShell() {
   const [updateState, setUpdateState] = useState<'idle' | 'available' | 'downloading' | 'ready'>('idle');
   const [updateVersion, setUpdateVersion] = useState<string | null>(null);
   const [updatePercent, setUpdatePercent] = useState<number | null>(null);
+  // Keep a ref in sync so event listener callbacks can read the current state
+  // without closing over a stale value.
+  const updateStateRef = useRef<'idle' | 'available' | 'downloading' | 'ready'>('idle');
+  updateStateRef.current = updateState;
 
   const refreshOverdue = useCallback(async () => {
     const now = Math.floor(Date.now() / 1000);
@@ -104,17 +108,13 @@ export default function AppShell() {
       setUpdateState('ready');
     });
     const offError = window.sourcerer.onUpdateError(({ message }) => {
-      // The download failed (electron-updater reports errors via the error event,
-      // not by rejecting the downloadUpdate() promise). Only revert if we were
-      // actually downloading — a check error firing from idle would otherwise
-      // incorrectly show the update banner with no version.
-      setUpdateState((prev) => {
-        if (prev === 'downloading') {
-          window.alert(`Update failed: ${message}\n\nPlease try again.`);
-          return 'available';
-        }
-        return prev;
-      });
+      // update:error is only sent for download-phase failures (check errors are handled
+      // by the main process directly). Revert to 'available' if we were downloading or
+      // ready (a post-download verification error), then show a main-process dialog.
+      if (updateStateRef.current === 'downloading' || updateStateRef.current === 'ready') {
+        setUpdateState('available');
+        window.sourcerer.showUpdateError(message);
+      }
     });
     // Replay any update event that fired before AppShell mounted (e.g. the
     // 10 s auto-check completed while the user was still on the lock screen).
@@ -122,6 +122,10 @@ export default function AppShell() {
       if (state?.event === 'available') {
         setUpdateVersion(state.version);
         setUpdateState('available');
+      } else if (state?.event === 'downloading') {
+        setUpdateVersion(state.version);
+        setUpdatePercent(state.percent ?? null);
+        setUpdateState('downloading');
       } else if (state?.event === 'downloaded') {
         setUpdateVersion(state.version);
         setUpdateState('ready');

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -103,12 +103,18 @@ export default function AppShell() {
       setUpdateVersion(version);
       setUpdateState('ready');
     });
-    const offError = window.sourcerer.onUpdateError(() => {
+    const offError = window.sourcerer.onUpdateError(({ message }) => {
       // The download failed (electron-updater reports errors via the error event,
       // not by rejecting the downloadUpdate() promise). Only revert if we were
       // actually downloading — a check error firing from idle would otherwise
       // incorrectly show the update banner with no version.
-      setUpdateState((prev) => (prev === 'downloading' ? 'available' : prev));
+      setUpdateState((prev) => {
+        if (prev === 'downloading') {
+          window.alert(`Update failed: ${message}\n\nPlease try again.`);
+          return 'available';
+        }
+        return prev;
+      });
     });
     // Replay any update event that fired before AppShell mounted (e.g. the
     // 10 s auto-check completed while the user was still on the lock screen).
@@ -120,7 +126,7 @@ export default function AppShell() {
         setUpdateVersion(state.version);
         setUpdateState('ready');
       }
-    });
+    }).catch(() => {});
     return () => {
       offAvailable();
       offProgress();

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -103,6 +103,11 @@ export default function AppShell() {
       setUpdateVersion(version);
       setUpdateState('ready');
     });
+    const offError = window.sourcerer.onUpdateError(() => {
+      // The download failed (electron-updater reports errors via the error event,
+      // not by rejecting the downloadUpdate() promise). Revert so the user can retry.
+      setUpdateState('available');
+    });
     // Replay any update event that fired before AppShell mounted (e.g. the
     // 10 s auto-check completed while the user was still on the lock screen).
     window.sourcerer.getUpdateState().then((state) => {
@@ -118,6 +123,7 @@ export default function AppShell() {
       offAvailable();
       offProgress();
       offDownloaded();
+      offError();
     };
   }, []);
 

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -40,6 +40,8 @@ export default function AppShell() {
   const [showImportCsv, setShowImportCsv] = useState(false);
   const [importResult, setImportResult] = useState<ImportResult | null>(null);
   const [importRefreshTrigger, setImportRefreshTrigger] = useState(0);
+  const [updateState, setUpdateState] = useState<'idle' | 'available' | 'downloading' | 'ready'>('idle');
+  const [updateVersion, setUpdateVersion] = useState<string | null>(null);
 
   const refreshOverdue = useCallback(async () => {
     const now = Math.floor(Date.now() / 1000);
@@ -88,6 +90,21 @@ export default function AppShell() {
     return window.sourcerer.onRemindersChanged(refreshOverdue);
   }, [refreshOverdue]);
 
+  useEffect(() => {
+    const offAvailable = window.sourcerer.onUpdateAvailable(({ version }) => {
+      setUpdateVersion(version);
+      setUpdateState('available');
+    });
+    const offDownloaded = window.sourcerer.onUpdateDownloaded(({ version }) => {
+      setUpdateVersion(version);
+      setUpdateState('ready');
+    });
+    return () => {
+      offAvailable();
+      offDownloaded();
+    };
+  }, []);
+
   function handleProjectCreated(project: Project) {
     setProjects((prev) => [...prev, project]);
     setNav({ view: 'project', projectId: project.id });
@@ -129,6 +146,28 @@ export default function AppShell() {
       <div className="app-titlebar">
         <div className="app-titlebar-left" />
         <div className="app-titlebar-right">
+          {updateState === 'available' && (
+            <button
+              className="app-update-btn"
+              onClick={() => {
+                setUpdateState('downloading');
+                window.sourcerer.downloadUpdate();
+              }}
+            >
+              Update available ({updateVersion})
+            </button>
+          )}
+          {updateState === 'downloading' && (
+            <span className="app-update-downloading">Downloading update&hellip;</span>
+          )}
+          {updateState === 'ready' && (
+            <button
+              className="app-update-btn app-update-btn--ready"
+              onClick={() => window.sourcerer.quitAndInstall()}
+            >
+              Restart to update ({updateVersion})
+            </button>
+          )}
           Sourcerer&nbsp;·&nbsp;Local vault&nbsp;·&nbsp;Encrypted
           <button className="app-titlebar-lock" onClick={() => window.sourcerer.lock()} title="Lock Sourcerer">
             🔒

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -105,8 +105,10 @@ export default function AppShell() {
     });
     const offError = window.sourcerer.onUpdateError(() => {
       // The download failed (electron-updater reports errors via the error event,
-      // not by rejecting the downloadUpdate() promise). Revert so the user can retry.
-      setUpdateState('available');
+      // not by rejecting the downloadUpdate() promise). Only revert if we were
+      // actually downloading — a check error firing from idle would otherwise
+      // incorrectly show the update banner with no version.
+      setUpdateState((prev) => (prev === 'downloading' ? 'available' : prev));
     });
     // Replay any update event that fired before AppShell mounted (e.g. the
     // 10 s auto-check completed while the user was still on the lock screen).


### PR DESCRIPTION
- Install electron-updater
- src/main/ipc/updater.ts: new module with registerUpdaterHandlers()
  - Dev: registers stub IPC handlers + update:dev-simulate for UI testing via window.sourcerer.simulateUpdate() in DevTools console
  - Production: autoDownload=false, forwards update:available / download-progress / update:downloaded events to renderer, fires auto-check 10s after launch
  - triggerUpdateCheck(): called from Help > Check for Updates menu item
- src/main/index.ts: import + call registerUpdaterHandlers(win); add 'Check for Updates...' item to Help menu
- preload/index.ts: expose onUpdateAvailable, onUpdateDownloaded, downloadUpdate, quitAndInstall, simulateUpdate
- env.d.ts: types for all five new methods
- AppShell.tsx: update state machine (idle / available / downloading / ready); subscribe to preload callbacks; render update banner in titlebar
- AppShell.css: .app-update-btn (outlined) and .app-update-btn--ready (filled) styles
- package.json: add electron-updater dep; add publish config pointing to github tomcardoso/sourcerer with releaseType: release