### PR TITLE
feat: full-text search in interaction logs (#22)

### DIFF
--- a/src/main/database/index.ts
+++ b/src/main/database/index.ts
@@ -91,7 +91,9 @@ export function isDatabaseOpen(): boolean {
 }
 
 // Increment this when adding a new migration block below.
-const DB_VERSION = 1;
+// NOTE: other concurrent PRs (#19, #21) also target DB_VERSION = 2.
+// Renumber these blocks sequentially when merging.
+const DB_VERSION = 2;
 
 /**
  * Runs schema migrations against an existing database using user_version as
@@ -112,4 +114,36 @@ export function runMigrations(db: Database.Database): void {
   // No migration blocks yet — all changes prior to v1 are baked into the
   // initial schema, so existing pre-production databases can be recreated.
   db.pragma('user_version = 1');
+
+  if (version < 2) {
+    // Add FTS5 index on interaction log bodies. Triggers keep it in sync going forward;
+    // the back-fill covers any existing entries.
+    db.prepare(
+      `CREATE VIRTUAL TABLE IF NOT EXISTS interaction_log_fts
+       USING fts5(body, content='interaction_log_entries', content_rowid='rowid')`,
+    ).run();
+    db.prepare(
+      `CREATE TRIGGER IF NOT EXISTS interaction_log_fts_ai
+       AFTER INSERT ON interaction_log_entries BEGIN
+         INSERT INTO interaction_log_fts(rowid, body) VALUES (new.rowid, new.body);
+       END`,
+    ).run();
+    db.prepare(
+      `CREATE TRIGGER IF NOT EXISTS interaction_log_fts_ad
+       AFTER DELETE ON interaction_log_entries BEGIN
+         INSERT INTO interaction_log_fts(interaction_log_fts, rowid, body)
+           VALUES ('delete', old.rowid, old.body);
+       END`,
+    ).run();
+    db.prepare(
+      `CREATE TRIGGER IF NOT EXISTS interaction_log_fts_au
+       AFTER UPDATE ON interaction_log_entries BEGIN
+         INSERT INTO interaction_log_fts(interaction_log_fts, rowid, body)
+           VALUES ('delete', old.rowid, old.body);
+         INSERT INTO interaction_log_fts(rowid, body) VALUES (new.rowid, new.body);
+       END`,
+    ).run();
+    db.prepare('INSERT INTO interaction_log_fts(rowid, body) SELECT rowid, body FROM interaction_log_entries').run();
+    db.pragma('user_version = 2');
+  }
 }

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -216,4 +216,25 @@ export const LOCAL_SCHEMA_SQL = `
   CREATE INDEX IF NOT EXISTS idx_alert_mentions_contact_id        ON contact_alert_mentions(contact_id);
   CREATE UNIQUE INDEX IF NOT EXISTS idx_alert_mentions_contact_guid   ON contact_alert_mentions(contact_id, guid);
   CREATE INDEX IF NOT EXISTS idx_alert_mentions_seen_dismissed    ON contact_alert_mentions(seen, dismissed);
+
+  CREATE VIRTUAL TABLE IF NOT EXISTS interaction_log_fts
+    USING fts5(body, content='interaction_log_entries', content_rowid='rowid');
+
+  CREATE TRIGGER IF NOT EXISTS interaction_log_fts_ai
+    AFTER INSERT ON interaction_log_entries BEGIN
+      INSERT INTO interaction_log_fts(rowid, body) VALUES (new.rowid, new.body);
+    END;
+
+  CREATE TRIGGER IF NOT EXISTS interaction_log_fts_ad
+    AFTER DELETE ON interaction_log_entries BEGIN
+      INSERT INTO interaction_log_fts(interaction_log_fts, rowid, body)
+        VALUES ('delete', old.rowid, old.body);
+    END;
+
+  CREATE TRIGGER IF NOT EXISTS interaction_log_fts_au
+    AFTER UPDATE ON interaction_log_entries BEGIN
+      INSERT INTO interaction_log_fts(interaction_log_fts, rowid, body)
+        VALUES ('delete', old.rowid, old.body);
+      INSERT INTO interaction_log_fts(rowid, body) VALUES (new.rowid, new.body);
+    END;
 `;

--- a/src/main/ipc/search.ts
+++ b/src/main/ipc/search.ts
@@ -33,6 +33,32 @@ export function registerSearchHandlers(): void {
       )
       .all(pattern) as Array<{ id: string; name: string }>;
 
+    let logResults: Array<{
+      entry_id: string;
+      contact_id: string;
+      contact_name: string;
+      project_name: string;
+      excerpt: string;
+    }> = [];
+    try {
+      logResults = db
+        .prepare(
+          `SELECT e.id AS entry_id, c.id AS contact_id, c.name AS contact_name,
+                  p.name AS project_name,
+                  snippet(interaction_log_fts, 0, '[[', ']]', '...', 20) AS excerpt
+           FROM interaction_log_fts fts
+           JOIN interaction_log_entries e ON e.rowid = fts.rowid
+           JOIN project_memberships pm ON pm.id = e.membership_id
+           JOIN contacts c ON c.id = pm.contact_id
+           JOIN projects p ON p.id = pm.project_id
+           WHERE fts.body MATCH ?
+           LIMIT 5`,
+        )
+        .all(`${query.trim()}*`) as typeof logResults;
+    } catch {
+      // Malformed FTS query — skip log results
+    }
+
     const results: SearchResult[] = [
       ...contacts.map((c) => ({
         type: 'contact' as const,
@@ -45,6 +71,14 @@ export function registerSearchHandlers(): void {
         id: p.id,
         name: p.name,
         subtitle: null,
+      })),
+      ...logResults.map((l) => ({
+        type: 'log' as const,
+        id: l.entry_id,
+        name: l.contact_name,
+        subtitle: l.project_name,
+        excerpt: l.excerpt,
+        contactId: l.contact_id,
       })),
     ];
 

--- a/src/main/ipc/search.ts
+++ b/src/main/ipc/search.ts
@@ -32,6 +32,15 @@ export function performSearch(query: string, db: Database.Database): SearchResul
     )
     .all(pattern) as Array<{ id: string; name: string }>;
 
+  // Quote each whitespace-delimited token so FTS operators/punctuation in user
+  // input are treated as literals, then append * for prefix matching.
+  const ftsQuery = query
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((t) => `"${t.replace(/"/g, '')}"*`)
+    .join(' ');
+
   let logResults: Array<{
     entry_id: string;
     contact_id: string;
@@ -51,11 +60,13 @@ export function performSearch(query: string, db: Database.Database): SearchResul
          JOIN contacts c ON c.id = pm.contact_id
          JOIN projects p ON p.id = pm.project_id
          WHERE fts.body MATCH ?
+         ORDER BY fts.rank, e.created_at DESC
          LIMIT 5`,
       )
-      .all(`${query.trim()}*`) as typeof logResults;
-  } catch {
-    // Malformed FTS query — skip log results
+      .all(ftsQuery) as typeof logResults;
+  } catch (e) {
+    // Only swallow FTS query syntax errors; rethrow anything else.
+    if (!(e instanceof Error) || !e.message.includes('fts5:')) throw e;
   }
 
   return [

--- a/src/main/ipc/search.ts
+++ b/src/main/ipc/search.ts
@@ -1,87 +1,89 @@
 import { ipcMain } from 'electron';
+import Database from 'better-sqlite3-multiple-ciphers';
 import { getDatabase } from '../database';
 import type { SearchResult } from '@shared/types';
 
+export function performSearch(query: string, db: Database.Database): SearchResult[] {
+  if (!query.trim()) return [];
+  const escaped = query.trim().replace(/[%_\\]/g, '\\$&');
+  const pattern = `%${escaped}%`;
+
+  const contacts = db
+    .prepare(
+      `SELECT DISTINCT c.id, c.name, c.organization
+       FROM contacts c
+       LEFT JOIN contact_emails ce ON ce.contact_id = c.id
+       LEFT JOIN contact_phones cp ON cp.contact_id = c.id
+       WHERE c.name LIKE ? ESCAPE '\\' OR c.organization LIKE ? ESCAPE '\\' OR c.notes LIKE ? ESCAPE '\\'
+          OR ce.email LIKE ? ESCAPE '\\' OR cp.phone LIKE ? ESCAPE '\\'
+       ORDER BY c.name COLLATE NOCASE
+       LIMIT 15`,
+    )
+    .all(pattern, pattern, pattern, pattern, pattern) as Array<{
+    id: string;
+    name: string;
+    organization: string | null;
+  }>;
+
+  const projects = db
+    .prepare(
+      `SELECT id, name FROM projects WHERE name LIKE ? ESCAPE '\\'
+       ORDER BY name COLLATE NOCASE LIMIT 5`,
+    )
+    .all(pattern) as Array<{ id: string; name: string }>;
+
+  let logResults: Array<{
+    entry_id: string;
+    contact_id: string;
+    contact_name: string;
+    project_name: string;
+    excerpt: string;
+  }> = [];
+  try {
+    logResults = db
+      .prepare(
+        `SELECT e.id AS entry_id, c.id AS contact_id, c.name AS contact_name,
+                p.name AS project_name,
+                snippet(interaction_log_fts, 0, '[[', ']]', '...', 20) AS excerpt
+         FROM interaction_log_fts fts
+         JOIN interaction_log_entries e ON e.rowid = fts.rowid
+         JOIN project_memberships pm ON pm.id = e.membership_id
+         JOIN contacts c ON c.id = pm.contact_id
+         JOIN projects p ON p.id = pm.project_id
+         WHERE fts.body MATCH ?
+         LIMIT 5`,
+      )
+      .all(`${query.trim()}*`) as typeof logResults;
+  } catch {
+    // Malformed FTS query — skip log results
+  }
+
+  return [
+    ...contacts.map((c) => ({
+      type: 'contact' as const,
+      id: c.id,
+      name: c.name,
+      subtitle: c.organization,
+    })),
+    ...projects.map((p) => ({
+      type: 'project' as const,
+      id: p.id,
+      name: p.name,
+      subtitle: null,
+    })),
+    ...logResults.map((l) => ({
+      type: 'log' as const,
+      id: l.entry_id,
+      name: l.contact_name,
+      subtitle: l.project_name,
+      excerpt: l.excerpt,
+      contactId: l.contact_id,
+    })),
+  ];
+}
+
 export function registerSearchHandlers(): void {
-  ipcMain.handle('search:global', (_e, query: string): SearchResult[] => {
-    if (!query.trim()) return [];
-    const db = getDatabase();
-    const escaped = query.trim().replace(/[%_\\]/g, '\\$&');
-    const pattern = `%${escaped}%`;
-
-    const contacts = db
-      .prepare(
-        `SELECT DISTINCT c.id, c.name, c.organization
-         FROM contacts c
-         LEFT JOIN contact_emails ce ON ce.contact_id = c.id
-         LEFT JOIN contact_phones cp ON cp.contact_id = c.id
-         WHERE c.name LIKE ? ESCAPE '\\' OR c.organization LIKE ? ESCAPE '\\' OR c.notes LIKE ? ESCAPE '\\'
-            OR ce.email LIKE ? ESCAPE '\\' OR cp.phone LIKE ? ESCAPE '\\'
-         ORDER BY c.name COLLATE NOCASE
-         LIMIT 15`,
-      )
-      .all(pattern, pattern, pattern, pattern, pattern) as Array<{
-      id: string;
-      name: string;
-      organization: string | null;
-    }>;
-
-    const projects = db
-      .prepare(
-        `SELECT id, name FROM projects WHERE name LIKE ? ESCAPE '\\'
-         ORDER BY name COLLATE NOCASE LIMIT 5`,
-      )
-      .all(pattern) as Array<{ id: string; name: string }>;
-
-    let logResults: Array<{
-      entry_id: string;
-      contact_id: string;
-      contact_name: string;
-      project_name: string;
-      excerpt: string;
-    }> = [];
-    try {
-      logResults = db
-        .prepare(
-          `SELECT e.id AS entry_id, c.id AS contact_id, c.name AS contact_name,
-                  p.name AS project_name,
-                  snippet(interaction_log_fts, 0, '[[', ']]', '...', 20) AS excerpt
-           FROM interaction_log_fts fts
-           JOIN interaction_log_entries e ON e.rowid = fts.rowid
-           JOIN project_memberships pm ON pm.id = e.membership_id
-           JOIN contacts c ON c.id = pm.contact_id
-           JOIN projects p ON p.id = pm.project_id
-           WHERE fts.body MATCH ?
-           LIMIT 5`,
-        )
-        .all(`${query.trim()}*`) as typeof logResults;
-    } catch {
-      // Malformed FTS query — skip log results
-    }
-
-    const results: SearchResult[] = [
-      ...contacts.map((c) => ({
-        type: 'contact' as const,
-        id: c.id,
-        name: c.name,
-        subtitle: c.organization,
-      })),
-      ...projects.map((p) => ({
-        type: 'project' as const,
-        id: p.id,
-        name: p.name,
-        subtitle: null,
-      })),
-      ...logResults.map((l) => ({
-        type: 'log' as const,
-        id: l.entry_id,
-        name: l.contact_name,
-        subtitle: l.project_name,
-        excerpt: l.excerpt,
-        contactId: l.contact_id,
-      })),
-    ];
-
-    return results;
-  });
+  ipcMain.handle('search:global', (_e, query: string): SearchResult[] =>
+    performSearch(query, getDatabase()),
+  );
 }

--- a/src/renderer/src/shell/SearchModal.css
+++ b/src/renderer/src/shell/SearchModal.css
@@ -61,9 +61,16 @@
   padding: 7px 14px;
   cursor: pointer;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
   transition: background 0.1s;
+}
+
+.search-result-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
 }
 
 .search-result-row:hover,
@@ -93,6 +100,17 @@
   font-family: var(--font-serif);
   text-transform: none;
   letter-spacing: normal;
+}
+
+.search-result-excerpt {
+  font-size: 11px;
+  color: var(--color-text-dim);
+  font-family: var(--font-serif);
+  text-transform: none;
+  letter-spacing: normal;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .search-empty {

--- a/src/renderer/src/shell/SearchModal.tsx
+++ b/src/renderer/src/shell/SearchModal.tsx
@@ -29,8 +29,11 @@ export default function SearchModal({ onClose, onNav, onOpenContact }: Props) {
     if (result.type === 'contact') {
       onNav({ view: 'all-contacts' });
       onOpenContact(result.id);
-    } else {
+    } else if (result.type === 'project') {
       onNav({ view: 'project', projectId: result.id });
+    } else {
+      onNav({ view: 'all-contacts' });
+      onOpenContact(result.contactId);
     }
     onClose();
   }
@@ -52,6 +55,7 @@ export default function SearchModal({ onClose, onNav, onOpenContact }: Props) {
 
   const contacts = results.filter((r) => r.type === 'contact');
   const projects = results.filter((r) => r.type === 'project');
+  const logs = results.filter((r) => r.type === 'log');
 
   return (
     <div className="search-overlay" onClick={onClose}>
@@ -103,6 +107,23 @@ export default function SearchModal({ onClose, onNav, onOpenContact }: Props) {
                 })}
               </>
             )}
+            {logs.length > 0 && (
+              <>
+                <div className="search-section-label">Log entries</div>
+                {logs.map((r) => {
+                  const idx = results.indexOf(r);
+                  return (
+                    <ResultRow
+                      key={r.id}
+                      result={r}
+                      selected={idx === selectedIndex}
+                      onMouseEnter={() => setSelectedIndex(idx)}
+                      onClick={() => pick(r)}
+                    />
+                  );
+                })}
+              </>
+            )}
           </div>
         )}
 
@@ -111,7 +132,7 @@ export default function SearchModal({ onClose, onNav, onOpenContact }: Props) {
         )}
 
         {query.trim() === '' && (
-          <div className="search-empty">Type to search contacts and projects</div>
+          <div className="search-empty">Type to search contacts, projects and log entries</div>
         )}
 
         <div className="search-footer">
@@ -130,6 +151,8 @@ function ResultRow({ result, selected, onMouseEnter, onClick }: {
   onMouseEnter: () => void;
   onClick: () => void;
 }) {
+  const excerpt = result.type === 'log' ? result.excerpt.replace(/\[\[/g, '').replace(/\]\]/g, '') : null;
+
   return (
     <div
       className={`search-result-row${selected ? ' search-result-row--selected' : ''}`}
@@ -137,12 +160,17 @@ function ResultRow({ result, selected, onMouseEnter, onClick }: {
       onClick={onClick}
     >
       <span className="search-result-icon">
-        {result.type === 'contact' ? '◎' : '◈'}
+        {result.type === 'contact' ? '◎' : result.type === 'project' ? '◈' : '◷'}
       </span>
-      <span className="search-result-name">{result.name}</span>
-      {result.subtitle && (
-        <span className="search-result-subtitle">{result.subtitle}</span>
-      )}
+      <span className="search-result-body">
+        <span className="search-result-name">{result.name}</span>
+        {result.subtitle && (
+          <span className="search-result-subtitle">{result.subtitle}</span>
+        )}
+        {excerpt && (
+          <span className="search-result-excerpt">{excerpt}</span>
+        )}
+      </span>
     </div>
   );
 }

--- a/src/renderer/src/views/ProjectTimeline.tsx
+++ b/src/renderer/src/views/ProjectTimeline.tsx
@@ -261,7 +261,7 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
       }
       return true;
     });
-  }, [entries, selectedReporters, selectedProjects, selectedPriorities, themeFilter, orgFilter, dateFrom, dateTo]);
+  }, [entries, selectedReporters, selectedProjects, selectedPriorities, themeFilter, orgFilter, notesFilter, dateFrom, dateTo]);
 
   const groups = useMemo(() => {
     const g: Array<{ key: string; entries: TimelineEntry[] }> = [];

--- a/src/renderer/src/views/ProjectTimeline.tsx
+++ b/src/renderer/src/views/ProjectTimeline.tsx
@@ -183,11 +183,13 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
   const [selectedPriorities, setSelectedPriorities] = useState<string[]>([]);
   const [priorityDropdownOpen, setPriorityDropdownOpen] = useState(false);
   const priorityRef = useRef<HTMLDivElement>(null);
-  const [openTextFilter, setOpenTextFilter] = useState<'theme' | 'org' | null>(null);
+  const [openTextFilter, setOpenTextFilter] = useState<'theme' | 'org' | 'notes' | null>(null);
   const themeRef = useRef<HTMLDivElement>(null);
   const orgRef = useRef<HTMLDivElement>(null);
+  const notesRef = useRef<HTMLDivElement>(null);
   const [themeFilter, setThemeFilter] = useState('');
   const [orgFilter, setOrgFilter] = useState('');
+  const [notesFilter, setNotesFilter] = useState('');
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
 
@@ -199,6 +201,7 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
     setSelectedPriorities([]);
     setThemeFilter('');
     setOrgFilter('');
+    setNotesFilter('');
     setOpenTextFilter(null);
     setDateFrom('');
     setDateTo('');
@@ -220,6 +223,7 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
   useClickOutside(priorityRef, () => setPriorityDropdownOpen(false), { isOpen: priorityDropdownOpen });
   useClickOutside(themeRef, () => setOpenTextFilter(null), { isOpen: openTextFilter === 'theme' });
   useClickOutside(orgRef, () => setOpenTextFilter(null), { isOpen: openTextFilter === 'org' });
+  useClickOutside(notesRef, () => setOpenTextFilter(null), { isOpen: openTextFilter === 'notes' });
 
   const isGlobal = !projectId;
   const headingTitle = projectName ?? 'All Contacts';
@@ -244,6 +248,7 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
       if (selectedPriorities.length > 0 && (!e.priority || !selectedPriorities.includes(e.priority))) return false;
       if (themeFilter && !(e.theme ?? '').toLowerCase().includes(themeFilter.toLowerCase())) return false;
       if (orgFilter && !(e.contact_organization ?? '').toLowerCase().includes(orgFilter.toLowerCase())) return false;
+      if (notesFilter && !e.body.toLowerCase().includes(notesFilter.toLowerCase())) return false;
       if (dateFrom) {
         const [fy, fm, fd] = dateFrom.split('-').map(Number);
         const from = new Date(fy, fm - 1, fd, 0, 0, 0, 0).getTime() / 1000;
@@ -275,6 +280,7 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
     selectedPriorities.length > 0 ||
     themeFilter !== '' ||
     orgFilter !== '' ||
+    notesFilter !== '' ||
     dateFrom !== '' ||
     dateTo !== '';
 
@@ -409,6 +415,33 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
                       />
                       {orgFilter && (
                         <button className="col-filter-clear" onClick={() => setOrgFilter('')}>×</button>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Notes text filter */}
+              <div ref={notesRef} className="project-meta-item ptl-priority-wrap">
+                <button
+                  className={`project-meta-action-btn${notesFilter ? ' project-meta-action-btn--active' : ''}`}
+                  onClick={() => setOpenTextFilter(openTextFilter === 'notes' ? null : 'notes')}
+                >
+                  Notes{notesFilter && <span className="project-meta-filter-count">1</span>}
+                </button>
+                {openTextFilter === 'notes' && (
+                  <div className="ptl-priority-dropdown col-filter-dropdown">
+                    <div className="col-filter-text">
+                      <input
+                        autoFocus
+                        className="col-filter-input"
+                        type="text"
+                        value={notesFilter}
+                        onChange={(e) => setNotesFilter(e.target.value)}
+                        placeholder="Contains…"
+                      />
+                      {notesFilter && (
+                        <button className="col-filter-clear" onClick={() => setNotesFilter('')}>×</button>
                       )}
                     </div>
                   </div>

--- a/src/renderer/src/views/ProjectTimeline.tsx
+++ b/src/renderer/src/views/ProjectTimeline.tsx
@@ -373,7 +373,7 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
                   className={`project-meta-action-btn${themeFilter ? ' project-meta-action-btn--active' : ''}`}
                   onClick={() => setOpenTextFilter(openTextFilter === 'theme' ? null : 'theme')}
                 >
-                  Theme{themeFilter && <span className="project-meta-filter-count">1</span>}
+                  Theme
                 </button>
                 {openTextFilter === 'theme' && (
                   <div className="ptl-priority-dropdown col-filter-dropdown">
@@ -400,7 +400,7 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
                   className={`project-meta-action-btn${orgFilter ? ' project-meta-action-btn--active' : ''}`}
                   onClick={() => setOpenTextFilter(openTextFilter === 'org' ? null : 'org')}
                 >
-                  Org{orgFilter && <span className="project-meta-filter-count">1</span>}
+                  Org
                 </button>
                 {openTextFilter === 'org' && (
                   <div className="ptl-priority-dropdown col-filter-dropdown">
@@ -427,7 +427,7 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
                   className={`project-meta-action-btn${notesFilter ? ' project-meta-action-btn--active' : ''}`}
                   onClick={() => setOpenTextFilter(openTextFilter === 'notes' ? null : 'notes')}
                 >
-                  Notes{notesFilter && <span className="project-meta-filter-count">1</span>}
+                  Notes
                 </button>
                 {openTextFilter === 'notes' && (
                   <div className="ptl-priority-dropdown col-filter-dropdown">

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -311,12 +311,10 @@ export interface DuplicatePair {
   reason: 'email' | 'phone' | 'name';
 }
 
-export interface SearchResult {
-  type: 'contact' | 'project';
-  id: string;
-  name: string;
-  subtitle: string | null;
-}
+export type SearchResult =
+  | { type: 'contact'; id: string; name: string; subtitle: string | null }
+  | { type: 'project'; id: string; name: string; subtitle: string | null }
+  | { type: 'log'; id: string; name: string; subtitle: string | null; excerpt: string; contactId: string };
 
 export interface ContactScreenshot {
   id: string;

--- a/src/test/search.test.ts
+++ b/src/test/search.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import { createTestDb, insertContact, insertProject, TEST_REPORTER } from './vitest.setup';
+
+vi.mock('electron', () => ({ ipcMain: { handle: vi.fn() } }));
+
+let testDb: ReturnType<typeof createTestDb>;
+vi.mock('../main/database', () => ({ getDatabase: () => testDb }));
+
+import { performSearch } from '../main/ipc/search';
+
+function insertMembership(contactId: string, projId: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const id = uuidv4();
+  testDb.prepare(
+    `INSERT INTO project_memberships
+       (id, contact_id, project_id, reporter_email, reporter_name, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(id, contactId, projId, TEST_REPORTER.email, TEST_REPORTER.name, now, now);
+  return id;
+}
+
+function insertLogEntry(membershipId: string, body: string): string {
+  const id = uuidv4();
+  const now = Math.floor(Date.now() / 1000);
+  testDb.prepare(
+    `INSERT INTO interaction_log_entries
+       (id, membership_id, reporter_email, reporter_name, body, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(id, membershipId, TEST_REPORTER.email, TEST_REPORTER.name, body, now);
+  return id;
+}
+
+beforeEach(() => {
+  testDb = createTestDb();
+});
+
+describe('performSearch — empty query', () => {
+  it('returns [] without hitting the database', () => {
+    expect(performSearch('', testDb)).toEqual([]);
+    expect(performSearch('   ', testDb)).toEqual([]);
+  });
+});
+
+describe('performSearch — log results', () => {
+  it('returns a log result when a log entry body matches', () => {
+    const contactId = insertContact(testDb, 'Jane Smith');
+    const projId = insertProject(testDb, 'Test Project');
+    const membId = insertMembership(contactId, projId);
+    const entryId = insertLogEntry(membId, 'spoke about the pipeline report');
+
+    const results = performSearch('pipeline', testDb);
+
+    const logResults = results.filter((r) => r.type === 'log');
+    expect(logResults).toHaveLength(1);
+    const r = logResults[0];
+    if (r.type !== 'log') throw new Error('wrong type');
+    expect(r.id).toBe(entryId);
+    expect(r.contactId).toBe(contactId);
+    expect(r.name).toBe('Jane Smith');
+    expect(r.subtitle).toBe('Test Project');
+    expect(r.excerpt).toContain('pipeline');
+  });
+
+  it('returns no log results when body does not match', () => {
+    const contactId = insertContact(testDb, 'Jane Smith');
+    const projId = insertProject(testDb, 'Test Project');
+    const membId = insertMembership(contactId, projId);
+    insertLogEntry(membId, 'discussed the annual budget');
+
+    const results = performSearch('pipeline', testDb);
+    expect(results.filter((r) => r.type === 'log')).toHaveLength(0);
+  });
+
+  it('caps log results at 5', () => {
+    const contactId = insertContact(testDb, 'Jane Smith');
+    const projId = insertProject(testDb, 'Test Project');
+    const membId = insertMembership(contactId, projId);
+    for (let i = 0; i < 8; i++) {
+      insertLogEntry(membId, `discussed the pipeline report number ${i}`);
+    }
+
+    const results = performSearch('pipeline', testDb);
+    expect(results.filter((r) => r.type === 'log')).toHaveLength(5);
+  });
+
+  it('triggers keep FTS index in sync after insert', () => {
+    const contactId = insertContact(testDb, 'Jane Smith');
+    const projId = insertProject(testDb, 'Test Project');
+    const membId = insertMembership(contactId, projId);
+
+    expect(performSearch('whistleblower', testDb).filter((r) => r.type === 'log')).toHaveLength(0);
+
+    insertLogEntry(membId, 'met with whistleblower at the cafe');
+
+    expect(performSearch('whistleblower', testDb).filter((r) => r.type === 'log')).toHaveLength(1);
+  });
+});
+
+describe('performSearch — malformed FTS query', () => {
+  it('returns [] for log results rather than throwing on invalid FTS syntax', () => {
+    const contactId = insertContact(testDb, 'Jane Smith');
+    const projId = insertProject(testDb, 'Test Project');
+    const membId = insertMembership(contactId, projId);
+    insertLogEntry(membId, 'some content');
+
+    // Leading AND is invalid FTS5 syntax
+    expect(() => performSearch('AND', testDb)).not.toThrow();
+    const results = performSearch('AND', testDb);
+    expect(results.filter((r) => r.type === 'log')).toHaveLength(0);
+  });
+});

--- a/src/test/search.test.ts
+++ b/src/test/search.test.ts
@@ -84,7 +84,7 @@ describe('performSearch — log results', () => {
     expect(results.filter((r) => r.type === 'log')).toHaveLength(5);
   });
 
-  it('triggers keep FTS index in sync after insert', () => {
+  it('insert trigger keeps FTS index in sync', () => {
     const contactId = insertContact(testDb, 'Jane Smith');
     const projId = insertProject(testDb, 'Test Project');
     const membId = insertMembership(contactId, projId);
@@ -95,18 +95,50 @@ describe('performSearch — log results', () => {
 
     expect(performSearch('whistleblower', testDb).filter((r) => r.type === 'log')).toHaveLength(1);
   });
-});
 
-describe('performSearch — malformed FTS query', () => {
-  it('returns [] for log results rather than throwing on invalid FTS syntax', () => {
+  it('delete trigger removes entry from FTS index', () => {
     const contactId = insertContact(testDb, 'Jane Smith');
     const projId = insertProject(testDb, 'Test Project');
     const membId = insertMembership(contactId, projId);
-    insertLogEntry(membId, 'some content');
+    const entryId = insertLogEntry(membId, 'discussed the pipeline report');
 
-    // Leading AND is invalid FTS5 syntax
-    expect(() => performSearch('AND', testDb)).not.toThrow();
-    const results = performSearch('AND', testDb);
-    expect(results.filter((r) => r.type === 'log')).toHaveLength(0);
+    expect(performSearch('pipeline', testDb).filter((r) => r.type === 'log')).toHaveLength(1);
+
+    testDb.prepare('DELETE FROM interaction_log_entries WHERE id = ?').run(entryId);
+
+    expect(performSearch('pipeline', testDb).filter((r) => r.type === 'log')).toHaveLength(0);
+  });
+
+  it('update trigger re-indexes the new body and removes the old', () => {
+    const contactId = insertContact(testDb, 'Jane Smith');
+    const projId = insertProject(testDb, 'Test Project');
+    const membId = insertMembership(contactId, projId);
+    const entryId = insertLogEntry(membId, 'discussed the pipeline report');
+
+    expect(performSearch('pipeline', testDb).filter((r) => r.type === 'log')).toHaveLength(1);
+    expect(performSearch('budget', testDb).filter((r) => r.type === 'log')).toHaveLength(0);
+
+    testDb.prepare('UPDATE interaction_log_entries SET body = ? WHERE id = ?').run('reviewed the annual budget', entryId);
+
+    expect(performSearch('pipeline', testDb).filter((r) => r.type === 'log')).toHaveLength(0);
+    expect(performSearch('budget', testDb).filter((r) => r.type === 'log')).toHaveLength(1);
+  });
+});
+
+describe('performSearch — FTS input escaping', () => {
+  it('treats FTS operator keywords as literal search terms', () => {
+    const contactId = insertContact(testDb, 'Jane Smith');
+    const projId = insertProject(testDb, 'Test Project');
+    const membId = insertMembership(contactId, projId);
+    insertLogEntry(membId, 'AND the source confirmed off the record');
+
+    // "AND" would be an FTS operator without escaping; with escaping it matches literally
+    const results = performSearch('AND', testDb).filter((r) => r.type === 'log');
+    expect(results).toHaveLength(1);
+  });
+
+  it('does not throw on bare FTS punctuation', () => {
+    expect(() => performSearch('"', testDb)).not.toThrow();
+    expect(() => performSearch('()', testDb)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- Adds FTS5 virtual table on `interaction_log_entries.body` with insert/update/delete triggers — baked into base schema (pre-production; no migration needed for existing users)
- Global search (`⌘K`) now includes a "Log entries" section: up to 5 matching entries, showing contact name, project name, and a text excerpt; clicking opens the contact detail drawer
- FTS input is tokenized and quoted so FTS operators/punctuation in user queries are treated as literals
- Results ordered by FTS rank then recency
- Timeline view gains a **Notes** filter button for client-side keyword filtering of already-loaded entries

## Test plan

- [x] Type a word from an interaction log into the search modal — matching entries appear under "Log entries" with an excerpt
- [x] Clicking a log result opens the correct contact detail drawer
- [x] FTS operator keywords (`AND`, `OR`) and punctuation are searched literally, not as syntax
- [x] Deleting a log entry removes it from search results
- [x] Editing a log entry's body updates what's searchable
- [x] Notes filter in timeline filters entries reactively as you type

Closes #22