### PR TITLE
Interaction log search within a contact

### DIFF
--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -779,10 +779,57 @@
   flex-shrink: 0;
 }
 
+.pt-log-modal-search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 20px;
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.pt-log-search-input {
+  flex: 1;
+  font-family: var(--font-serif);
+  font-size: 13px;
+  background: none;
+  border: none;
+  outline: none;
+  color: var(--color-text);
+}
+
+.pt-log-search-input::placeholder {
+  color: var(--color-text-dim);
+}
+
+.pt-log-search-clear {
+  background: none;
+  border: none;
+  font-size: 14px;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.pt-log-search-clear:hover {
+  color: var(--color-text);
+}
+
 .pt-log-modal-body {
   overflow-y: auto;
   padding: 0 20px 20px;
   flex: 1;
+}
+
+.pt-log-modal-footer {
+  padding: 8px 20px;
+  border-top: 1px solid var(--color-border);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-dim);
+  flex-shrink: 0;
 }
 
 /* ── Compose form ── */

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -788,6 +788,10 @@
   flex-shrink: 0;
 }
 
+.pt-log-modal-search:focus-within {
+  border-bottom-color: var(--color-primary);
+}
+
 .pt-log-search-input {
   flex: 1;
   font-family: var(--font-serif);

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -80,12 +80,13 @@ function LogAllModal({ entries, onClose }: { entries: InteractionLogEntry[]; onC
               className="pt-log-search-input"
               type="text"
               placeholder="Search entries…"
+              aria-label="Search log entries"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               autoFocus
             />
             {query && (
-              <button className="pt-log-search-clear" onClick={() => setQuery('')}>×</button>
+              <button className="pt-log-search-clear" aria-label="Clear search" onClick={() => setQuery('')}>×</button>
             )}
           </div>
         )}

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -49,6 +49,8 @@ function LogRow({ entry }: { entry: InteractionLogEntry }) {
 }
 
 function LogAllModal({ entries, onClose }: { entries: InteractionLogEntry[]; onClose: () => void }) {
+  const [query, setQuery] = useState('');
+
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (e.key === 'Escape') {
@@ -60,6 +62,11 @@ function LogAllModal({ entries, onClose }: { entries: InteractionLogEntry[]; onC
     return () => document.removeEventListener('keydown', onKey);
   }, [onClose]);
 
+  const reversed = [...entries].reverse();
+  const visible = query
+    ? reversed.filter((e) => e.body.toLowerCase().includes(query.toLowerCase()))
+    : reversed;
+
   return createPortal(
     <div className="modal-overlay" onClick={onClose}>
       <div className="pt-log-modal-card" onClick={(e) => e.stopPropagation()}>
@@ -67,12 +74,32 @@ function LogAllModal({ entries, onClose }: { entries: InteractionLogEntry[]; onC
           <span className="pt-reminders-label">Interaction Log</span>
           <button className="detail-close" onClick={onClose}>×</button>
         </div>
+        {entries.length > 0 && (
+          <div className="pt-log-modal-search">
+            <input
+              className="pt-log-search-input"
+              type="text"
+              placeholder="Search entries…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              autoFocus
+            />
+            {query && (
+              <button className="pt-log-search-clear" onClick={() => setQuery('')}>×</button>
+            )}
+          </div>
+        )}
         <div className="pt-log-modal-body">
-          {entries.length === 0
-            ? <p className="pt-reminders-empty">No entries yet.</p>
-            : [...entries].reverse().map((e) => <LogRow key={e.id} entry={e} />)
+          {visible.length === 0
+            ? <p className="pt-reminders-empty">{query ? 'No entries match.' : 'No entries yet.'}</p>
+            : visible.map((e) => <LogRow key={e.id} entry={e} />)
           }
         </div>
+        {query && entries.length > 0 && (
+          <div className="pt-log-modal-footer">
+            {visible.length} of {entries.length} {entries.length === 1 ? 'entry' : 'entries'}
+          </div>
+        )}
       </div>
     </div>,
     document.body,


### PR DESCRIPTION
## Summary

Adds a search input to the \"View all\" interaction log modal that filters entries in real time using client-side string matching.

## Implementation notes

- Search input added at the top of `LogAllModal` in `ProjectTab.tsx`; autofocuses on open
- Filtering is client-side (`body.toLowerCase().includes(query.toLowerCase())`) — no IPC or FTS involved
- Footer shows \"X of Y entries\" when a filter is active
- FTS5 operators (AND, OR, NOT, NEAR) are **not** available here; this is plain substring search. The global search (PR #23) does use FTS5, but tokens are quoted before dispatch so operators are treated as literal search terms rather than query syntax — preventing injection and unexpected errors for natural-language queries

## Test plan

- [x] Typing in the search box filters entries to those matching the term
- [x] Clearing the input restores all entries
- [x] FTS operators typed by the user are treated as literals, not syntax (N/A for modal; confirmed in global search)
- [x] Empty state shown when no entries match

Closes #28