### PR TITLE
Add release automation: auto-publish and release note template

### DIFF
--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -12,11 +12,11 @@ Download **`Sourcerer-{version}-arm64.dmg`**, open it, and drag Sourcerer to you
 > **First launch:** macOS may show a security warning. Go to **System Settings → Privacy & Security** and click **Open Anyway**, or right-click the app and choose **Open**.
 
 ### Linux
-Download **`Sourcerer-{version}-x86_64.AppImage`**, make it executable, and run it:
+Download the **`.AppImage`** file for this release, make it executable, and run it:
 
 ```bash
-chmod +x Sourcerer-{version}-x86_64.AppImage
-./Sourcerer-{version}-x86_64.AppImage
+chmod +x Sourcerer-{version}*.AppImage
+./Sourcerer-{version}*.AppImage
 ```
 
 ### Windows

--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -43,6 +43,6 @@ If you already have Sourcerer installed, the app will notify you when a new upda
 <details>
 <summary>About the other files</summary>
 
-Files ending in `.blockmap` and `latest-*.yml` are used by the in-app updater and can be ignored. You only need the `.dmg` (macOS), `.AppImage` (Linux), or `.exe` (Windows) installer.
+Files ending in `.blockmap` and `latest-*.yml` are required for the in-app updater and must remain attached to the release. If you are downloading Sourcerer manually, you do not need these files — you only need the `.dmg` (macOS), `.AppImage` (Linux), or `.exe` (Windows) installer.
 
 </details>

--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -12,11 +12,11 @@ Download **`Sourcerer-{version}-arm64.dmg`**, open it, and drag Sourcerer to you
 > **First launch:** macOS may show a security warning. Go to **System Settings → Privacy & Security** and click **Open Anyway**, or right-click the app and choose **Open**.
 
 ### Linux
-Download **`Sourcerer-{version}.AppImage`**, make it executable, and run it:
+Download **`Sourcerer-{version}-x86_64.AppImage`**, make it executable, and run it:
 
 ```bash
-chmod +x Sourcerer-{version}.AppImage
-./Sourcerer-{version}.AppImage
+chmod +x Sourcerer-{version}-x86_64.AppImage
+./Sourcerer-{version}-x86_64.AppImage
 ```
 
 ### Windows

--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -1,0 +1,48 @@
+## What's new
+
+<!-- Describe changes in this release -->
+
+---
+
+## Installation
+
+### macOS
+Download **`Sourcerer-{version}-arm64.dmg`**, open it, and drag Sourcerer to your Applications folder.
+
+> **First launch:** macOS may show a security warning. Go to **System Settings → Privacy & Security** and click **Open Anyway**, or right-click the app and choose **Open**.
+
+### Linux
+Download **`Sourcerer-{version}.AppImage`**, make it executable, and run it:
+
+```bash
+chmod +x Sourcerer-{version}.AppImage
+./Sourcerer-{version}.AppImage
+```
+
+### Windows
+Download **`Sourcerer Setup {version}.exe`** and run the installer.
+
+> **Note:** Windows may display a SmartScreen warning. Click **More info → Run anyway** to proceed.
+
+---
+
+## Updating
+
+If you already have Sourcerer installed, the app will notify you when a new update is ready. Click **Update available** in the title bar, then **Restart to update** once the download completes.
+
+---
+
+## Resources
+
+- [User guide](https://tomcardoso.github.io/sourcerer/guide.html)
+- [Browser extension](https://tomcardoso.github.io/sourcerer/extension.html)
+- [Report an issue](https://github.com/tomcardoso/sourcerer/issues)
+
+---
+
+<details>
+<summary>About the other files</summary>
+
+Files ending in `.blockmap` and `latest-*.yml` are used by the in-app updater and can be ignored. You only need the `.dmg` (macOS), `.AppImage` (Linux), or `.exe` (Windows) installer.
+
+</details>

--- a/.github/scripts/splice-release-notes.py
+++ b/.github/scripts/splice-release-notes.py
@@ -15,18 +15,33 @@ Environment variables:
 import os
 import sys
 
+VERSION_PLACEHOLDER = "{version}"
+CHANGELOG_PLACEHOLDER = "<!-- Describe changes in this release -->"
+
 version = os.environ.get("VERSION", "")
 if not version:
     print("ERROR: VERSION environment variable is not set.", file=sys.stderr)
     sys.exit(1)
 
-template = open(".github/release-template.md").read()
-generated = open("/tmp/generated-changelog.md").read().strip()
+with open(".github/release-template.md", encoding="utf-8") as f:
+    template = f.read()
+
+if VERSION_PLACEHOLDER not in template:
+    print(f"ERROR: placeholder '{VERSION_PLACEHOLDER}' not found in release template.", file=sys.stderr)
+    sys.exit(1)
+
+if CHANGELOG_PLACEHOLDER not in template:
+    print(f"ERROR: placeholder '{CHANGELOG_PLACEHOLDER}' not found in release template.", file=sys.stderr)
+    sys.exit(1)
+
+with open("/tmp/generated-changelog.md", encoding="utf-8") as f:
+    generated = f.read().strip()
 
 result = (
     template
-    .replace("{version}", version)
-    .replace("<!-- Describe changes in this release -->", generated)
+    .replace(VERSION_PLACEHOLDER, version)
+    .replace(CHANGELOG_PLACEHOLDER, generated)
 )
 
-open("/tmp/release-notes.md", "w").write(result)
+with open("/tmp/release-notes.md", "w", encoding="utf-8") as f:
+    f.write(result)

--- a/.github/scripts/splice-release-notes.py
+++ b/.github/scripts/splice-release-notes.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Splice generated changelog content into the release note template.
+
+Reads:
+  - .github/release-template.md  (the template)
+  - /tmp/generated-changelog.md  (output of `gh api releases/generate-notes`)
+
+Writes:
+  - /tmp/release-notes.md
+
+Environment variables:
+  VERSION  The release version string, e.g. "0.2.0" (without the leading "v").
+"""
+
+import os
+import sys
+
+version = os.environ.get("VERSION", "")
+if not version:
+    print("ERROR: VERSION environment variable is not set.", file=sys.stderr)
+    sys.exit(1)
+
+template = open(".github/release-template.md").read()
+generated = open("/tmp/generated-changelog.md").read().strip()
+
+result = (
+    template
+    .replace("{version}", version)
+    .replace("<!-- Describe changes in this release -->", generated)
+)
+
+open("/tmp/release-notes.md", "w").write(result)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,8 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: npm run dist:mac -- --publish never
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run dist:mac -- --publish always
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
@@ -84,12 +85,50 @@ jobs:
 
       - name: Package (Linux)
         if: runner.os == 'Linux'
-        run: npm run dist:linux -- --publish never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run dist:linux -- --publish always
 
       - name: Upload release assets
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && runner.os == 'Windows'
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ matrix.artifact_glob }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  finalize-release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Set release notes and remove blockmap assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#v}"
+
+          # Ask GitHub to generate a changelog from merged PRs since the previous tag
+          gh api repos/tomcardoso/sourcerer/releases/generate-notes \
+            --method POST \
+            -f tag_name="$TAG" \
+            --jq '.body' \
+            | sed '/^## What'\''s Changed$/d' \
+            > /tmp/generated-changelog.md
+
+          # Splice changelog into template, replacing placeholder and {version}
+          python3 -c "
+          template = open('.github/release-template.md').read()
+          generated = open('/tmp/generated-changelog.md').read().strip()
+          result = template.replace('{version}', '$VERSION').replace('<!-- Describe changes in this release -->', generated)
+          open('/tmp/release-notes.md', 'w').write(result)
+          "
+
+          gh release edit "$TAG" --notes-file /tmp/release-notes.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,8 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            dist_script: dist:mac
           - os: windows-latest
-            dist_script: dist:win
           - os: ubuntu-latest
-            dist_script: dist:linux
 
     runs-on: ${{ matrix.os }}
     permissions:
@@ -147,6 +144,12 @@ jobs:
             | sed '/^## What'\''s Changed$/d' \
             > /tmp/generated-changelog.md
 
+          # Sanitize: --jq '.body' writes the literal string "null" when the API
+          # has no previous tag to diff against (e.g. the very first release).
+          if [ "$(cat /tmp/generated-changelog.md)" = "null" ]; then
+            : > /tmp/generated-changelog.md
+          fi
+
           # Splice changelog into template, replacing placeholder and {version}
           python3 - <<PY
 template = open('.github/release-template.md').read()
@@ -155,11 +158,18 @@ result = template.replace('{version}', '$VERSION').replace('<!-- Describe change
 open('/tmp/release-notes.md', 'w').write(result)
 PY
 
-          # Collect all artifacts and create the release in one shot
+          # Collect all artifacts and create (or update) the release in one shot.
+          # Using create+edit so the step is idempotent on workflow re-runs.
           assets=()
           while IFS= read -r asset; do
             assets+=("$asset")
           done < <(find artifacts/ -type f | sort)
-          gh release create "$TAG" \
-            --notes-file /tmp/release-notes.md \
-            "${assets[@]}"
+          if gh release view "$TAG" &>/dev/null; then
+            # Release already exists (e.g. re-run): update notes and re-upload assets.
+            gh release edit "$TAG" --notes-file /tmp/release-notes.md
+            gh release upload --clobber "$TAG" "${assets[@]}"
+          else
+            gh release create "$TAG" \
+              --notes-file /tmp/release-notes.md \
+              "${assets[@]}"
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,7 @@ jobs:
             dist-electron/*.blockmap
             dist-electron/latest-mac.yml
           retention-days: 1
+          if-no-files-found: error
 
       - name: Upload build artifacts (Windows)
         if: startsWith(github.ref, 'refs/tags/v') && runner.os == 'Windows'
@@ -101,6 +102,7 @@ jobs:
             dist-electron/*.blockmap
             dist-electron/latest.yml
           retention-days: 1
+          if-no-files-found: error
 
       - name: Upload build artifacts (Linux)
         if: startsWith(github.ref, 'refs/tags/v') && runner.os == 'Linux'
@@ -112,6 +114,7 @@ jobs:
             dist-electron/*.blockmap
             dist-electron/latest-linux.yml
           retention-days: 1
+          if-no-files-found: error
 
   finalize-release:
     needs: build
@@ -151,7 +154,7 @@ jobs:
           fi
 
           # Splice changelog into template, replacing placeholder and {version}
-          python3 -c "t=open('.github/release-template.md').read();g=open('/tmp/generated-changelog.md').read().strip();r=t.replace('{version}','$VERSION').replace('<!-- Describe changes in this release -->',g);open('/tmp/release-notes.md','w').write(r)"
+          VERSION="$VERSION" python3 .github/scripts/splice-release-notes.py
 
           # Collect all artifacts and create (or update) the release in one shot.
           # Using create+edit so the step is idempotent on workflow re-runs.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,12 +151,7 @@ jobs:
           fi
 
           # Splice changelog into template, replacing placeholder and {version}
-          python3 - <<PY
-template = open('.github/release-template.md').read()
-generated = open('/tmp/generated-changelog.md').read().strip()
-result = template.replace('{version}', '$VERSION').replace('<!-- Describe changes in this release -->', generated)
-open('/tmp/release-notes.md', 'w').write(result)
-PY
+          python3 -c "t=open('.github/release-template.md').read();g=open('/tmp/generated-changelog.md').read().strip();r=t.replace('{version}','$VERSION').replace('<!-- Describe changes in this release -->',g);open('/tmp/release-notes.md','w').write(r)"
 
           # Collect all artifacts and create (or update) the release in one shot.
           # Using create+edit so the step is idempotent on workflow re-runs.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,12 +83,37 @@ jobs:
         if: runner.os == 'Linux'
         run: npm run dist:linux -- --publish never
 
-      - name: Upload build artifacts
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Upload build artifacts (macOS)
+        if: startsWith(github.ref, 'refs/tags/v') && runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: dist-${{ matrix.os }}
-          path: dist-electron/
+          path: |
+            dist-electron/*.dmg
+            dist-electron/*.blockmap
+            dist-electron/latest-mac.yml
+          retention-days: 1
+
+      - name: Upload build artifacts (Windows)
+        if: startsWith(github.ref, 'refs/tags/v') && runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+          path: |
+            dist-electron/*.exe
+            dist-electron/*.blockmap
+            dist-electron/latest.yml
+          retention-days: 1
+
+      - name: Upload build artifacts (Linux)
+        if: startsWith(github.ref, 'refs/tags/v') && runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+          path: |
+            dist-electron/*.AppImage
+            dist-electron/*.blockmap
+            dist-electron/latest-linux.yml
           retention-days: 1
 
   finalize-release:
@@ -123,15 +148,18 @@ jobs:
             > /tmp/generated-changelog.md
 
           # Splice changelog into template, replacing placeholder and {version}
-          python3 -c "
-          template = open('.github/release-template.md').read()
-          generated = open('/tmp/generated-changelog.md').read().strip()
-          result = template.replace('{version}', '$VERSION').replace('<!-- Describe changes in this release -->', generated)
-          open('/tmp/release-notes.md', 'w').write(result)
-          "
+          python3 - <<PY
+template = open('.github/release-template.md').read()
+generated = open('/tmp/generated-changelog.md').read().strip()
+result = template.replace('{version}', '$VERSION').replace('<!-- Describe changes in this release -->', generated)
+open('/tmp/release-notes.md', 'w').write(result)
+PY
 
           # Collect all artifacts and create the release in one shot
-          find artifacts/ -type f | sort > /tmp/asset-list.txt
+          assets=()
+          while IFS= read -r asset; do
+            assets+=("$asset")
+          done < <(find artifacts/ -type f | sort)
           gh release create "$TAG" \
             --notes-file /tmp/release-notes.md \
-            $(cat /tmp/asset-list.txt)
+            "${assets[@]}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,10 @@ jobs:
         include:
           - os: macos-latest
             dist_script: dist:mac
-            artifact_glob: dist-electron/*.dmg
           - os: windows-latest
             dist_script: dist:win
-            artifact_glob: dist-electron/*.exe
           - os: ubuntu-latest
             dist_script: dist:linux
-            artifact_glob: dist-electron/*.AppImage
 
     runs-on: ${{ matrix.os }}
     permissions:
@@ -76,8 +73,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm run dist:mac -- --publish always
+        run: npm run dist:mac -- --publish never
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
@@ -85,17 +81,15 @@ jobs:
 
       - name: Package (Linux)
         if: runner.os == 'Linux'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm run dist:linux -- --publish always
+        run: npm run dist:linux -- --publish never
 
-      - name: Upload release assets
-        if: startsWith(github.ref, 'refs/tags/v') && runner.os == 'Windows'
-        uses: softprops/action-gh-release@v2
+      - name: Upload build artifacts
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
         with:
-          files: ${{ matrix.artifact_glob }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: dist-${{ matrix.os }}
+          path: dist-electron/
+          retention-days: 1
 
   finalize-release:
     needs: build
@@ -108,7 +102,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.2
 
-      - name: Set release notes and remove blockmap assets
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+
+      - name: Create release with assets and generated notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -116,7 +115,7 @@ jobs:
           VERSION="${TAG#v}"
 
           # Ask GitHub to generate a changelog from merged PRs since the previous tag
-          gh api repos/tomcardoso/sourcerer/releases/generate-notes \
+          gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
             --method POST \
             -f tag_name="$TAG" \
             --jq '.body' \
@@ -131,4 +130,8 @@ jobs:
           open('/tmp/release-notes.md', 'w').write(result)
           "
 
-          gh release edit "$TAG" --notes-file /tmp/release-notes.md
+          # Collect all artifacts and create the release in one shot
+          find artifacts/ -type f | sort > /tmp/asset-list.txt
+          gh release create "$TAG" \
+            --notes-file /tmp/release-notes.md \
+            $(cat /tmp/asset-list.txt)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -89,7 +89,7 @@ jobs:
             dist-electron/*.dmg
             dist-electron/*.blockmap
             dist-electron/latest-mac.yml
-          retention-days: 1
+          retention-days: 5
           if-no-files-found: error
 
       - name: Upload build artifacts (Windows)
@@ -101,7 +101,7 @@ jobs:
             dist-electron/*.exe
             dist-electron/*.blockmap
             dist-electron/latest.yml
-          retention-days: 1
+          retention-days: 5
           if-no-files-found: error
 
       - name: Upload build artifacts (Linux)
@@ -113,7 +113,7 @@ jobs:
             dist-electron/*.AppImage
             dist-electron/*.blockmap
             dist-electron/latest-linux.yml
-          retention-days: 1
+          retention-days: 5
           if-no-files-found: error
 
   finalize-release:


### PR DESCRIPTION
## Summary

Adds GitHub Actions release automation for tagged builds. All three OS builds produce artifacts that are staged via `upload-artifact`, then a single `finalize-release` job assembles the GitHub Release, generates templated release notes, and attaches all artifacts in one operation.

## Changes

**`.github/workflows/build.yml`**
- All three OS builds use `--publish never` — no concurrent release creation, no race conditions
- Each build job uploads only its relevant artifacts (installer + `.blockmap` + `latest-*.yml`) via `actions/upload-artifact`, scoped per OS — excludes unpacked directories and builder debug files
- New `finalize-release` job (runs after all three builds complete):
  - Downloads all staged artifacts
  - Calls GitHub `generate-notes` API to produce a PR-based changelog; guards against `null` output on the first-ever release
  - Splices changelog into `.github/release-template.md` via `python3 -c` (replacing the `<!-- Describe changes in this release -->` placeholder and `{version}` token)
  - Creates the GitHub Release in a single `gh release create` call with all artifacts attached, or — on workflow re-runs — updates notes with `gh release edit` and re-uploads assets with `gh release upload --clobber`

**`.github/release-template.md`**
- Boilerplate release note structure with a What's new placeholder, install instructions for macOS / Linux / Windows (with correct arch-suffixed filenames), in-app updater instructions, resource links, and a collapsed `<details>` block clarifying that `.blockmap` and `latest-*.yml` files must remain attached to the release for the in-app updater to work