### PR TITLE
Prompt to update status when logging an interaction

### DIFF
--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -1233,6 +1233,66 @@
   opacity: 1;
 }
 
+.pt-status-prompt {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  margin: 8px 0;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  font-size: 12px;
+}
+
+.pt-status-prompt-label {
+  color: var(--color-text-dim);
+  flex-shrink: 0;
+}
+
+.pt-status-prompt-select {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 3px 6px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  cursor: pointer;
+  flex: 1;
+  min-width: 0;
+}
+
+.pt-status-prompt-update {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 10px;
+  background: var(--color-text);
+  color: var(--color-surface);
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.pt-status-prompt-update:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pt-status-prompt-dismiss {
+  background: none;
+  border: none;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  flex-shrink: 0;
+  padding: 0;
+}
+
+.pt-status-prompt-dismiss:hover {
+  color: var(--color-text);
+}
+
 .pt-assign-btn {
   background: none;
   border: 1px solid var(--color-border);

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -1250,7 +1250,7 @@
 }
 
 .pt-status-prompt-select {
-  font-family: var(--font-mono);
+  font-family: var(--font-serif);
   font-size: 11px;
   padding: 3px 6px;
   background: var(--color-surface);

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -81,6 +81,9 @@ function LogAllModal({ entries, onClose }: { entries: InteractionLogEntry[]; onC
 
 const LOG_PREVIEW = 3;
 
+// Labels from the default status seed. No UI exists yet to rename statuses, so
+// these strings are stable in practice. If custom statuses land, this constant
+// should move to a shared location or status_options should gain a system_key column.
 const TRIGGER_STATUSES = ['Not yet contacted', 'Contacted, no reply'];
 
 function LogSection({
@@ -146,6 +149,8 @@ function LogSection({
     setUpdatingStatus(true);
     try {
       await onStatusChange(promptStatus);
+      setShowStatusPrompt(false);
+    } catch {
       setShowStatusPrompt(false);
     } finally {
       setUpdatingStatus(false);

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -81,19 +81,37 @@ function LogAllModal({ entries, onClose }: { entries: InteractionLogEntry[]; onC
 
 const LOG_PREVIEW = 3;
 
-function LogSection({ membership, onEntryAdded }: { membership: ContactProject; onEntryAdded?: () => void }) {
+const TRIGGER_STATUSES = ['Not yet contacted', 'Contacted, no reply'];
+
+function LogSection({
+  membership,
+  membershipStatus,
+  statusOptions,
+  onStatusChange,
+  onEntryAdded,
+}: {
+  membership: ContactProject;
+  membershipStatus: string;
+  statusOptions: StatusOption[];
+  onStatusChange: (value: string) => Promise<void>;
+  onEntryAdded?: () => void;
+}) {
   const [entries, setEntries] = useState<InteractionLogEntry[]>([]);
   const [text, setText] = useState('');
   const [logDate, setLogDate] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [adding, setAdding] = useState(false);
   const [showAll, setShowAll] = useState(false);
+  const [showStatusPrompt, setShowStatusPrompt] = useState(false);
+  const [promptStatus, setPromptStatus] = useState('');
+  const [updatingStatus, setUpdatingStatus] = useState(false);
 
   useEffect(() => {
     setEntries([]);
     setText('');
     setLogDate('');
     setAdding(false);
+    setShowStatusPrompt(false);
     window.sourcerer.listInteractionLog(membership.membership_id).then(setEntries);
   }, [membership.membership_id]);
 
@@ -110,8 +128,27 @@ function LogSection({ membership, onEntryAdded }: { membership: ContactProject; 
       setLogDate('');
       setAdding(false);
       onEntryAdded?.();
+      if (TRIGGER_STATUSES.includes(membershipStatus)) {
+        const suggested =
+          statusOptions.find((s) => s.label === 'In dialogue') ??
+          statusOptions.find((s) => !TRIGGER_STATUSES.includes(s.label));
+        if (suggested) {
+          setPromptStatus(suggested.label);
+          setShowStatusPrompt(true);
+        }
+      }
     } finally {
       setSubmitting(false);
+    }
+  }
+
+  async function handleStatusUpdate() {
+    setUpdatingStatus(true);
+    try {
+      await onStatusChange(promptStatus);
+      setShowStatusPrompt(false);
+    } finally {
+      setUpdatingStatus(false);
     }
   }
 
@@ -142,6 +179,33 @@ function LogSection({ membership, onEntryAdded }: { membership: ContactProject; 
       )}
 
       {preview.map((e) => <LogRow key={e.id} entry={e} />)}
+
+      {showStatusPrompt && (
+        <div className="pt-status-prompt">
+          <span className="pt-status-prompt-label">Update status?</span>
+          <select
+            className="pt-status-prompt-select"
+            value={promptStatus}
+            onChange={(e) => setPromptStatus(e.target.value)}
+          >
+            {statusOptions
+              .filter((s) => !TRIGGER_STATUSES.includes(s.label))
+              .map((s) => (
+                <option key={s.id} value={s.label}>{s.label}</option>
+              ))}
+          </select>
+          <button
+            className="pt-status-prompt-update"
+            onClick={handleStatusUpdate}
+            disabled={updatingStatus}
+          >
+            {updatingStatus ? 'Updating…' : 'Update'}
+          </button>
+          <button className="pt-status-prompt-dismiss" onClick={() => setShowStatusPrompt(false)}>
+            Dismiss
+          </button>
+        </div>
+      )}
 
       {adding && (
         <div className="pt-log-compose">
@@ -728,7 +792,13 @@ export default function ProjectTab({ contact, statusOptions, priorityOptions, on
         outreachEnabled={currentUser?.outreachRemindersEnabled ?? true}
         contactOutreachEnabled={localOutreachEnabled}
       />
-      <LogSection membership={membership} onEntryAdded={() => { onMembershipUpdated(); setReminderRefresh((t) => t + 1); }} />
+      <LogSection
+        membership={membership}
+        membershipStatus={localStatus}
+        statusOptions={statusOptions}
+        onStatusChange={handleStatusChange}
+        onEntryAdded={() => { onMembershipUpdated(); setReminderRefresh((t) => t + 1); }}
+      />
       <ScratchpadSection membership={membership} contactId={contact.id} />
     </div>
   );


### PR DESCRIPTION
## Summary

After saving a new interaction log entry, check the contact's current status in that project. If it is "Not yet contacted" or "Contacted, no reply", show a low-friction inline prompt offering to update the status — with a suggested next status pre-selected. The user can confirm, pick a different status, or dismiss.

## Implementation plan

- After a log entry is saved in `ProjectTab`, query the membership's current status
- If status is in the trigger set ("Not yet contacted", "Contacted, no reply"), surface an inline prompt beneath the log form
- Prompt shows suggested status (e.g. "In dialogue") with a confirm button, a dropdown to pick a different status, and a dismiss option
- On confirm, call the existing `updateMembership` IPC handler to write the new status

## Test plan

- [x] Log an interaction when status is "Not yet contacted" — prompt appears
- [x] Log an interaction when status is "Contacted, no reply" — prompt appears
- [x] Log an interaction when status is something else (e.g. "In dialogue") — no prompt
- [x] Confirm suggested status — membership status updates and project view reflects it
- [x] Pick a different status from the dropdown and confirm — correct status written
- [x] Dismiss — no status change, prompt disappears

Closes #18