### PR TITLE
Bulk status/priority update in project view

### DIFF
--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -456,6 +456,24 @@ export function registerContactHandlers(): void {
   });
 
   ipcMain.handle(
+    'memberships:bulk-update',
+    (_, { membershipIds, status, priority }: { membershipIds: string[]; status?: string | null; priority?: string | null }): void => {
+      const db = getDatabase();
+      const now = Math.floor(Date.now() / 1000);
+      db.transaction(() => {
+        if (status !== undefined) {
+          const stmt = db.prepare('UPDATE project_memberships SET status = ?, updated_at = ? WHERE id = ?');
+          for (const id of membershipIds) stmt.run(status ?? null, now, id);
+        }
+        if (priority !== undefined) {
+          const stmt = db.prepare('UPDATE project_memberships SET priority = ?, updated_at = ? WHERE id = ?');
+          for (const id of membershipIds) stmt.run(priority ?? null, now, id);
+        }
+      })();
+    },
+  );
+
+  ipcMain.handle(
     'memberships:set-reporters',
     (_, { membershipId, reporters }: { membershipId: string; reporters: Array<{ email: string; name: string }> }): void => {
       const db = getDatabase();

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -458,6 +458,7 @@ export function registerContactHandlers(): void {
   ipcMain.handle(
     'memberships:bulk-update',
     (_, { membershipIds, status, priority }: { membershipIds: string[]; status?: string | null; priority?: string | null }): void => {
+      if (!membershipIds.length) return;
       const db = getDatabase();
       const now = Math.floor(Date.now() / 1000);
       db.transaction(() => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -118,6 +118,8 @@ const sourcererApi = {
     ipcRenderer.invoke('memberships:remove', { contactId, projectId }),
   updateMembership: (data: UpdateMembershipInput): Promise<void> =>
     ipcRenderer.invoke('memberships:update', data),
+  bulkUpdateMemberships: (data: { membershipIds: string[]; status?: string | null; priority?: string | null }): Promise<void> =>
+    ipcRenderer.invoke('memberships:bulk-update', data),
   setMembershipReporters: (membershipId: string, reporters: Array<{ email: string; name: string }>): Promise<void> =>
     ipcRenderer.invoke('memberships:set-reporters', { membershipId, reporters }),
   listProjectReporters: (projectId: string): Promise<Array<{ email: string; name: string }>> =>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -86,6 +86,7 @@ declare global {
       addToProject: (contactId: string, projectId: string) => Promise<void>;
       removeFromProject: (contactId: string, projectId: string) => Promise<void>;
       updateMembership: (data: UpdateMembershipInput) => Promise<void>;
+      bulkUpdateMemberships: (data: { membershipIds: string[]; status?: string | null; priority?: string | null }) => Promise<void>;
       setMembershipReporters: (membershipId: string, reporters: Array<{ email: string; name: string }>) => Promise<void>;
       listProjectReporters: (projectId: string) => Promise<Array<{ email: string; name: string }>>;
       listProjectTimeline: (projectId: string) => Promise<TimelineEntry[]>;

--- a/src/renderer/src/views/AllContacts.css
+++ b/src/renderer/src/views/AllContacts.css
@@ -367,6 +367,33 @@
   cursor: not-allowed;
 }
 
+.bulk-bar-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin-right: 4px;
+}
+
+.bulk-bar-select {
+  height: 28px;
+  padding: 0 6px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.10em;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-strong);
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.bulk-bar-select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* Clear filters button */
 .clear-filters-btn {
   height: 32px;

--- a/src/renderer/src/views/AllContacts.css
+++ b/src/renderer/src/views/AllContacts.css
@@ -365,6 +365,75 @@
   cursor: not-allowed;
 }
 
+.bulk-actions-wrap {
+  position: relative;
+}
+
+.bulk-actions-trigger {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: none;
+  border: 1px solid var(--color-border-strong);
+  font-size: 14px;
+  letter-spacing: -0.05em;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bulk-actions-trigger:hover:not(:disabled) {
+  border-color: var(--color-text);
+  color: var(--color-text);
+}
+
+.bulk-actions-trigger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.bulk-actions-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 100;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border-strong);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  min-width: 180px;
+  overflow: hidden;
+}
+
+.bulk-actions-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 8px 14px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text);
+}
+
+.bulk-actions-item:hover {
+  background: var(--color-surface);
+}
+
+.bulk-actions-item--danger {
+  color: var(--color-danger);
+}
+
+.bulk-actions-item--danger:hover {
+  background: rgba(185, 28, 28, 0.06);
+}
+
 .bulk-bar-label {
   font-family: var(--font-mono);
   font-size: 10px;

--- a/src/renderer/src/views/AllContacts.css
+++ b/src/renderer/src/views/AllContacts.css
@@ -370,23 +370,21 @@
 }
 
 .bulk-actions-trigger {
-  width: 28px;
   height: 28px;
-  padding: 0;
+  padding: 0 10px;
   background: none;
-  border: 1px solid var(--color-border-strong);
-  font-size: 14px;
-  letter-spacing: -0.05em;
-  color: var(--color-text-muted);
+  border: 1px solid var(--color-danger);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-danger);
   cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .bulk-actions-trigger:hover:not(:disabled) {
-  border-color: var(--color-text);
-  color: var(--color-text);
+  background: rgba(185, 28, 28, 0.06);
 }
 
 .bulk-actions-trigger:disabled {

--- a/src/renderer/src/views/AllContacts.css
+++ b/src/renderer/src/views/AllContacts.css
@@ -236,6 +236,12 @@
   flex-shrink: 0;
 }
 
+.bulk-bar-element {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .bulk-bar-count {
   font-family: var(--font-mono);
   font-size: 10px;
@@ -243,8 +249,6 @@
   text-transform: uppercase;
   letter-spacing: 0.16em;
   color: var(--color-primary);
-  margin-right: 4px;
-  display: inline;
 }
 
 .bulk-bar-clear {
@@ -252,20 +256,14 @@
   height: 20px;
   border: none;
   background: none;
-  /* color: var(--color-text-muted); */
   color: var(--color-primary) !important;
-  /* margin-bottom: 2px; */
   font-size: 16px;
   line-height: 1;
   cursor: pointer;
   padding: 0;
-  /* display: flex;
+  display: flex;
   align-items: center;
-  justify-content: center; */
-  margin-right: 4px;
-  /* display: inline; */
-  position: relative;
-  top: 1px;
+  justify-content: center;
 }
 
 .bulk-bar-clear:hover {
@@ -275,7 +273,7 @@
 .bulk-bar-btn {
   height: 28px;
   padding: 0 10px;
-  font-size: 12px;
+  font-size: 10px;
 }
 
 .bulk-project-wrap {
@@ -320,7 +318,7 @@
   font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 500;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--color-danger);
   cursor: pointer;
@@ -380,9 +378,9 @@
 .bulk-bar-select {
   height: 28px;
   padding: 0 6px;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.10em;
+  font-family: var(--font-serif);
+  font-size: 12px;
+  /* letter-spacing: 0.10em; */
   background: var(--color-surface);
   border: 1px solid var(--color-border-strong);
   color: var(--color-text);

--- a/src/renderer/src/views/ProjectView.tsx
+++ b/src/renderer/src/views/ProjectView.tsx
@@ -277,7 +277,6 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
       const membershipIds = rows.filter((r) => checkedIds.has(r.id)).map((r) => r.membership_id);
       await window.sourcerer.bulkUpdateMemberships({ membershipIds, status });
       setRows((prev) => prev.map((r) => checkedIds.has(r.id) ? { ...r, status } : r));
-      setCheckedIds(new Set());
     } finally {
       setBulkWorking(false);
     }
@@ -290,7 +289,6 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
       const membershipIds = rows.filter((r) => checkedIds.has(r.id)).map((r) => r.membership_id);
       await window.sourcerer.bulkUpdateMemberships({ membershipIds, priority });
       setRows((prev) => prev.map((r) => checkedIds.has(r.id) ? { ...r, priority } : r));
-      setCheckedIds(new Set());
     } finally {
       setBulkWorking(false);
     }
@@ -687,7 +685,7 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
             <>
               {statusOptions.length > 0 && (
                 <div className="bulk-bar-element">
-                  <label className="bulk-bar-label">Status:</label>
+                  <label className="bulk-bar-label">Status</label>
                   <select
                     className="bulk-bar-select"
                     value=""
@@ -697,7 +695,7 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
                     }}
                     disabled={bulkWorking}
                   >
-                    <option value="" disabled>Set status…</option>
+                    <option value="" disabled>Set status</option>
                     {statusOptions.map((o) => (
                       <option key={o.id} value={o.label}>{o.label}</option>
                     ))}
@@ -707,7 +705,7 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
               )}
               {priorityOptions.length > 0 && (
                 <div className="bulk-bar-element">
-                  <label className="bulk-bar-label">Priority:</label>
+                  <label className="bulk-bar-label">Priority</label>
                   <select
                     className="bulk-bar-select"
                     value=""
@@ -717,7 +715,7 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
                     }}
                     disabled={bulkWorking}
                   >
-                    <option value="" disabled>Set priority…</option>
+                    <option value="" disabled>Set priority</option>
                     {priorityOptions.map((o) => (
                       <option key={o.id} value={o.label}>{o.label}</option>
                     ))}

--- a/src/renderer/src/views/ProjectView.tsx
+++ b/src/renderer/src/views/ProjectView.tsx
@@ -732,9 +732,8 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
                   className="bulk-actions-trigger"
                   onClick={() => setShowBulkActions((v) => !v)}
                   disabled={bulkWorking}
-                  title="More actions"
                 >
-                  ···
+                  Remove from…
                 </button>
                 {showBulkActions && (
                   <div className="bulk-actions-menu">
@@ -742,13 +741,13 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
                       className="bulk-actions-item bulk-actions-item--danger"
                       onClick={() => { setShowBulkActions(false); setConfirmRemove(true); }}
                     >
-                      Remove from project
+                      Project
                     </button>
                     <button
                       className="bulk-actions-item bulk-actions-item--danger"
                       onClick={() => { setShowBulkActions(false); setConfirmDelete(true); }}
                     >
-                      Delete from Sourcerer
+                      Sourcerer
                     </button>
                   </div>
                 )}

--- a/src/renderer/src/views/ProjectView.tsx
+++ b/src/renderer/src/views/ProjectView.tsx
@@ -695,13 +695,15 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
                     value=""
                     onChange={(e) => {
                       const v = e.target.value;
-                      handleBulkSetStatus(v === '__clear__' ? null : v);
+                      if (v === '__clear__') { handleBulkSetStatus(null); return; }
+                      const opt = statusOptions.find((o) => o.id === v);
+                      if (opt) handleBulkSetStatus(opt.label);
                     }}
                     disabled={bulkWorking}
                   >
                     <option value="" disabled>Set status</option>
                     {statusOptions.map((o) => (
-                      <option key={o.id} value={o.label}>{o.label}</option>
+                      <option key={o.id} value={o.id}>{o.label}</option>
                     ))}
                     <option value="__clear__">— clear —</option>
                   </select>
@@ -715,13 +717,15 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
                     value=""
                     onChange={(e) => {
                       const v = e.target.value;
-                      handleBulkSetPriority(v === '__clear__' ? null : v);
+                      if (v === '__clear__') { handleBulkSetPriority(null); return; }
+                      const opt = priorityOptions.find((o) => o.id === v);
+                      if (opt) handleBulkSetPriority(opt.label);
                     }}
                     disabled={bulkWorking}
                   >
                     <option value="" disabled>Set priority</option>
                     {priorityOptions.map((o) => (
-                      <option key={o.id} value={o.label}>{o.label}</option>
+                      <option key={o.id} value={o.id}>{o.label}</option>
                     ))}
                     <option value="__clear__">— clear —</option>
                   </select>

--- a/src/renderer/src/views/ProjectView.tsx
+++ b/src/renderer/src/views/ProjectView.tsx
@@ -270,6 +270,32 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
     }
   }
 
+  async function handleBulkSetStatus(status: string | null) {
+    if (!project) return;
+    setBulkWorking(true);
+    try {
+      const membershipIds = rows.filter((r) => checkedIds.has(r.id)).map((r) => r.membership_id);
+      await window.sourcerer.bulkUpdateMemberships({ membershipIds, status });
+      setRows((prev) => prev.map((r) => checkedIds.has(r.id) ? { ...r, status } : r));
+      setCheckedIds(new Set());
+    } finally {
+      setBulkWorking(false);
+    }
+  }
+
+  async function handleBulkSetPriority(priority: string | null) {
+    if (!project) return;
+    setBulkWorking(true);
+    try {
+      const membershipIds = rows.filter((r) => checkedIds.has(r.id)).map((r) => r.membership_id);
+      await window.sourcerer.bulkUpdateMemberships({ membershipIds, priority });
+      setRows((prev) => prev.map((r) => checkedIds.has(r.id) ? { ...r, priority } : r));
+      setCheckedIds(new Set());
+    } finally {
+      setBulkWorking(false);
+    }
+  }
+
   async function handleBulkDelete() {
     setBulkWorking(true);
     try {
@@ -659,6 +685,46 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
             </div>
           ) : (
             <>
+              {statusOptions.length > 0 && (
+                <div className="bulk-bar-element">
+                  <label className="bulk-bar-label">Status:</label>
+                  <select
+                    className="bulk-bar-select"
+                    value=""
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      handleBulkSetStatus(v === '__clear__' ? null : v);
+                    }}
+                    disabled={bulkWorking}
+                  >
+                    <option value="" disabled>Set status…</option>
+                    {statusOptions.map((o) => (
+                      <option key={o.id} value={o.label}>{o.label}</option>
+                    ))}
+                    <option value="__clear__">— clear —</option>
+                  </select>
+                </div>
+              )}
+              {priorityOptions.length > 0 && (
+                <div className="bulk-bar-element">
+                  <label className="bulk-bar-label">Priority:</label>
+                  <select
+                    className="bulk-bar-select"
+                    value=""
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      handleBulkSetPriority(v === '__clear__' ? null : v);
+                    }}
+                    disabled={bulkWorking}
+                  >
+                    <option value="" disabled>Set priority…</option>
+                    {priorityOptions.map((o) => (
+                      <option key={o.id} value={o.label}>{o.label}</option>
+                    ))}
+                    <option value="__clear__">— clear —</option>
+                  </select>
+                </div>
+              )}
               <div className="bulk-bar-element">
                 <button
                   className="bulk-delete-btn"

--- a/src/renderer/src/views/ProjectView.tsx
+++ b/src/renderer/src/views/ProjectView.tsx
@@ -67,6 +67,7 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
   const [syncError, setSyncError] = useState<string | null>(null);
   const [fileUnreachable, setFileUnreachable] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
+  const [showBulkActions, setShowBulkActions] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [sort, setSort] = useState<{ key: SortKey | null; dir: SortDir }>({ key: null, dir: 'asc' });
   const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
@@ -79,11 +80,14 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
   const [editDescription, setEditDescription] = useState('');
   const [editSubmitting, setEditSubmitting] = useState(false);
   const exportMenuRef = useRef<HTMLDivElement>(null);
+  const bulkActionsRef = useRef<HTMLDivElement>(null);
   const selectAllRef = useRef<HTMLInputElement>(null);
   const syncStartedAt = useRef<number>(0);
 
   const handleCloseExportMenu = useCallback(() => setShowExportMenu(false), []);
   useClickOutside(exportMenuRef, handleCloseExportMenu, { isOpen: showExportMenu });
+  const handleCloseBulkActions = useCallback(() => setShowBulkActions(false), []);
+  useClickOutside(bulkActionsRef, handleCloseBulkActions, { isOpen: showBulkActions });
 
   const refresh = useCallback(() => {
     if (!project) return;
@@ -723,24 +727,31 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
                   </select>
                 </div>
               )}
-              <div className="bulk-bar-element">
+              <div className="bulk-bar-element bulk-actions-wrap" ref={bulkActionsRef} style={{ marginLeft: 'auto' }}>
                 <button
-                  className="bulk-delete-btn"
-                  style={{ marginLeft: 'auto' }}
-                  onClick={() => setConfirmRemove(true)}
+                  className="bulk-actions-trigger"
+                  onClick={() => setShowBulkActions((v) => !v)}
                   disabled={bulkWorking}
+                  title="More actions"
                 >
-                  Remove from project
+                  ···
                 </button>
-              </div>
-              <div className="bulk-bar-element">
-                <button
-                  className="bulk-delete-btn"
-                  onClick={() => setConfirmDelete(true)}
-                  disabled={bulkWorking}
-                >
-                  Delete from Sourcerer
-                </button>
+                {showBulkActions && (
+                  <div className="bulk-actions-menu">
+                    <button
+                      className="bulk-actions-item bulk-actions-item--danger"
+                      onClick={() => { setShowBulkActions(false); setConfirmRemove(true); }}
+                    >
+                      Remove from project
+                    </button>
+                    <button
+                      className="bulk-actions-item bulk-actions-item--danger"
+                      onClick={() => { setShowBulkActions(false); setConfirmDelete(true); }}
+                    >
+                      Delete from Sourcerer
+                    </button>
+                  </div>
+                )}
               </div>
             </>
           )}


### PR DESCRIPTION
## Summary

Add multi-select to the project contact list so reporters can bulk-apply a status or priority to multiple contacts in one action, and access the remove/delete operations from a single menu.

## Implementation notes

- Checkbox selection already existed; this PR wires up the bulk action bar with new controls
- Status and priority dropdowns update all selected memberships in a single SQLite transaction via a new \`memberships:bulk-update\` IPC handler
- Selection **persists** after applying status/priority so you can chain updates (e.g. set status then set priority) without re-selecting
- Destructive actions (remove from project, delete from Sourcerer) are collapsed into a \`Remove from…\` danger button that opens a submenu with \`Project\` / \`Sourcerer\` options, keeping the bar uncluttered
- Confirm step is still required for both destructive actions

## Test plan

- [x] Select multiple contacts — batch action bar appears
- [x] Apply a status change — all selected contacts update immediately, selection stays
- [x] Apply a priority change — all selected contacts update immediately, selection stays
- [x] Clear selection button works
- [x] Selecting all / deselecting all works
- [x] \"Remove from…\" button opens submenu with Project / Sourcerer options
- [x] Both destructive actions still require a confirm step

Closes #27