### PR TITLE
chore: bump version to 0.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sourcerer",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sourcerer",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcerer",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "description": "Encrypted source management for journalists",
   "author": "Tom Cardoso",


### PR DESCRIPTION
Patch release — bumps version to 0.1.8.

Includes:
- Title field and messaging handles on contacts (#32)
- vCard (.vcf) import (#20)
- CI workflow for PR test gate