### PR TITLE
feat: project archiving (#19)

### DIFF
--- a/src/main/database/index.ts
+++ b/src/main/database/index.ts
@@ -91,7 +91,9 @@ export function isDatabaseOpen(): boolean {
 }
 
 // Increment this when adding a new migration block below.
-const DB_VERSION = 1;
+// NOTE: other concurrent PRs (#21, #22) also target DB_VERSION = 2.
+// Renumber these blocks sequentially when merging.
+const DB_VERSION = 2;
 
 /**
  * Runs schema migrations against an existing database using user_version as
@@ -112,4 +114,9 @@ export function runMigrations(db: Database.Database): void {
   // No migration blocks yet — all changes prior to v1 are baked into the
   // initial schema, so existing pre-production databases can be recreated.
   db.pragma('user_version = 1');
+
+  if (version < 2) {
+    db.prepare('ALTER TABLE projects ADD COLUMN is_archived INTEGER NOT NULL DEFAULT 0').run();
+    db.pragma('user_version = 2');
+  }
 }

--- a/src/main/database/index.ts
+++ b/src/main/database/index.ts
@@ -90,10 +90,8 @@ export function isDatabaseOpen(): boolean {
   return activeDb !== null;
 }
 
-// Increment this when adding a new migration block below.
-// NOTE: other concurrent PRs (#21, #22) also target DB_VERSION = 2.
-// Renumber these blocks sequentially when merging.
-const DB_VERSION = 2;
+// Increment when adding a new migration block below.
+const DB_VERSION = 1;
 
 /**
  * Runs schema migrations against an existing database using user_version as
@@ -111,12 +109,7 @@ export function runMigrations(db: Database.Database): void {
   const version = db.pragma('user_version', { simple: true }) as number;
   if (version >= DB_VERSION) return;
 
-  // No migration blocks yet — all changes prior to v1 are baked into the
-  // initial schema, so existing pre-production databases can be recreated.
-  db.pragma('user_version = 1');
-
-  if (version < 2) {
-    db.prepare('ALTER TABLE projects ADD COLUMN is_archived INTEGER NOT NULL DEFAULT 0').run();
-    db.pragma('user_version = 2');
-  }
+  // No migration blocks yet — all schema changes so far are baked into the
+  // initial schema SQL, so existing pre-production databases can be recreated.
+  db.pragma(`user_version = ${DB_VERSION}`);
 }

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -191,7 +191,8 @@ export const LOCAL_SCHEMA_SQL = `
     note             TEXT,
     is_auto_outreach INTEGER NOT NULL DEFAULT 0,
     created_at       INTEGER NOT NULL,
-    completed_at     INTEGER
+    completed_at     INTEGER,
+    last_notified_at INTEGER
   );
 
   CREATE TABLE IF NOT EXISTS contact_screenshots (

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -99,6 +99,7 @@ export const LOCAL_SCHEMA_SQL = `
     name                 TEXT    NOT NULL,
     description          TEXT,
     is_shared            INTEGER NOT NULL DEFAULT 0,
+    is_archived          INTEGER NOT NULL DEFAULT 0,
     shared_db_path       TEXT,
     shared_db_key        BLOB,
     shared_pending_writes INTEGER NOT NULL DEFAULT 0,

--- a/src/main/http-server.ts
+++ b/src/main/http-server.ts
@@ -317,6 +317,7 @@ function generateIcal(db: ReturnType<typeof getDatabase>): string {
        FROM reminders r
        JOIN contacts c ON c.id = r.contact_id
        JOIN projects p ON p.id = r.project_id
+       WHERE p.is_archived = 0
        ORDER BY r.due_date ASC`,
     )
     .all() as Array<{ id: string; due_date: number; note: string | null; is_auto_outreach: number; contact_name: string; project_name: string }>;

--- a/src/main/ipc/projects.ts
+++ b/src/main/ipc/projects.ts
@@ -324,6 +324,14 @@ export function registerProjectHandlers(): void {
     return db.prepare('SELECT * FROM projects WHERE id = ?').get(id) as Project;
   });
 
+  ipcMain.handle('projects:archive', (_, id: string): void => {
+    getDatabase().prepare('UPDATE projects SET is_archived = 1 WHERE id = ?').run(id);
+  });
+
+  ipcMain.handle('projects:unarchive', (_, id: string): void => {
+    getDatabase().prepare('UPDATE projects SET is_archived = 0 WHERE id = ?').run(id);
+  });
+
   ipcMain.handle('projects:delete', (_, id: string): void => {
     closeSharedDb(id);
     getDatabase().prepare('DELETE FROM projects WHERE id = ?').run(id);

--- a/src/main/ipc/projects.ts
+++ b/src/main/ipc/projects.ts
@@ -5,6 +5,7 @@ import { getDatabase } from '../database';
 import { createSharedDb, openSharedDb, closeSharedDb } from '../database/shared-db';
 import { encodePayload, decodePayload } from '../sync/payload';
 import { syncProject } from '../sync/engine';
+import { broadcastRemindersChanged } from './reminders';
 import type { Project, User } from '@shared/types';
 
 export function registerProjectHandlers(): void {
@@ -326,10 +327,12 @@ export function registerProjectHandlers(): void {
 
   ipcMain.handle('projects:archive', (_, id: string): void => {
     getDatabase().prepare('UPDATE projects SET is_archived = 1 WHERE id = ?').run(id);
+    broadcastRemindersChanged();
   });
 
   ipcMain.handle('projects:unarchive', (_, id: string): void => {
     getDatabase().prepare('UPDATE projects SET is_archived = 0 WHERE id = ?').run(id);
+    broadcastRemindersChanged();
   });
 
   ipcMain.handle('projects:delete', (_, id: string): void => {

--- a/src/main/ipc/reminders.ts
+++ b/src/main/ipc/reminders.ts
@@ -38,7 +38,7 @@ export function registerReminderHandlers(): void {
          FROM reminders r
          JOIN contacts c ON c.id = r.contact_id
          JOIN projects p ON p.id = r.project_id
-         WHERE r.completed_at IS NULL
+         WHERE r.completed_at IS NULL AND p.is_archived = 0
          ORDER BY r.due_date ASC`,
       )
       .all() as Reminder[];

--- a/src/main/sync/outreach-checker.ts
+++ b/src/main/sync/outreach-checker.ts
@@ -54,6 +54,7 @@ export function checkOutreachReminders(): void {
        WHERE pm.outreach_reminders_enabled = 1
          AND COALESCE(pm.outreach_interval_days, po.outreach_interval_days) IS NOT NULL
          AND pm.reporter_email = (SELECT email FROM users WHERE id = 1)
+         AND p.is_archived = 0
        GROUP BY pm.id`,
     )
     .all() as OutreachRow[];

--- a/src/main/sync/reminder-checker.ts
+++ b/src/main/sync/reminder-checker.ts
@@ -22,6 +22,7 @@ export function checkReminders(): void {
   const notificationsEnabled = userRow?.reminder_notifications_enabled !== 0;
 
   const now = Math.floor(Date.now() / 1000);
+  const oneDayAgo = now - 86400;
 
   const rows = db
     .prepare(
@@ -30,13 +31,17 @@ export function checkReminders(): void {
        JOIN contacts c ON c.id = r.contact_id
        JOIN projects p ON p.id = r.project_id
        WHERE r.due_date <= ? AND r.is_auto_outreach = 0 AND r.completed_at IS NULL
-         AND p.is_archived = 0`,
+         AND p.is_archived = 0
+         AND (r.last_notified_at IS NULL OR r.last_notified_at < ?)`,
     )
-    .all(now) as DueReminder[];
+    .all(now, oneDayAgo) as DueReminder[];
+
+  const stamp = db.prepare('UPDATE reminders SET last_notified_at = ? WHERE id = ?');
 
   for (const row of rows) {
     if (notifiedThisSession.has(row.id)) continue;
     notifiedThisSession.add(row.id);
+    stamp.run(now, row.id);
 
     if (!notificationsEnabled) continue;
 

--- a/src/main/sync/reminder-checker.ts
+++ b/src/main/sync/reminder-checker.ts
@@ -29,7 +29,8 @@ export function checkReminders(): void {
        FROM reminders r
        JOIN contacts c ON c.id = r.contact_id
        JOIN projects p ON p.id = r.project_id
-       WHERE r.due_date <= ? AND r.is_auto_outreach = 0 AND r.completed_at IS NULL`,
+       WHERE r.due_date <= ? AND r.is_auto_outreach = 0 AND r.completed_at IS NULL
+         AND p.is_archived = 0`,
     )
     .all(now) as DueReminder[];
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -90,6 +90,8 @@ const sourcererApi = {
   updateProject: (id: string, name: string, description: string | null): Promise<Project> =>
     ipcRenderer.invoke('projects:update', { id, name, description }),
   unshareProject: (id: string): Promise<Project> => ipcRenderer.invoke('projects:unshare', id),
+  archiveProject: (id: string): Promise<void> => ipcRenderer.invoke('projects:archive', id),
+  unarchiveProject: (id: string): Promise<void> => ipcRenderer.invoke('projects:unarchive', id),
   deleteProject: (id: string): Promise<void> => ipcRenderer.invoke('projects:delete', id),
 
   // Contacts

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -316,7 +316,7 @@ function RemindersSection({
 
   async function handleAdd() {
     if (!dueDate) return;
-    const ts = Math.floor(new Date(`${dueDate}T00:00:00`).getTime() / 1000);
+    const ts = Math.floor(new Date(`${dueDate}T09:00:00`).getTime() / 1000);
     const r = await window.sourcerer.createReminder({
       contactId,
       projectId,

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -316,7 +316,7 @@ function RemindersSection({
 
   async function handleAdd() {
     if (!dueDate) return;
-    const ts = Math.floor(new Date(dueDate).getTime() / 1000);
+    const ts = Math.floor(new Date(`${dueDate}T00:00:00`).getTime() / 1000);
     const r = await window.sourcerer.createReminder({
       contactId,
       projectId,

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -64,6 +64,8 @@ declare global {
       regenerateSharedProject: (projectId: string) => Promise<{ payload: string } | null>;
       renameProject: (id: string, name: string) => Promise<void>;
       updateProject: (id: string, name: string, description: string | null) => Promise<Project>;
+      archiveProject: (id: string) => Promise<void>;
+      unarchiveProject: (id: string) => Promise<void>;
       deleteProject: (id: string) => Promise<void>;
       unshareProject: (id: string) => Promise<Project>;
 

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -162,6 +162,14 @@ export default function AppShell() {
     setProjects((prev) => prev.map((p) => (p.id === id ? { ...p, name } : p)));
   }
 
+  function handleProjectArchived(id: string) {
+    setProjects((prev) => prev.map((p) => (p.id === id ? { ...p, is_archived: 1 as const } : p)));
+  }
+
+  function handleProjectUnarchived(id: string) {
+    setProjects((prev) => prev.map((p) => (p.id === id ? { ...p, is_archived: 0 as const } : p)));
+  }
+
   function handleProjectDeleted(id: string) {
     setProjects((prev) => prev.filter((p) => p.id !== id));
     setNav((current) => {
@@ -230,6 +238,8 @@ export default function AppShell() {
         onProjectCreatedShared={handleProjectCreatedShared}
         onProjectJoined={handleProjectJoined}
         onProjectRenamed={handleProjectRenamed}
+        onProjectArchived={handleProjectArchived}
+        onProjectUnarchived={handleProjectUnarchived}
         onProjectDeleted={handleProjectDeleted}
         onAddContact={() => setShowAddContact(true)}
         onImportCsv={() => setShowImportCsv(true)}

--- a/src/renderer/src/shell/Sidebar.css
+++ b/src/renderer/src/shell/Sidebar.css
@@ -300,7 +300,8 @@
   font-size: 13px;
 }
 
-.sidebar-project-delete {
+.sidebar-project-delete,
+.sidebar-project-archive {
   flex-shrink: 0;
   font-size: 16px;
   line-height: 1;
@@ -312,12 +313,49 @@
   transition: opacity 0.1s, color 0.1s;
 }
 
-.sidebar-project-btn:hover .sidebar-project-delete {
+.sidebar-project-btn:hover .sidebar-project-delete,
+.sidebar-project-btn:hover .sidebar-project-archive {
   opacity: 1;
 }
 
 .sidebar-project-delete:hover {
   color: var(--color-danger);
+}
+
+.sidebar-project-archive:hover {
+  color: var(--color-text);
+}
+
+.sidebar-project-item--archived .sidebar-project-btn {
+  opacity: 0.45;
+}
+
+.sidebar-project-item--archived .sidebar-project-btn:hover {
+  opacity: 0.75;
+}
+
+/* Show archived toggle */
+.sidebar-show-archived-btn {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--color-text-muted);
+  display: block;
+  width: 100%;
+  padding: 5px 8px;
+  border: none;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+  opacity: 0.6;
+  margin-top: 2px;
+}
+
+.sidebar-show-archived-btn:hover {
+  opacity: 1;
+  color: var(--color-text);
 }
 
 /* Rename input */

--- a/src/renderer/src/shell/Sidebar.tsx
+++ b/src/renderer/src/shell/Sidebar.tsx
@@ -189,7 +189,7 @@ export default function Sidebar({
             <button className="sidebar-header-add" onClick={() => setShowNewProject(true)} title="New project">+</button>
           </div>
 
-          {projects.filter((p) => p.is_archived === 0).length === 0 && projects.filter((p) => p.is_archived === 1).length === 0 && (
+          {projects.length === 0 && (
             <p className="sidebar-empty">No projects yet.</p>
           )}
 

--- a/src/renderer/src/shell/Sidebar.tsx
+++ b/src/renderer/src/shell/Sidebar.tsx
@@ -21,6 +21,8 @@ interface Props {
   onProjectCreatedShared: (project: Project, payload: string) => void;
   onProjectJoined: (project: Project) => void;
   onProjectRenamed: (id: string, name: string) => void;
+  onProjectArchived: (id: string) => void;
+  onProjectUnarchived: (id: string) => void;
   onProjectDeleted: (id: string) => void;
   onAddContact: () => void;
   onImportCsv: () => void;
@@ -39,12 +41,15 @@ export default function Sidebar({
   onProjectCreatedShared,
   onProjectJoined,
   onProjectRenamed,
+  onProjectArchived,
+  onProjectUnarchived,
   onProjectDeleted,
   onAddContact,
   onImportCsv,
 }: Props) {
   const [showNewProject, setShowNewProject] = useState(false);
   const [showJoinProject, setShowJoinProject] = useState(false);
+  const [showArchived, setShowArchived] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
@@ -68,6 +73,16 @@ export default function Sidebar({
   function handleRenameKey(e: KeyboardEvent<HTMLInputElement>, id: string) {
     if (e.key === 'Enter') commitRename(id);
     if (e.key === 'Escape') setRenamingId(null);
+  }
+
+  async function handleArchive(id: string) {
+    await window.sourcerer.archiveProject(id);
+    onProjectArchived(id);
+  }
+
+  async function handleUnarchive(id: string) {
+    await window.sourcerer.unarchiveProject(id);
+    onProjectUnarchived(id);
   }
 
   async function confirmDelete(id: string) {
@@ -174,13 +189,15 @@ export default function Sidebar({
             <button className="sidebar-header-add" onClick={() => setShowNewProject(true)} title="New project">+</button>
           </div>
 
-          {projects.length === 0 && (
+          {projects.filter((p) => p.is_archived === 0).length === 0 && projects.filter((p) => p.is_archived === 1).length === 0 && (
             <p className="sidebar-empty">No projects yet.</p>
           )}
 
           <ul className="sidebar-project-list">
-            {projects.map((project, idx) => (
-              <li key={project.id} className="sidebar-project-item">
+            {projects
+              .filter((p) => showArchived || p.is_archived === 0)
+              .map((project, idx) => (
+              <li key={project.id} className={`sidebar-project-item${project.is_archived === 1 ? ' sidebar-project-item--archived' : ''}`}>
                 {renamingId === project.id ? (
                   <input
                     ref={renameInputRef}
@@ -204,20 +221,37 @@ export default function Sidebar({
                   <button
                     className={`sidebar-project-btn ${isActive({ view: 'project', projectId: project.id }) ? 'active' : ''}`}
                     onClick={() => onNav({ view: 'project', projectId: project.id })}
-                    onDoubleClick={() => startRename(project)}
-                    title="Double-click to rename"
+                    onDoubleClick={() => project.is_archived === 0 && startRename(project)}
+                    title={project.is_archived === 0 ? 'Double-click to rename' : undefined}
                   >
                     <span
                       className="sidebar-project-dot"
                       style={{ background: DOT_COLORS[idx % DOT_COLORS.length] }}
                     />
                     <span className="sidebar-project-name">{project.name}</span>
-                    <span
-                      className="sidebar-project-delete"
-                      role="button"
-                      title="Delete project"
-                      onClick={(e) => { e.stopPropagation(); setDeletingId(project.id); }}
-                    >×</span>
+                    {project.is_archived === 1 ? (
+                      <span
+                        className="sidebar-project-delete"
+                        role="button"
+                        title="Unarchive project"
+                        onClick={(e) => { e.stopPropagation(); handleUnarchive(project.id); }}
+                      >↩</span>
+                    ) : (
+                      <>
+                        <span
+                          className="sidebar-project-archive"
+                          role="button"
+                          title="Archive project"
+                          onClick={(e) => { e.stopPropagation(); handleArchive(project.id); }}
+                        >⊘</span>
+                        <span
+                          className="sidebar-project-delete"
+                          role="button"
+                          title="Delete project"
+                          onClick={(e) => { e.stopPropagation(); setDeletingId(project.id); }}
+                        >×</span>
+                      </>
+                    )}
                   </button>
                   {isActive({ view: 'project', projectId: project.id }) && (
                     <button
@@ -232,6 +266,14 @@ export default function Sidebar({
               </li>
             ))}
           </ul>
+
+          {projects.some((p) => p.is_archived === 1) && (
+            <button className="sidebar-show-archived-btn" onClick={() => setShowArchived((v) => !v)}>
+              {showArchived
+                ? 'Hide archived'
+                : `Show archived (${projects.filter((p) => p.is_archived === 1).length})`}
+            </button>
+          )}
 
           <button className="sidebar-join-project" onClick={() => setShowJoinProject(true)}>
             + Join shared project

--- a/src/renderer/src/views/RemindersView.tsx
+++ b/src/renderer/src/views/RemindersView.tsx
@@ -98,6 +98,7 @@ export default function RemindersView({ onCountChange, user }: Props) {
   useEffect(() => {
     refresh();
     window.sourcerer.getCalendarUrl().then(setCalendarUrl);
+    return window.sourcerer.onRemindersChanged(refresh);
   }, [refresh]);
 
   async function handleDelete(id: string) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -24,6 +24,7 @@ export interface Project {
   name: string;
   description: string | null;
   is_shared: 0 | 1;
+  is_archived: 0 | 1;
   shared_db_path: string | null;
   shared_pending_writes: 0 | 1;
   created_at: number;

--- a/src/test/outreach-checker.test.ts
+++ b/src/test/outreach-checker.test.ts
@@ -279,3 +279,21 @@ describe('checkOutreachReminders — disabled reminders', () => {
     expect(broadcast).not.toHaveBeenCalled();
   });
 });
+
+describe('checkOutreachReminders — archived projects', () => {
+  it('skips memberships belonging to an archived project', () => {
+    insertUser();
+    const projId = insertProject(testDb, 'Archived Project');
+    testDb.prepare('UPDATE projects SET is_archived = 1 WHERE id = ?').run(projId);
+    const contactId = insertContact(testDb, 'Test Contact');
+    insertMembership(contactId, projId, 7);
+
+    checkOutreachReminders();
+
+    const count = (
+      testDb.prepare('SELECT COUNT(*) AS n FROM reminders').get() as { n: number }
+    ).n;
+    expect(count).toBe(0);
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/reminder-checker.test.ts
+++ b/src/test/reminder-checker.test.ts
@@ -136,7 +136,7 @@ describe('checkReminders', () => {
     expect(MockNotification).toHaveBeenCalledOnce();
   });
 
-  it('fires again after clearReminderNotificationCache', () => {
+  it('does not re-fire within 24h even after clearReminderNotificationCache', () => {
     insertUser();
     const cid = insertContact(testDb, 'Grace Kim');
     const pid = insertProject(testDb, 'Eta');
@@ -146,7 +146,20 @@ describe('checkReminders', () => {
     clearReminderNotificationCache();
     checkReminders();
 
-    expect(MockNotification).toHaveBeenCalledTimes(2);
+    expect(MockNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fires after 24h have elapsed since last notification', () => {
+    insertUser();
+    const cid = insertContact(testDb, 'Grace Kim');
+    const pid = insertProject(testDb, 'Eta');
+    const reminderId = insertReminder(cid, pid);
+    const twoDaysAgo = Math.floor(Date.now() / 1000) - 2 * 86400;
+    testDb.prepare('UPDATE reminders SET last_notified_at = ? WHERE id = ?').run(twoDaysAgo, reminderId);
+
+    checkReminders();
+
+    expect(MockNotification).toHaveBeenCalledTimes(1);
   });
 
   it('includes the project name in the notification body when no note is set', () => {

--- a/src/test/reminder-checker.test.ts
+++ b/src/test/reminder-checker.test.ts
@@ -187,4 +187,16 @@ describe('checkReminders', () => {
       expect.objectContaining({ title: expect.stringContaining('James Clarke') }),
     );
   });
+
+  it('skips reminders belonging to an archived project', () => {
+    insertUser();
+    const cid = insertContact(testDb, 'Lambda Contact');
+    const pid = insertProject(testDb, 'Lambda');
+    testDb.prepare('UPDATE projects SET is_archived = 1 WHERE id = ?').run(pid);
+    insertReminder(cid, pid);
+
+    checkReminders();
+
+    expect(MockNotification).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `is_archived INTEGER NOT NULL DEFAULT 0` to the `projects` table (baked into base schema — this is pre-production, no migration needed)
- New `projects:archive` / `projects:unarchive` IPC handlers (+ preload + `env.d.ts` types)
- Sidebar hides archived projects by default. When archived projects exist, a **"Show archived (N)"** toggle appears at the bottom of the project list. Archived projects are shown at reduced opacity (0.45, 0.75 on hover)
- Each active project gains an **archive button (⊘)** on hover (next to the existing delete ×); archived projects show an **unarchive button (↩)** in its place
- Reminder checker and outreach checker both exclude archived projects via `AND p.is_archived = 0`
- Reminders view and calendar ICS feed exclude reminders from archived projects

**Also included (discovered and fixed during review):**
- `last_notified_at` column on `reminders` — gates re-notification to once per 24h so overdue reminders don't fire on every unlock
- `onRemindersChanged` IPC subscription wired into `RemindersView` so the list and sidebar counter update reactively when a project is archived/unarchived
- Due-date parsing in `ProjectTab` changed from `new Date("YYYY-MM-DD")` (UTC midnight) to `new Date("YYYY-MM-DDT09:00:00")` (9am local time) so reminder notifications fire at a sensible hour

## Test plan

- [x] Archive a project — it disappears from sidebar; "Show archived (1)" appears
- [x] Click "Show archived" — archived project reappears at reduced opacity with ↩ button
- [x] Click ↩ — project unarchives and returns to full opacity in the active list
- [x] Delete an archived project — works normally
- [x] Overdue outreach / reminders for archived projects no longer fire
- [x] Archiving/unarchiving a project reactively updates RemindersView and the sidebar counter
- [x] Overdue reminders do not re-notify within 24h of the last notification

Closes #19