### PR TITLE
feat: scheduled automatic backups (#21)

### DIFF
--- a/src/main/database/index.ts
+++ b/src/main/database/index.ts
@@ -39,7 +39,7 @@ export function initDatabase(dbPath: string, keyHex: string): Database.Database 
   const db = openRaw(dbPath, keyHex);
   db.exec(LOCAL_SCHEMA_SQL);
   seedDefaults(db);
-  // Schema is already current — stamp version so migrations are skipped on next unlock.
+  // Stamp version so migrations are skipped on subsequent unlocks.
   db.pragma(`user_version = ${DB_VERSION}`);
   activeDb = db;
   activeKeyHex = keyHex;
@@ -101,10 +101,8 @@ export function isDatabaseOpen(): boolean {
   return activeDb !== null;
 }
 
-// Increment this when adding a new migration block below.
-// NOTE: other concurrent PRs (#19, #22) also target DB_VERSION = 2.
-// Renumber these blocks sequentially when merging.
-const DB_VERSION = 2;
+// Increment when adding a new migration block below.
+const DB_VERSION = 1;
 
 /**
  * Runs schema migrations against an existing database using user_version as
@@ -117,19 +115,12 @@ const DB_VERSION = 2;
  *   2. Add an `if (version < N) { ... db.pragma('user_version = N'); }` block below.
  *   3. Update schema.ts so brand-new databases already include the change.
  */
-/** Exported for test instrumentation only; callers should use unlockDatabase. */
-export function runMigrations(db: Database.Database): void {
+function runMigrations(db: Database.Database): void {
   const version = db.pragma('user_version', { simple: true }) as number;
   if (version >= DB_VERSION) return;
 
-  // No migration blocks yet — all changes prior to v1 are baked into the
-  // initial schema, so existing pre-production databases can be recreated.
-  db.pragma('user_version = 1');
-
-  if (version < 2) {
-    db.prepare("ALTER TABLE users ADD COLUMN auto_backup_enabled INTEGER NOT NULL DEFAULT 0").run();
-    db.prepare("ALTER TABLE users ADD COLUMN auto_backup_dest_path TEXT").run();
-    db.prepare("ALTER TABLE users ADD COLUMN auto_backup_max_count INTEGER NOT NULL DEFAULT 10").run();
-    db.pragma('user_version = 2');
-  }
+  // No migration blocks yet — all schema changes so far are baked into the
+  // initial schema SQL, so existing pre-production databases can be recreated.
+  db.pragma(`user_version = ${DB_VERSION}`);
 }
+

--- a/src/main/database/index.ts
+++ b/src/main/database/index.ts
@@ -6,6 +6,7 @@ import { seedDevData } from './dev-seeds';
 
 let activeDb: Database.Database | null = null;
 let activeKeyHex: string | null = null;
+let activePassword: string | null = null;
 
 function openRaw(dbPath: string, keyHex: string): Database.Database {
   const db = new Database(dbPath);
@@ -78,11 +79,21 @@ export function updateActiveKeyHex(newKeyHex: string): void {
   activeKeyHex = newKeyHex;
 }
 
+export function getPassword(): string {
+  if (!activePassword) throw new Error('Database is not open.');
+  return activePassword;
+}
+
+export function setActivePassword(password: string): void {
+  activePassword = password;
+}
+
 export function closeDatabase(): void {
   if (activeDb) {
     activeDb.close();
     activeDb = null;
     activeKeyHex = null;
+    activePassword = null;
   }
 }
 
@@ -91,7 +102,9 @@ export function isDatabaseOpen(): boolean {
 }
 
 // Increment this when adding a new migration block below.
-const DB_VERSION = 1;
+// NOTE: other concurrent PRs (#19, #22) also target DB_VERSION = 2.
+// Renumber these blocks sequentially when merging.
+const DB_VERSION = 2;
 
 /**
  * Runs schema migrations against an existing database using user_version as
@@ -112,4 +125,11 @@ export function runMigrations(db: Database.Database): void {
   // No migration blocks yet — all changes prior to v1 are baked into the
   // initial schema, so existing pre-production databases can be recreated.
   db.pragma('user_version = 1');
+
+  if (version < 2) {
+    db.prepare("ALTER TABLE users ADD COLUMN auto_backup_enabled INTEGER NOT NULL DEFAULT 0").run();
+    db.prepare("ALTER TABLE users ADD COLUMN auto_backup_dest_path TEXT").run();
+    db.prepare("ALTER TABLE users ADD COLUMN auto_backup_max_count INTEGER NOT NULL DEFAULT 10").run();
+    db.pragma('user_version = 2');
+  }
 }

--- a/src/main/database/index.ts
+++ b/src/main/database/index.ts
@@ -115,7 +115,8 @@ const DB_VERSION = 1;
  *   2. Add an `if (version < N) { ... db.pragma('user_version = N'); }` block below.
  *   3. Update schema.ts so brand-new databases already include the change.
  */
-function runMigrations(db: Database.Database): void {
+/** Exported for test instrumentation only; callers should use unlockDatabase. */
+export function runMigrations(db: Database.Database): void {
   const version = db.pragma('user_version', { simple: true }) as number;
   if (version >= DB_VERSION) return;
 

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -19,7 +19,10 @@ export const LOCAL_SCHEMA_SQL = `
     reminder_notifications_enabled INTEGER NOT NULL DEFAULT 1,
     rss_poll_interval_hours        INTEGER NOT NULL DEFAULT 6,
     wayback_enabled                INTEGER NOT NULL DEFAULT 1,
-    last_rss_fetched_at            INTEGER
+    last_rss_fetched_at            INTEGER,
+    auto_backup_enabled            INTEGER NOT NULL DEFAULT 0,
+    auto_backup_dest_path          TEXT,
+    auto_backup_max_count          INTEGER NOT NULL DEFAULT 10
   );
 
   CREATE TABLE IF NOT EXISTS contacts (

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,11 +16,12 @@ import { registerAlertHandlers } from './ipc/alerts';
 import { registerReminderHandlers } from './ipc/reminders';
 import { registerImportHandlers } from './ipc/import';
 import { registerBackupHandlers } from './ipc/backup';
+import { registerAutoBackupHandlers, runAutoBackup, getLastAutoBackupTime } from './ipc/auto-backup';
 import { registerScreenshotHandlers } from './ipc/screenshots';
 import { registerSearchHandlers } from './ipc/search';
 import { registerUpdaterHandlers, triggerUpdateCheck } from './ipc/updater';
 import { autoLock } from './auto-lock';
-import { closeDatabase } from './database';
+import { closeDatabase, getDatabase, isDatabaseOpen } from './database';
 import { closeAllSharedDbs } from './database/shared-db';
 import { startHttpServer } from './http-server';
 import { stopPoller } from './sync/poller';
@@ -194,6 +195,7 @@ app.whenReady().then(() => {
   registerReminderHandlers();
   registerImportHandlers();
   registerBackupHandlers();
+  registerAutoBackupHandlers();
   registerScreenshotHandlers();
   registerSearchHandlers();
   registerUpdaterHandlers();
@@ -205,6 +207,11 @@ app.whenReady().then(() => {
   });
 });
 
+// Auto-backup on clean quit
+app.on('before-quit', () => {
+  runAutoBackup().catch(() => {});
+});
+
 app.on('window-all-closed', () => {
   stopPoller();
   closeAllSharedDbs();
@@ -212,4 +219,32 @@ app.on('window-all-closed', () => {
   autoLock.stop();
   if (process.platform !== 'darwin') app.quit();
 });
+
+// Daily auto-backup timer: check every hour if 24h have passed since the last backup
+let autoBackupInterval: ReturnType<typeof setInterval> | null = null;
+
+export function startAutoBackupTimer(): void {
+  if (autoBackupInterval) return;
+  const ONE_HOUR = 60 * 60 * 1000;
+  const ONE_DAY = 24 * ONE_HOUR;
+  autoBackupInterval = setInterval(async () => {
+    if (!isDatabaseOpen()) return;
+    const db = getDatabase();
+    const user = db
+      .prepare('SELECT auto_backup_enabled, auto_backup_dest_path FROM users WHERE id = 1')
+      .get() as { auto_backup_enabled: number; auto_backup_dest_path: string | null } | undefined;
+    if (!user?.auto_backup_enabled || !user.auto_backup_dest_path) return;
+    const lastMs = await getLastAutoBackupTime(user.auto_backup_dest_path);
+    if (lastMs === null || Date.now() - lastMs >= ONE_DAY) {
+      runAutoBackup().catch(() => {});
+    }
+  }, ONE_HOUR);
+}
+
+export function stopAutoBackupTimer(): void {
+  if (autoBackupInterval) {
+    clearInterval(autoBackupInterval);
+    autoBackupInterval = null;
+  }
+}
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -207,9 +207,12 @@ app.whenReady().then(() => {
   });
 });
 
-// Auto-backup on clean quit
-app.on('before-quit', () => {
-  runAutoBackup().catch(() => {});
+// Auto-backup on clean quit — preventDefault so the app waits for the async
+// backup to finish before actually exiting. app.exit() bypasses before-quit
+// so it won't recurse.
+app.on('before-quit', (event) => {
+  event.preventDefault();
+  runAutoBackup().catch(() => {}).finally(() => app.exit(0));
 });
 
 app.on('window-all-closed', () => {

--- a/src/main/ipc/auto-backup.ts
+++ b/src/main/ipc/auto-backup.ts
@@ -1,0 +1,104 @@
+import { ipcMain } from 'electron';
+import fs from 'fs/promises';
+import path from 'path';
+import zlib from 'zlib';
+import crypto from 'crypto';
+import { promisify } from 'util';
+import { getPaths, deriveKey } from '../utils';
+import { getDatabase, isDatabaseOpen, getPassword } from '../database';
+
+const gzip = promisify(zlib.gzip);
+
+const BACKUP_PREFIX = 'sourcerer-auto-backup-';
+const BACKUP_EXT = '.sourcerer-backup';
+
+function timestampedName(): string {
+  return `${BACKUP_PREFIX}${new Date().toISOString().replace(/:/g, '-')}${BACKUP_EXT}`;
+}
+
+export async function runAutoBackup(): Promise<{ success: boolean; error?: string }> {
+  if (!isDatabaseOpen()) return { success: false, error: 'Database not open.' };
+
+  const db = getDatabase();
+  const user = db
+    .prepare('SELECT auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count FROM users WHERE id = 1')
+    .get() as { auto_backup_enabled: number; auto_backup_dest_path: string | null; auto_backup_max_count: number } | undefined;
+
+  if (!user?.auto_backup_enabled || !user.auto_backup_dest_path) {
+    return { success: false };
+  }
+
+  const destPath = user.auto_backup_dest_path;
+  const maxCount = user.auto_backup_max_count ?? 10;
+
+  try {
+    // Ensure the destination folder exists (user may have moved it)
+    await fs.mkdir(destPath, { recursive: true });
+
+    const { dbPath, saltPath } = getPaths();
+    const password = getPassword();
+    const dbSalt = await fs.readFile(saltPath);
+    const dbBuf = await fs.readFile(dbPath);
+
+    const innerJson = JSON.stringify({
+      db: dbBuf.toString('base64'),
+      salt: dbSalt.toString('base64'),
+    });
+    const compressed = await gzip(Buffer.from(innerJson, 'utf-8'));
+
+    const backupSalt = crypto.randomBytes(32);
+    const backupKeyHex = await deriveKey(password, backupSalt);
+    const backupKey = Buffer.from(backupKeyHex, 'hex');
+
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv('aes-256-gcm', backupKey, iv);
+    const ciphertext = Buffer.concat([cipher.update(compressed), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    const bundle = JSON.stringify({
+      version: 2,
+      backup_salt: backupSalt.toString('base64'),
+      iv: iv.toString('base64'),
+      auth_tag: authTag.toString('base64'),
+      ciphertext: ciphertext.toString('base64'),
+    });
+
+    const outPath = path.join(destPath, timestampedName());
+    await fs.writeFile(outPath, Buffer.from(bundle, 'utf-8'), { mode: 0o600 });
+
+    // Prune old backups beyond maxCount
+    const allFiles = await fs.readdir(destPath);
+    const backupFiles = allFiles
+      .filter((f) => f.startsWith(BACKUP_PREFIX) && f.endsWith(BACKUP_EXT))
+      .sort()
+      .reverse();
+    for (const old of backupFiles.slice(maxCount)) {
+      await fs.unlink(path.join(destPath, old)).catch(() => {});
+    }
+
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: String(err) };
+  }
+}
+
+export async function getLastAutoBackupTime(destPath: string): Promise<number | null> {
+  try {
+    const files = await fs.readdir(destPath);
+    const backups = files
+      .filter((f) => f.startsWith(BACKUP_PREFIX) && f.endsWith(BACKUP_EXT))
+      .sort()
+      .reverse();
+    if (backups.length === 0) return null;
+    const stat = await fs.stat(path.join(destPath, backups[0]));
+    return stat.mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+export function registerAutoBackupHandlers(): void {
+  ipcMain.handle('backup:run-auto', async (): Promise<{ success: boolean; error?: string }> => {
+    return runAutoBackup();
+  });
+}

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -1,4 +1,4 @@
-import { ipcMain, app } from 'electron';
+import { ipcMain, app, dialog } from 'electron';
 import { promises as fs } from 'fs';
 import path from 'path';
 import crypto from 'crypto';
@@ -238,5 +238,40 @@ export function registerSettingsHandlers(): void {
     await fs.rm(screenshotsPath, { recursive: true, force: true }).catch(() => {});
 
     app.quit();
+  });
+
+  ipcMain.handle('settings:get-auto-backup', (): { enabled: boolean; destPath: string | null; maxCount: number } => {
+    const row = getDatabase()
+      .prepare('SELECT auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count FROM users WHERE id = 1')
+      .get() as { auto_backup_enabled: number; auto_backup_dest_path: string | null; auto_backup_max_count: number } | undefined;
+    return {
+      enabled: (row?.auto_backup_enabled ?? 0) !== 0,
+      destPath: row?.auto_backup_dest_path ?? null,
+      maxCount: row?.auto_backup_max_count ?? 10,
+    };
+  });
+
+  ipcMain.handle(
+    'settings:set-auto-backup',
+    (_, data: { enabled?: boolean; destPath?: string | null; maxCount?: number }): void => {
+      const db = getDatabase();
+      if (data.enabled !== undefined) {
+        db.prepare('UPDATE users SET auto_backup_enabled = ? WHERE id = 1').run(data.enabled ? 1 : 0);
+      }
+      if (data.destPath !== undefined) {
+        db.prepare('UPDATE users SET auto_backup_dest_path = ? WHERE id = 1').run(data.destPath ?? null);
+      }
+      if (data.maxCount !== undefined) {
+        db.prepare('UPDATE users SET auto_backup_max_count = ? WHERE id = 1').run(Math.max(1, data.maxCount));
+      }
+    },
+  );
+
+  ipcMain.handle('settings:choose-backup-folder', async (): Promise<string | null> => {
+    const { canceled, filePaths } = await dialog.showOpenDialog({
+      title: 'Choose backup folder',
+      properties: ['openDirectory', 'createDirectory'],
+    });
+    return canceled || filePaths.length === 0 ? null : filePaths[0];
   });
 }

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import crypto from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
 import Database from 'better-sqlite3-multiple-ciphers';
-import { getDatabase, closeDatabase, updateActiveKeyHex } from '../database';
+import { getDatabase, closeDatabase, updateActiveKeyHex, setActivePassword } from '../database';
 import { getPaths, deriveKey } from '../utils';
 import { autoLock } from '../auto-lock';
 import { setRssPollIntervalHours } from '../sync/poller';
@@ -172,8 +172,9 @@ export function registerSettingsHandlers(): void {
         db.pragma(`rekey="x'${newKeyHex}'"`);
         db.pragma('journal_mode = WAL');
 
-        // Update the in-memory key so screenshot encryption keeps working
+        // Update the in-memory key and password so screenshot encryption and auto-backups keep working
         updateActiveKeyHex(newKeyHex);
+        setActivePassword(newPassword);
 
         // Atomic rename completes the operation; if this fails the .tmp file
         // serves as a recovery signal on the next unlock attempt.

--- a/src/main/ipc/unlock.ts
+++ b/src/main/ipc/unlock.ts
@@ -1,9 +1,10 @@
 import { ipcMain, BrowserWindow } from 'electron';
 import { promises as fs } from 'fs';
 import { getPaths, deriveKey } from '../utils';
-import { unlockDatabase, maybeRunDevSeeds } from '../database';
+import { unlockDatabase, maybeRunDevSeeds, setActivePassword } from '../database';
 import { autoLock } from '../auto-lock';
 import { startPoller } from '../sync/poller';
+import { startAutoBackupTimer } from '../index';
 import { checkOutreachReminders, clearOutreachNotificationCache } from '../sync/outreach-checker';
 import { checkReminders, clearReminderNotificationCache } from '../sync/reminder-checker';
 import type { UnlockResult } from '@shared/types';
@@ -46,6 +47,7 @@ export function registerUnlockHandlers(): void {
         await fs.rename(saltTmpPath, saltPath);
       }
 
+      setActivePassword(password);
       maybeRunDevSeeds(db);
 
       const savedUser = db
@@ -68,6 +70,7 @@ export function registerUnlockHandlers(): void {
       }
 
       startPoller();
+      startAutoBackupTimer();
       clearOutreachNotificationCache();
       clearReminderNotificationCache();
       checkOutreachReminders();

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -189,6 +189,14 @@ const sourcererApi = {
     ipcRenderer.invoke('backup:export', { password }),
   restoreBackup: (password: string): Promise<{ success: boolean; canceled?: boolean; error?: string }> =>
     ipcRenderer.invoke('backup:restore', { password }),
+  runAutoBackup: (): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('backup:run-auto'),
+  getAutoBackupSettings: (): Promise<{ enabled: boolean; destPath: string | null; maxCount: number }> =>
+    ipcRenderer.invoke('settings:get-auto-backup'),
+  setAutoBackupSettings: (data: { enabled?: boolean; destPath?: string | null; maxCount?: number }): Promise<void> =>
+    ipcRenderer.invoke('settings:set-auto-backup', data),
+  chooseBackupFolder: (): Promise<string | null> =>
+    ipcRenderer.invoke('settings:choose-backup-folder'),
   searchGlobal: (query: string): Promise<import('@shared/types').SearchResult[]> =>
     ipcRenderer.invoke('search:global', query),
   assignScreenshot: (data: { tempId: string; contactId: string }): Promise<{ success: boolean; error?: string }> =>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -178,6 +178,10 @@ declare global {
       // Backup
       exportBackup: (password: string) => Promise<{ success: boolean; error?: string }>;
       restoreBackup: (password: string) => Promise<{ success: boolean; canceled?: boolean; error?: string }>;
+      runAutoBackup: () => Promise<{ success: boolean; error?: string }>;
+      getAutoBackupSettings: () => Promise<{ enabled: boolean; destPath: string | null; maxCount: number }>;
+      setAutoBackupSettings: (data: { enabled?: boolean; destPath?: string | null; maxCount?: number }) => Promise<void>;
+      chooseBackupFolder: () => Promise<string | null>;
 
       // Search
       searchGlobal: (query: string) => Promise<SearchResult[]>;

--- a/src/renderer/src/global.css
+++ b/src/renderer/src/global.css
@@ -257,6 +257,11 @@ code {
   margin-bottom: 0;
 }
 
+.sv-toggle--disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .sv-toggle-row--has-hint {
   align-items: flex-start;
 }

--- a/src/renderer/src/views/AllContacts.css
+++ b/src/renderer/src/views/AllContacts.css
@@ -335,10 +335,12 @@
 .bulk-delete-confirm-text {
   margin-left: auto;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 10px;
   color: var(--color-danger);
   font-weight: 500;
   letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-right: 10px;
 }
 
 .bulk-delete-confirm-btn {
@@ -353,6 +355,7 @@
   text-transform: uppercase;
   color: #fff;
   cursor: pointer;
+  margin-right: 10px;
 }
 
 .bulk-delete-confirm-btn:hover:not(:disabled) {

--- a/src/renderer/src/views/SettingsView.css
+++ b/src/renderer/src/views/SettingsView.css
@@ -541,18 +541,11 @@
 
 .sv-path-code {
   font-size: 13px;
-  /* font-size: 12px;
-  font-family: var(--font-mono);
-  background: var(--color-bg-muted, #f3f4f6);
-  border: 1px solid var(--color-border);
-  padding: 2px 6px;
-  color: var(--color-text);
-  word-break: break-all;
-  margin-right: 4px; */
 }
 
 .sv-field--inline-row {
   flex-direction: column;
+  margin-top: 2px;
 }
 
 .sv-inline-actions {
@@ -564,5 +557,4 @@
 
 .sv-input--short {
   width: 72px;
-}
 }

--- a/src/renderer/src/views/SettingsView.css
+++ b/src/renderer/src/views/SettingsView.css
@@ -536,17 +536,19 @@
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+  margin-bottom: 10px;
 }
 
 .sv-path-code {
-  font-size: 12px;
+  font-size: 13px;
+  /* font-size: 12px;
   font-family: var(--font-mono);
   background: var(--color-bg-muted, #f3f4f6);
   border: 1px solid var(--color-border);
   padding: 2px 6px;
   color: var(--color-text);
   word-break: break-all;
-  margin-right: 4px;
+  margin-right: 4px; */
 }
 
 .sv-field--inline-row {

--- a/src/renderer/src/views/SettingsView.css
+++ b/src/renderer/src/views/SettingsView.css
@@ -530,3 +530,37 @@
 .sv-credit a:hover {
   color: var(--color-text);
 }
+
+.sv-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.sv-path-code {
+  font-size: 12px;
+  font-family: var(--font-mono);
+  background: var(--color-bg-muted, #f3f4f6);
+  border: 1px solid var(--color-border);
+  padding: 2px 6px;
+  color: var(--color-text);
+  word-break: break-all;
+  margin-right: 4px;
+}
+
+.sv-field--inline-row {
+  flex-direction: column;
+}
+
+.sv-inline-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.sv-input--short {
+  width: 72px;
+}
+}

--- a/src/renderer/src/views/SettingsView.css
+++ b/src/renderer/src/views/SettingsView.css
@@ -467,6 +467,7 @@
   font-size: 12px;
   color: var(--color-text-muted);
   margin-top: 2px;
+  margin-bottom: 5px;
 }
 
 .sv-wipe-confirm {
@@ -545,7 +546,6 @@
 
 .sv-field--inline-row {
   flex-direction: column;
-  margin-top: 2px;
 }
 
 .sv-inline-actions {

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -691,16 +691,16 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
                 Restoring a backup will permanently overwrite your current database and cannot be undone.
                 Enter the master password used when the backup was created, then choose the file.
               </p>
-              <input
-                className="sv-input"
-                type="password"
-                placeholder="Backup password"
-                value={restorePassword}
-                onChange={(e) => { setRestorePassword(e.target.value); setRestoreError(null); }}
-                autoComplete="current-password"
-                disabled={restoringBackup}
-              />
               <div className="sv-wipe-row">
+                <input
+                  className="sv-input"
+                  type="password"
+                  placeholder="Backup password"
+                  value={restorePassword}
+                  onChange={(e) => { setRestorePassword(e.target.value); setRestoreError(null); }}
+                  autoComplete="current-password"
+                  disabled={restoringBackup}
+                />
                 <button
                   className="sv-wipe-confirm-btn"
                   onClick={handleRestoreBackup}

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -19,14 +19,15 @@ const TIMEOUT_OPTIONS = [
   { label: 'Never', seconds: 0 },
 ];
 
-function Toggle({ checked, onChange, label, hint }: { checked: boolean; onChange: (v: boolean) => void; label: string; hint?: string }) {
+function Toggle({ checked, onChange, label, hint, disabled }: { checked: boolean; onChange: (v: boolean) => void; label: string; hint?: string; disabled?: boolean }) {
   return (
     <div className={`sv-toggle-row${hint ? ' sv-toggle-row--has-hint' : ''}`}>
       <button
         type="button"
-        className={`sv-toggle${checked ? ' sv-toggle--on' : ''}`}
-        onClick={() => onChange(!checked)}
+        className={`sv-toggle${checked ? ' sv-toggle--on' : ''}${disabled ? ' sv-toggle--disabled' : ''}`}
+        onClick={() => !disabled && onChange(!checked)}
         aria-pressed={checked}
+        disabled={disabled}
       >
         <span className="sv-toggle-knob" />
         <span className="sv-toggle-label">{checked ? 'ON' : 'OFF'}</span>
@@ -730,12 +731,6 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
               and can be restored using your master password.
             </div>
           </div>
-          <Toggle
-            checked={autoBackupEnabled}
-            onChange={handleAutoBackupToggle}
-            label="Enable automatic backups"
-            hint={autoBackupDestPath ? undefined : 'Choose a backup folder first.'}
-          />
           <div className="sv-field">
             <label className="sv-label">Backup folder</label>
             <div className="sv-row">
@@ -750,6 +745,13 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
               </button>
             </div>
           </div>
+          <Toggle
+            checked={autoBackupEnabled}
+            onChange={handleAutoBackupToggle}
+            label="Enable automatic backups"
+            hint={autoBackupDestPath ? undefined : 'Choose a backup folder first.'}
+            disabled={!autoBackupDestPath}
+          />
           <div className="sv-field sv-field--inline-row">
             <label className="sv-label">Max backups to keep</label>
             <div className="sv-inline-actions">

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -79,6 +79,13 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
   const [panicWiping, setPanicWiping] = useState(false);
   const [screenshotFolderBytes, setScreenshotFolderBytes] = useState<number>(0);
 
+  const [autoBackupEnabled, setAutoBackupEnabled] = useState(false);
+  const [autoBackupDestPath, setAutoBackupDestPath] = useState<string | null>(null);
+  const [autoBackupMaxCount, setAutoBackupMaxCount] = useState(10);
+  const [autoBackupMaxCountInput, setAutoBackupMaxCountInput] = useState('10');
+  const [autoBackupRunning, setAutoBackupRunning] = useState(false);
+  const [autoBackupResult, setAutoBackupResult] = useState<string | null>(null);
+
   const countryOptions = useMemo(() => {
     const names = new Intl.DisplayNames([navigator.language], { type: 'region' });
     return getCountries()
@@ -109,6 +116,12 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
     window.sourcerer.getIdleTimeout().then(setIdleTimeout);
     window.sourcerer.getCalendarUrl().then(setCalendarUrl);
     window.sourcerer.getScreenshotFolderSize().then(setScreenshotFolderBytes);
+    window.sourcerer.getAutoBackupSettings().then(({ enabled, destPath, maxCount }) => {
+      setAutoBackupEnabled(enabled);
+      setAutoBackupDestPath(destPath);
+      setAutoBackupMaxCount(maxCount);
+      setAutoBackupMaxCountInput(String(maxCount));
+    });
   }, [user?.id]);
 
   async function handleProfileSave() {
@@ -256,6 +269,37 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
     setPhoneCountry(country);
     const updated = await window.sourcerer.setPhoneCountry(country);
     onUserUpdated(updated);
+  }
+
+  async function handleChooseBackupFolder() {
+    const chosen = await window.sourcerer.chooseBackupFolder();
+    if (!chosen) return;
+    setAutoBackupDestPath(chosen);
+    await window.sourcerer.setAutoBackupSettings({ destPath: chosen });
+  }
+
+  async function handleAutoBackupToggle(enabled: boolean) {
+    setAutoBackupEnabled(enabled);
+    await window.sourcerer.setAutoBackupSettings({ enabled });
+  }
+
+  async function handleAutoBackupMaxCountBlur() {
+    const n = parseInt(autoBackupMaxCountInput, 10);
+    if (!isNaN(n) && n >= 1) {
+      setAutoBackupMaxCount(n);
+      await window.sourcerer.setAutoBackupSettings({ maxCount: n });
+    } else {
+      setAutoBackupMaxCountInput(String(autoBackupMaxCount));
+    }
+  }
+
+  async function handleRunAutoBackupNow() {
+    setAutoBackupRunning(true);
+    setAutoBackupResult(null);
+    const result = await window.sourcerer.runAutoBackup();
+    setAutoBackupRunning(false);
+    setAutoBackupResult(result.success ? 'Backup saved.' : (result.error ?? 'Backup failed.'));
+    setTimeout(() => setAutoBackupResult(null), 4000);
   }
 
   const profileDirty =
@@ -674,6 +718,59 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
               {restoreError && <div className="sv-error-inline">{restoreError}</div>}
             </div>
           )}
+        </div>
+
+        {/* Automatic backups */}
+        <div className="sv-section">
+          <div className="sv-section-title">Automatic backups</div>
+          <div className="sv-field">
+            <div className="sv-hint">
+              Choose a folder and Sourcerer will silently save an encrypted backup on every clean quit
+              and once per day while the app is running. Backups use the same format as manual exports
+              and can be restored using your master password.
+            </div>
+          </div>
+          <div className="sv-field">
+            <label className="sv-label">Backup folder</label>
+            <div className="sv-row">
+              <span className="sv-hint sv-hint--path">
+                {autoBackupDestPath ?? 'No folder selected'}
+              </span>
+              <button className="sv-save-btn" onClick={handleChooseBackupFolder}>
+                Choose folder…
+              </button>
+            </div>
+          </div>
+          <Toggle
+            checked={autoBackupEnabled}
+            onChange={handleAutoBackupToggle}
+            label="Enable automatic backups"
+            hint={autoBackupDestPath ? undefined : 'Choose a backup folder first.'}
+          />
+          <div className="sv-field">
+            <label className="sv-label">Max backups to keep</label>
+            <input
+              className="sv-input sv-input--short"
+              type="number"
+              min={1}
+              value={autoBackupMaxCountInput}
+              onChange={(e) => setAutoBackupMaxCountInput(e.target.value)}
+              onBlur={handleAutoBackupMaxCountBlur}
+              disabled={!autoBackupDestPath}
+            />
+          </div>
+          <div className="sv-field">
+            <button
+              className="sv-save-btn"
+              onClick={handleRunAutoBackupNow}
+              disabled={autoBackupRunning || !autoBackupDestPath || !autoBackupEnabled}
+            >
+              {autoBackupRunning ? 'Backing up…' : 'Back up now'}
+            </button>
+            {autoBackupResult && (
+              <span className="sv-hint sv-hint--inline">{autoBackupResult}</span>
+            )}
+          </div>
         </div>
 
         {/* Danger Zone */}

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -730,23 +730,27 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
               and can be restored using your master password.
             </div>
           </div>
-          <div className="sv-field">
-            <label className="sv-label">Backup folder</label>
-            <div className="sv-row">
-              <code className="sv-path-code">
-                {autoBackupDestPath ?? 'No folder selected'}
-              </code>
-              <button className="sv-save-btn" onClick={handleChooseBackupFolder}>
-                Choose folder…
-              </button>
-            </div>
-          </div>
           <Toggle
             checked={autoBackupEnabled}
             onChange={handleAutoBackupToggle}
             label="Enable automatic backups"
             hint={autoBackupDestPath ? undefined : 'Choose a backup folder first.'}
           />
+          <div className="sv-field">
+            <label className="sv-label">Backup folder</label>
+            <div className="sv-row">
+              <code className="sv-path-code">
+                {autoBackupDestPath ?? 'No folder selected'}
+              </code>
+              <button
+                className="sv-save-btn"
+                onClick={handleChooseBackupFolder}
+                disabled={autoBackupRunning || !autoBackupDestPath || !autoBackupEnabled}
+              >
+                Choose folder…
+              </button>
+            </div>
+          </div>
           <div className="sv-field sv-field--inline-row">
             <label className="sv-label">Max backups to keep</label>
             <div className="sv-inline-actions">

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -745,7 +745,6 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
               <button
                 className="sv-save-btn"
                 onClick={handleChooseBackupFolder}
-                disabled={autoBackupRunning || !autoBackupDestPath || !autoBackupEnabled}
               >
                 Choose folder…
               </button>
@@ -761,7 +760,7 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
                 value={autoBackupMaxCountInput}
                 onChange={(e) => setAutoBackupMaxCountInput(e.target.value)}
                 onBlur={handleAutoBackupMaxCountBlur}
-                disabled={!autoBackupDestPath}
+                disabled={!autoBackupDestPath || !autoBackupEnabled}
               />
               <button
                 className="sv-save-btn"

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -733,9 +733,9 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
           <div className="sv-field">
             <label className="sv-label">Backup folder</label>
             <div className="sv-row">
-              <span className="sv-hint sv-hint--path">
+              <code className="sv-path-code">
                 {autoBackupDestPath ?? 'No folder selected'}
-              </span>
+              </code>
               <button className="sv-save-btn" onClick={handleChooseBackupFolder}>
                 Choose folder…
               </button>
@@ -747,29 +747,29 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
             label="Enable automatic backups"
             hint={autoBackupDestPath ? undefined : 'Choose a backup folder first.'}
           />
-          <div className="sv-field">
+          <div className="sv-field sv-field--inline-row">
             <label className="sv-label">Max backups to keep</label>
-            <input
-              className="sv-input sv-input--short"
-              type="number"
-              min={1}
-              value={autoBackupMaxCountInput}
-              onChange={(e) => setAutoBackupMaxCountInput(e.target.value)}
-              onBlur={handleAutoBackupMaxCountBlur}
-              disabled={!autoBackupDestPath}
-            />
-          </div>
-          <div className="sv-field">
-            <button
-              className="sv-save-btn"
-              onClick={handleRunAutoBackupNow}
-              disabled={autoBackupRunning || !autoBackupDestPath || !autoBackupEnabled}
-            >
-              {autoBackupRunning ? 'Backing up…' : 'Back up now'}
-            </button>
-            {autoBackupResult && (
-              <span className="sv-hint sv-hint--inline">{autoBackupResult}</span>
-            )}
+            <div className="sv-inline-actions">
+              <input
+                className="sv-input sv-input--short"
+                type="number"
+                min={1}
+                value={autoBackupMaxCountInput}
+                onChange={(e) => setAutoBackupMaxCountInput(e.target.value)}
+                onBlur={handleAutoBackupMaxCountBlur}
+                disabled={!autoBackupDestPath}
+              />
+              <button
+                className="sv-save-btn"
+                onClick={handleRunAutoBackupNow}
+                disabled={autoBackupRunning || !autoBackupDestPath || !autoBackupEnabled}
+              >
+                {autoBackupRunning ? 'Backing up…' : 'Back up now'}
+              </button>
+              {autoBackupResult && (
+                <span className="sv-hint sv-hint--inline">{autoBackupResult}</span>
+              )}
+            </div>
           </div>
         </div>
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -49,6 +49,9 @@ export interface User {
   reminder_notifications_enabled: 0 | 1;
   rss_poll_interval_hours: number;
   wayback_enabled: 0 | 1;
+  auto_backup_enabled: 0 | 1;
+  auto_backup_dest_path: string | null;
+  auto_backup_max_count: number;
 }
 
 export interface ContactListItem {


### PR DESCRIPTION
## Summary

- Stores the plaintext password in memory at unlock time (cleared on lock) so auto-backups can run silently without prompting
- Three new `user` table columns: `auto_backup_enabled`, `auto_backup_dest_path`, `auto_backup_max_count` (default 10); DB migration v1 → v2
- New `src/main/ipc/auto-backup.ts`: encrypts with the same AES-256-GCM / gzip bundle format as manual exports — fully restorable via the existing restore flow
- Runs on every clean quit (`before-quit`); also checks hourly while unlocked and runs if 24 h have passed since the newest backup file
- Prunes oldest `.sourcerer-backup` files in the folder beyond `max_count`
- **Settings > Automatic backups** section: folder picker, enable/disable toggle (disabled until a folder is chosen), max-count input, and "Back up now" button for immediate testing

> **Note on DB_VERSION:** PRs #19 and #22 also target `DB_VERSION = 2`. Renumber migration blocks sequentially when merging these PRs.

## Test plan

- [x] Choose a folder in Settings → Automatic backups, enable the toggle
- [x] Click "Back up now" — a `.sourcerer-backup` file appears in the folder
- [x] Quit the app cleanly — another backup file appears
- [x] Create more than 10 backups — older ones are pruned automatically
- [x] Restore one of the auto-backups using the regular Restore flow with your master password

Closes #21