### PR TITLE
Sync extension with schema, fix Wayback Machine archiving

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -6,10 +6,10 @@ chrome.runtime.onInstalled.addListener(() => {
     title: 'Save to Sourcerer',
     contexts: ['selection'],
   });
-  chrome.contextMenus.create({ id: 'sourcerer-email', parentId: MENU_PARENT, title: 'Save as email',  contexts: ['selection'] });
-  chrome.contextMenus.create({ id: 'sourcerer-phone', parentId: MENU_PARENT, title: 'Save as phone',  contexts: ['selection'] });
-  chrome.contextMenus.create({ id: 'sourcerer-note',  parentId: MENU_PARENT, title: 'Save as note',   contexts: ['selection'] });
-  chrome.contextMenus.create({ id: 'sourcerer-contact', parentId: MENU_PARENT, title: 'Add as new contact', contexts: ['selection'] });
+  chrome.contextMenus.create({ id: 'sourcerer-email',   parentId: MENU_PARENT, title: 'Save as email',       contexts: ['selection'] });
+  chrome.contextMenus.create({ id: 'sourcerer-phone',   parentId: MENU_PARENT, title: 'Save as phone',       contexts: ['selection'] });
+  chrome.contextMenus.create({ id: 'sourcerer-note',    parentId: MENU_PARENT, title: 'Save as note',        contexts: ['selection'] });
+  chrome.contextMenus.create({ id: 'sourcerer-contact', parentId: MENU_PARENT, title: 'Add as new contact',  contexts: ['selection'] });
 });
 
 const FIELD_TYPE_MAP = {

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -322,6 +322,7 @@
       margin-top: 10px;
       color: var(--text-muted);
       line-height: 1.5;
+      text-transform: uppercase;
     }
     .screen-status:empty { margin-top: 0; }
     .screen-status.ok  { color: var(--ok); }
@@ -332,6 +333,15 @@
       height: 1px;
       background: var(--border);
       margin: 12px 0;
+    }
+
+    .contact-list-empty {
+      padding: 10px;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      color: var(--text-dim);
+      text-align: center;
+      text-transform: uppercase;
     }
 
     .hidden { display: none !important; }
@@ -393,8 +403,10 @@
     <p class="screen-heading">New contact</p>
     <input id="contact-name"  class="form-input" placeholder="Name *" />
     <input id="contact-org"   class="form-input" placeholder="Organization" />
+    <input id="contact-title" class="form-input" placeholder="Title / Role" />
     <input id="contact-email" class="form-input" placeholder="Email" />
     <input id="contact-phone" class="form-input" placeholder="Phone" />
+    <input id="contact-url"   class="form-input" placeholder="Source URL (optional)" />
     <button id="btn-contact-save" class="btn-action">Add contact</button>
     <div id="contact-status" class="screen-status"></div>
   </div>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -102,7 +102,23 @@ async function addContactField(token, contactId, fieldType, value) {
     body: JSON.stringify({ contactId, fieldType, value }),
     signal: AbortSignal.timeout(5000),
   });
-  if (!r.ok) throw new Error(`Server error ${r.status}`);
+  if (!r.ok) {
+    const data = await r.json().catch(() => ({}));
+    throw new Error(data.error || `Server error ${r.status}`);
+  }
+}
+
+function isCapturableUrl(url) {
+  if (!url) return false;
+  return !['chrome://', 'chrome-extension://', 'about:', 'edge://', 'moz-extension://'].some((p) => url.startsWith(p));
+}
+
+async function getActiveTabUrl() {
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+    const u = tab?.url ?? '';
+    return isCapturableUrl(u) ? u : '';
+  } catch { return ''; }
 }
 
 // ── New: create a new contact ─────────────────────────────────────────────
@@ -113,7 +129,10 @@ async function createContact(token, fields) {
     body: JSON.stringify(fields),
     signal: AbortSignal.timeout(5000),
   });
-  if (!r.ok) throw new Error(`Server error ${r.status}`);
+  if (!r.ok) {
+    const data = await r.json().catch(() => ({}));
+    throw new Error(data.error || `Server error ${r.status}`);
+  }
   return r.json();
 }
 
@@ -332,11 +351,13 @@ async function wireConnected(token) {
   const btnNewContact = document.getElementById('btn-new-contact');
   show(btnNewContact);
   document.getElementById('btn-contact-back').onclick = () => showScreen('screen-main');
-  btnNewContact.onclick = () => {
-    document.getElementById('contact-name').value = '';
-    document.getElementById('contact-org').value  = '';
+  btnNewContact.onclick = async () => {
+    document.getElementById('contact-name').value  = '';
+    document.getElementById('contact-org').value   = '';
+    document.getElementById('contact-title').value = '';
     document.getElementById('contact-email').value = '';
     document.getElementById('contact-phone').value = '';
+    document.getElementById('contact-url').value   = await getActiveTabUrl();
     const st = document.getElementById('contact-status');
     st.textContent = ''; st.className = 'screen-status';
     document.getElementById('btn-contact-save').disabled = false;
@@ -346,14 +367,16 @@ async function wireConnected(token) {
   document.getElementById('btn-contact-save').onclick = async () => {
     const name  = document.getElementById('contact-name').value.trim();
     const org   = document.getElementById('contact-org').value.trim();
+    const title = document.getElementById('contact-title').value.trim();
     const email = document.getElementById('contact-email').value.trim();
     const phone = document.getElementById('contact-phone').value.trim();
+    const url   = document.getElementById('contact-url').value.trim();
     const st = document.getElementById('contact-status');
     if (!name) { st.textContent = 'Name is required.'; st.className = 'screen-status err'; return; }
     document.getElementById('btn-contact-save').disabled = true;
     st.textContent = 'Saving…'; st.className = 'screen-status';
     try {
-      await createContact(token, { name, organization: org || undefined, email: email || undefined, phone: phone || undefined });
+      await createContact(token, { name, organization: org || undefined, title: title || undefined, email: email || undefined, phone: phone || undefined, url: url || undefined });
       st.textContent = '✓ Contact added.'; st.className = 'screen-status ok';
       setTimeout(() => showScreen('screen-main'), 1400);
     } catch (err) {
@@ -373,8 +396,10 @@ async function wireConnected(token) {
     if (pending?.action === 'contact') {
       document.getElementById('contact-name').value  = pending.text.slice(0, 120);
       document.getElementById('contact-org').value   = '';
+      document.getElementById('contact-title').value = '';
       document.getElementById('contact-email').value = '';
       document.getElementById('contact-phone').value = '';
+      document.getElementById('contact-url').value   = await getActiveTabUrl();
       const st = document.getElementById('contact-status');
       st.textContent = ''; st.className = 'screen-status';
       document.getElementById('btn-contact-save').disabled = false;
@@ -414,6 +439,13 @@ async function wireConnected(token) {
               (c.organization ?? '').toLowerCase().includes(query.toLowerCase()))
           : allContacts;
         list.innerHTML = '';
+        if (matches.length === 0) {
+          const empty = document.createElement('p');
+          empty.className = 'contact-list-empty';
+          empty.textContent = query ? 'No contacts match.' : 'No contacts found.';
+          list.appendChild(empty);
+          return;
+        }
         matches.slice(0, 40).forEach((c) => {
           const btn = document.createElement('button');
           btn.className = 'contact-item';
@@ -477,7 +509,14 @@ async function wireConnected(token) {
             (c.organization ?? '').toLowerCase().includes(query.toLowerCase()))
         : allContacts;
       list.innerHTML = '';
-      matches.slice(0, 40).forEach((c) => {
+      if (matches.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'contact-list-empty';
+      empty.textContent = query ? 'No contacts match.' : 'No contacts found.';
+      list.appendChild(empty);
+      return;
+    }
+    matches.slice(0, 40).forEach((c) => {
         const btn = document.createElement('button');
         btn.className = 'contact-item';
         btn.dataset.id = c.id;

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -19,6 +19,8 @@ export const LOCAL_SCHEMA_SQL = `
     reminder_notifications_enabled INTEGER NOT NULL DEFAULT 1,
     rss_poll_interval_hours        INTEGER NOT NULL DEFAULT 6,
     wayback_enabled                INTEGER NOT NULL DEFAULT 1,
+    archive_access_key             TEXT,
+    archive_secret_key             TEXT,
     last_rss_fetched_at            INTEGER,
     auto_backup_enabled            INTEGER NOT NULL DEFAULT 0,
     auto_backup_dest_path          TEXT,

--- a/src/main/http-server.ts
+++ b/src/main/http-server.ts
@@ -2,21 +2,10 @@ import { createServer, IncomingMessage, ServerResponse } from 'http';
 import { randomBytes, randomUUID, timingSafeEqual } from 'crypto';
 import { app, BrowserWindow } from 'electron';
 import { isDatabaseOpen, getDatabase } from './database';
-import { normalizeEmail, normalizePhone, validateEmail, validateUrl } from './sanitize';
+import { normalizeEmail, normalizePhone, validateEmail, validateUrl, detectLinkType } from './sanitize';
 import { triggerWaybackSave } from './ipc/contacts';
 
 const MAX_SCREENSHOT_BYTES = 50 * 1024 * 1024;
-
-function detectLinkType(url: string): 'linkedin' | 'x' | 'instagram' | 'facebook' | 'website' {
-  try {
-    const host = new URL(url).hostname.replace(/^www\./, '');
-    if (host === 'linkedin.com' || host.endsWith('.linkedin.com')) return 'linkedin';
-    if (host === 'x.com' || host === 'twitter.com') return 'x';
-    if (host === 'instagram.com') return 'instagram';
-    if (host === 'facebook.com') return 'facebook';
-    return 'website';
-  } catch { return 'website'; }
-}
 const MAX_PENDING_SCREENSHOTS = 20;
 const pendingScreenshots = new Map<string, { buf: Buffer; tabUrl: string | null }>();
 

--- a/src/main/http-server.ts
+++ b/src/main/http-server.ts
@@ -242,25 +242,27 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
         const { phone_country: phoneCountry = 'US', wayback_enabled: waybackEnabled = 0, archive_access_key: archiveAccessKey = null, archive_secret_key: archiveSecretKey = null } = db
           .prepare('SELECT phone_country, wayback_enabled, archive_access_key, archive_secret_key FROM users WHERE id = 1')
           .get() as { phone_country: string; wayback_enabled: number; archive_access_key: string | null; archive_secret_key: string | null };
-        const rawEmail = (email as string | undefined)?.trim() || null;
+        const rawEmail = typeof email === 'string' ? email.trim() || null : null;
         if (rawEmail && !validateEmail(rawEmail)) {
           json(res, 400, { error: 'Email address is invalid.' }); return;
         }
-        const rawPhone = (phone as string | undefined)?.trim() || null;
+        const rawPhone = typeof phone === 'string' ? phone.trim() || null : null;
         let normalizedPhone: string | null = null;
         if (rawPhone) {
           normalizedPhone = normalizePhone(rawPhone, phoneCountry);
           if (!normalizedPhone) { json(res, 400, { error: 'Phone number is invalid.' }); return; }
         }
-        const rawUrl = (url as string | undefined)?.trim() || null;
+        const rawUrl = typeof url === 'string' ? url.trim() || null : null;
         if (rawUrl && !validateUrl(rawUrl)) {
           json(res, 400, { error: 'URL is invalid.' }); return;
         }
+        const rawOrg = typeof organization === 'string' ? organization.trim() || null : null;
+        const rawTitle = typeof title === 'string' ? title.trim() || null : null;
         const contactId = randomUUID();
         const now = Math.floor(Date.now() / 1000);
         db.prepare(
           'INSERT INTO contacts (id, name, organization, title, notes, created_at, updated_at) VALUES (?, ?, ?, ?, NULL, ?, ?)'
-        ).run(contactId, name.trim(), (organization as string | undefined)?.trim() || null, (title as string | undefined)?.trim() || null, now, now);
+        ).run(contactId, name.trim(), rawOrg, rawTitle, now, now);
         if (rawEmail) {
           db.prepare(
             'INSERT INTO contact_emails (id, contact_id, email, sort_order, created_at) VALUES (?, ?, ?, 0, ?)'
@@ -293,8 +295,8 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
     req.on('data', (chunk: Buffer) => { raw += chunk.toString('utf-8'); });
     req.on('end', () => {
       try {
-        const { contactId, fieldType, value } = JSON.parse(raw) as { contactId: string; fieldType: string; value: string };
-        if (!contactId || !fieldType || !value?.trim()) {
+        const { contactId, fieldType, value } = JSON.parse(raw) as { contactId: string; fieldType: string; value: unknown };
+        if (!contactId || !fieldType || typeof value !== 'string' || !value.trim()) {
           json(res, 400, { error: 'missing_fields' });
           return;
         }

--- a/src/main/http-server.ts
+++ b/src/main/http-server.ts
@@ -2,9 +2,21 @@ import { createServer, IncomingMessage, ServerResponse } from 'http';
 import { randomBytes, randomUUID, timingSafeEqual } from 'crypto';
 import { app, BrowserWindow } from 'electron';
 import { isDatabaseOpen, getDatabase } from './database';
-import { normalizeEmail, normalizePhone } from './sanitize';
+import { normalizeEmail, normalizePhone, validateEmail, validateUrl } from './sanitize';
+import { triggerWaybackSave } from './ipc/contacts';
 
 const MAX_SCREENSHOT_BYTES = 50 * 1024 * 1024;
+
+function detectLinkType(url: string): 'linkedin' | 'x' | 'instagram' | 'facebook' | 'website' {
+  try {
+    const host = new URL(url).hostname.replace(/^www\./, '');
+    if (host === 'linkedin.com' || host.endsWith('.linkedin.com')) return 'linkedin';
+    if (host === 'x.com' || host === 'twitter.com') return 'x';
+    if (host === 'instagram.com') return 'instagram';
+    if (host === 'facebook.com') return 'facebook';
+    return 'website';
+  } catch { return 'website'; }
+}
 const MAX_PENDING_SCREENSHOTS = 20;
 const pendingScreenshots = new Map<string, { buf: Buffer; tabUrl: string | null }>();
 
@@ -232,30 +244,52 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
     req.on('data', (chunk: Buffer) => { raw += chunk.toString('utf-8'); });
     req.on('end', () => {
       try {
-        const { name, organization, email, phone } = JSON.parse(raw);
+        const { name, organization, title, email, phone, url } = JSON.parse(raw);
         if (!name || typeof name !== 'string' || !name.trim()) {
           json(res, 400, { error: 'name_required' });
           return;
         }
         const db = getDatabase();
-        const { phone_country: phoneCountry = 'US' } = db
-          .prepare('SELECT phone_country FROM users WHERE id = 1')
-          .get() as { phone_country: string };
+        const { phone_country: phoneCountry = 'US', wayback_enabled: waybackEnabled = 0, archive_access_key: archiveAccessKey = null, archive_secret_key: archiveSecretKey = null } = db
+          .prepare('SELECT phone_country, wayback_enabled, archive_access_key, archive_secret_key FROM users WHERE id = 1')
+          .get() as { phone_country: string; wayback_enabled: number; archive_access_key: string | null; archive_secret_key: string | null };
+        const rawEmail = (email as string | undefined)?.trim() || null;
+        if (rawEmail && !validateEmail(rawEmail)) {
+          json(res, 400, { error: 'Email address is invalid.' }); return;
+        }
+        const rawPhone = (phone as string | undefined)?.trim() || null;
+        let normalizedPhone: string | null = null;
+        if (rawPhone) {
+          normalizedPhone = normalizePhone(rawPhone, phoneCountry);
+          if (!normalizedPhone) { json(res, 400, { error: 'Phone number is invalid.' }); return; }
+        }
+        const rawUrl = (url as string | undefined)?.trim() || null;
+        if (rawUrl && !validateUrl(rawUrl)) {
+          json(res, 400, { error: 'URL is invalid.' }); return;
+        }
         const contactId = randomUUID();
         const now = Math.floor(Date.now() / 1000);
         db.prepare(
-          'INSERT INTO contacts (id, name, organization, title, notes, created_at, updated_at) VALUES (?, ?, ?, NULL, NULL, ?, ?)'
-        ).run(contactId, name.trim(), (organization as string | undefined)?.trim() || null, now, now);
-        if ((email as string | undefined)?.trim()) {
+          'INSERT INTO contacts (id, name, organization, title, notes, created_at, updated_at) VALUES (?, ?, ?, ?, NULL, ?, ?)'
+        ).run(contactId, name.trim(), (organization as string | undefined)?.trim() || null, (title as string | undefined)?.trim() || null, now, now);
+        if (rawEmail) {
           db.prepare(
             'INSERT INTO contact_emails (id, contact_id, email, sort_order, created_at) VALUES (?, ?, ?, 0, ?)'
-          ).run(randomUUID(), contactId, normalizeEmail((email as string).trim()), now);
+          ).run(randomUUID(), contactId, normalizeEmail(rawEmail), now);
         }
-        if ((phone as string | undefined)?.trim()) {
-          const rawPhone = (phone as string).trim();
+        if (normalizedPhone) {
           db.prepare(
             'INSERT INTO contact_phones (id, contact_id, phone, sort_order, created_at) VALUES (?, ?, ?, 0, ?)'
-          ).run(randomUUID(), contactId, normalizePhone(rawPhone, phoneCountry) ?? rawPhone, now);
+          ).run(randomUUID(), contactId, normalizedPhone, now);
+        }
+        if (rawUrl) {
+          const linkType = detectLinkType(rawUrl);
+          db.prepare(
+            'INSERT INTO contact_links (id, contact_id, type, label, url, sort_order, created_at) VALUES (?, ?, ?, NULL, ?, 0, ?)'
+          ).run(randomUUID(), contactId, linkType, rawUrl, now);
+          if (waybackEnabled && archiveAccessKey && archiveSecretKey && linkType === 'website') {
+            triggerWaybackSave(contactId, rawUrl).catch(() => {});
+          }
         }
         json(res, 200, { id: contactId, name: name.trim() });
       } catch (err) {
@@ -283,12 +317,15 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
           .get() as { phone_country: string };
         const now = Math.floor(Date.now() / 1000);
         if (fieldType === 'email') {
+          if (!validateEmail(value.trim())) { json(res, 400, { error: 'Email address is invalid.' }); return; }
           const row = db.prepare('SELECT MAX(sort_order) AS m FROM contact_emails WHERE contact_id = ?').get(contactId) as { m: number | null };
           db.prepare('INSERT INTO contact_emails (id, contact_id, email, sort_order, created_at) VALUES (?, ?, ?, ?, ?)').run(randomUUID(), contactId, normalizeEmail(value.trim()), (row.m ?? -1) + 1, now);
         } else if (fieldType === 'phone') {
           const rawPhone = value.trim();
+          const normalizedPhone = normalizePhone(rawPhone, phoneCountry);
+          if (!normalizedPhone) { json(res, 400, { error: 'Phone number is invalid.' }); return; }
           const row = db.prepare('SELECT MAX(sort_order) AS m FROM contact_phones WHERE contact_id = ?').get(contactId) as { m: number | null };
-          db.prepare('INSERT INTO contact_phones (id, contact_id, phone, sort_order, created_at) VALUES (?, ?, ?, ?, ?)').run(randomUUID(), contactId, normalizePhone(rawPhone, phoneCountry) ?? rawPhone, (row.m ?? -1) + 1, now);
+          db.prepare('INSERT INTO contact_phones (id, contact_id, phone, sort_order, created_at) VALUES (?, ?, ?, ?, ?)').run(randomUUID(), contactId, normalizedPhone, (row.m ?? -1) + 1, now);
         } else if (fieldType === 'note') {
           const existing = (db.prepare('SELECT notes FROM contacts WHERE id = ?').get(contactId) as { notes: string | null }).notes;
           const updated = existing ? `${existing}\n\n${value.trim()}` : value.trim();

--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -16,7 +16,8 @@ export function registerAppHandlers(): void {
         `SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
                 phone_country, outreach_reminders_enabled, outreach_require_interaction,
                 staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
-                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled
+                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
+                archive_access_key, archive_secret_key
          FROM users WHERE id = 1`,
       )
       .get() as User;

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -29,7 +29,7 @@ import type { DuplicatePair } from '@shared/types';
 let cachedPairs: DuplicatePair[] = [];
 let dedupScanTimer: ReturnType<typeof setTimeout> | null = null;
 
-async function triggerWaybackSave(contactId: string, url: string): Promise<void> {
+export async function triggerWaybackSave(contactId: string, url: string): Promise<void> {
   console.log(`[wayback] Requesting archive for ${url}`);
   const broadcast = (status: 'pending' | 'failed') => {
     for (const win of BrowserWindow.getAllWindows()) {
@@ -39,29 +39,77 @@ async function triggerWaybackSave(contactId: string, url: string): Promise<void>
 
   broadcast('pending');
   try {
-    const response = await net.fetch(`https://web.archive.org/save/${encodeURIComponent(url)}`, {
-      redirect: 'follow',
-      headers: { 'User-Agent': 'Sourcerer/1.0' },
-    });
-    const waybackUrl = response.url;
-    console.log(`[wayback] Response status=${response.status} url=${waybackUrl}`);
-    if (!response.ok) {
-      console.warn(`[wayback] Archive request failed with HTTP ${response.status} for ${url}`);
+    // Require Archive.org S3 credentials — SPN2 rejects unauthenticated requests
+    const { archive_access_key: accessKey, archive_secret_key: secretKey } = getDatabase()
+      .prepare('SELECT archive_access_key, archive_secret_key FROM users WHERE id = 1')
+      .get() as { archive_access_key: string | null; archive_secret_key: string | null };
+    if (!accessKey || !secretKey) {
+      console.warn('[wayback] Skipping: no Archive.org API keys configured in Settings.');
       broadcast('failed');
       return;
     }
-    if (waybackUrl.includes('web.archive.org/web/') && isDatabaseOpen()) {
-      getDatabase()
-        .prepare("UPDATE contact_links SET wayback_url = ? WHERE contact_id = ? AND type = 'website' AND url = ?")
-        .run(waybackUrl, contactId, url);
-      console.log(`[wayback] Saved snapshot for ${url} → ${waybackUrl}`);
-      for (const win of BrowserWindow.getAllWindows()) {
-        win.webContents.send('contacts:wayback-updated', contactId);
-      }
-    } else {
-      console.warn(`[wayback] Unexpected response URL, snapshot not saved: ${waybackUrl}`);
+
+    // SPN2 API: POST capture request, returns { job_id }
+    const submitRes = await net.fetch('https://web.archive.org/save', {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Authorization': `LOW ${accessKey}:${secretKey}`,
+        'User-Agent': 'Sourcerer/1.0',
+      },
+      body: `url=${encodeURIComponent(url)}`,
+    });
+    if (!submitRes.ok) {
+      console.warn(`[wayback] Capture request failed with HTTP ${submitRes.status} for ${url}`);
       broadcast('failed');
+      return;
     }
+    const { job_id } = await submitRes.json() as { job_id?: string };
+    if (!job_id) {
+      console.warn(`[wayback] No job_id in response for ${url}`);
+      broadcast('failed');
+      return;
+    }
+    console.log(`[wayback] Job started: ${job_id}`);
+
+    // Poll /save/status/<job_id> until success, error, or timeout (~2.5 min)
+    for (let attempt = 0; attempt < 30; attempt++) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 5000));
+      const statusRes = await net.fetch(`https://web.archive.org/save/status/${job_id}`, {
+        headers: {
+          'Accept': 'application/json',
+          'Authorization': `LOW ${accessKey}:${secretKey}`,
+          'User-Agent': 'Sourcerer/1.0',
+        },
+      });
+      const rawBody = await statusRes.text();
+      if (!statusRes.ok) { console.warn(`[wayback] Poll ${attempt + 1}: HTTP ${statusRes.status}`); continue; }
+      let data: { status?: string; timestamp?: string; original_url?: string; message?: string };
+      try { data = JSON.parse(rawBody); } catch { console.warn(`[wayback] Poll ${attempt + 1}: non-JSON response`); continue; }
+      console.log(`[wayback] Poll ${attempt + 1}: status=${data.status}`);
+      if (data.status === 'success' && data.timestamp && data.original_url) {
+        const waybackUrl = `https://web.archive.org/web/${data.timestamp}/${data.original_url}`;
+        if (isDatabaseOpen()) {
+          getDatabase()
+            .prepare("UPDATE contact_links SET wayback_url = ? WHERE contact_id = ? AND type = 'website' AND url = ?")
+            .run(waybackUrl, contactId, url);
+          console.log(`[wayback] Saved snapshot for ${url} → ${waybackUrl}`);
+          for (const win of BrowserWindow.getAllWindows()) {
+            win.webContents.send('contacts:wayback-updated', contactId);
+          }
+        }
+        return;
+      }
+      if (data.status === 'error') {
+        console.warn(`[wayback] Capture error for ${url}: ${data.message ?? 'unknown'}`);
+        broadcast('failed');
+        return;
+      }
+      // status === 'pending' — keep polling
+    }
+    console.warn(`[wayback] Timed out waiting for archive of ${url}`);
+    broadcast('failed');
   } catch (err) {
     console.error(`[wayback] Failed to archive ${url}:`, err);
     broadcast('failed');

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -130,6 +130,9 @@ export function registerSettingsHandlers(): void {
   });
 
   ipcMain.handle('settings:set-archive-keys', (_, { accessKey, secretKey }: { accessKey: string; secretKey: string }): User => {
+    if (typeof accessKey !== 'string' || typeof secretKey !== 'string') {
+      throw new Error('Invalid archive key payload');
+    }
     const db = getDatabase();
     db.prepare('UPDATE users SET archive_access_key = ?, archive_secret_key = ? WHERE id = 1')
       .run(accessKey.trim() || null, secretKey.trim() || null);

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -129,6 +129,13 @@ export function registerSettingsHandlers(): void {
     return db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
   });
 
+  ipcMain.handle('settings:set-archive-keys', (_, { accessKey, secretKey }: { accessKey: string; secretKey: string }): User => {
+    const db = getDatabase();
+    db.prepare('UPDATE users SET archive_access_key = ?, archive_secret_key = ? WHERE id = 1')
+      .run(accessKey.trim() || null, secretKey.trim() || null);
+    return db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
+  });
+
   ipcMain.handle(
     'settings:change-password',
     async (_, { currentPassword, newPassword }: { currentPassword: string; newPassword: string }): Promise<{ success: boolean; error?: string }> => {
@@ -202,7 +209,8 @@ export function registerSettingsHandlers(): void {
         `SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
                 phone_country, outreach_reminders_enabled, outreach_require_interaction,
                 staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
-                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled
+                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
+                archive_access_key, archive_secret_key
          FROM users WHERE id = 1`,
       )
       .get() as User;

--- a/src/main/sanitize.ts
+++ b/src/main/sanitize.ts
@@ -32,3 +32,14 @@ export function validateUrl(raw: string): boolean {
     return false;
   }
 }
+
+export function detectLinkType(url: string): 'linkedin' | 'x' | 'instagram' | 'facebook' | 'website' {
+  try {
+    const host = new URL(url).hostname.replace(/^www\./, '');
+    if (host === 'linkedin.com' || host.endsWith('.linkedin.com')) return 'linkedin';
+    if (host === 'x.com' || host === 'twitter.com') return 'x';
+    if (host === 'instagram.com') return 'instagram';
+    if (host === 'facebook.com') return 'facebook';
+    return 'website';
+  } catch { return 'website'; }
+}

--- a/src/main/sanitize.ts
+++ b/src/main/sanitize.ts
@@ -36,10 +36,11 @@ export function validateUrl(raw: string): boolean {
 export function detectLinkType(url: string): 'linkedin' | 'x' | 'instagram' | 'facebook' | 'website' {
   try {
     const host = new URL(url).hostname.replace(/^www\./, '');
-    if (host === 'linkedin.com' || host.endsWith('.linkedin.com')) return 'linkedin';
-    if (host === 'x.com' || host === 'twitter.com') return 'x';
-    if (host === 'instagram.com') return 'instagram';
-    if (host === 'facebook.com') return 'facebook';
+    if (host === 'linkedin.com'  || host.endsWith('.linkedin.com'))  return 'linkedin';
+    if (host === 'x.com'         || host.endsWith('.x.com')
+     || host === 'twitter.com'   || host.endsWith('.twitter.com'))   return 'x';
+    if (host === 'instagram.com' || host.endsWith('.instagram.com')) return 'instagram';
+    if (host === 'facebook.com'  || host.endsWith('.facebook.com'))  return 'facebook';
     return 'website';
   } catch { return 'website'; }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -172,6 +172,8 @@ const sourcererApi = {
     ipcRenderer.invoke('settings:set-rss-poll-interval', hours),
   setWaybackEnabled: (enabled: boolean): Promise<User> =>
     ipcRenderer.invoke('settings:set-wayback-enabled', enabled),
+  setArchiveKeys: (accessKey: string, secretKey: string): Promise<User> =>
+    ipcRenderer.invoke('settings:set-archive-keys', { accessKey, secretKey }),
   setAlertNotificationsEnabled: (enabled: boolean): Promise<User> =>
     ipcRenderer.invoke('settings:set-alert-notifications-enabled', enabled),
   setReminderNotificationsEnabled: (enabled: boolean): Promise<User> =>

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -805,7 +805,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                 })
             )}
           />
-          {user?.wayback_enabled !== 0 && (
+          {user?.wayback_enabled !== 0 && user?.archive_access_key && user?.archive_secret_key && (
             <p className="ac-field-hint">Wayback Machine archiving is enabled.</p>
           )}
         </div>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -128,6 +128,7 @@ declare global {
       setReminderNotificationsEnabled: (enabled: boolean) => Promise<User>;
       setRssPollInterval: (hours: number) => Promise<User>;
       setWaybackEnabled: (enabled: boolean) => Promise<User>;
+      setArchiveKeys: (accessKey: string, secretKey: string) => Promise<User>;
       setPriorityInterval: (id: string, days: number | null) => Promise<void>;
       getCalendarUrl: () => Promise<string>;
       regenerateCalendarToken: () => Promise<User>;

--- a/src/renderer/src/views/SettingsView.css
+++ b/src/renderer/src/views/SettingsView.css
@@ -116,6 +116,12 @@
   box-shadow: 0 0 0 3px rgba(29, 78, 216, 0.1);
 }
 
+.sv-input:disabled,
+.sv-select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .sv-profile-actions {
   display: flex;
   justify-content: flex-end;
@@ -305,6 +311,15 @@
 
 .sv-hint code {
   font-size: 0.85em;
+}
+
+.sv-hint a {
+  color: var(--color-text-dim);
+  text-decoration: underline;
+}
+
+.sv-hint a:hover {
+  color: var(--color-text);
 }
 
 .sv-inline-field {
@@ -546,6 +561,22 @@
 
 .sv-field--inline-row {
   flex-direction: column;
+}
+
+.sv-key-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.sv-key-row .sv-field {
+  flex: 1;
+}
+
+.sv-hint--top {
+  margin-top: 10px;
+  margin-bottom: 0;
 }
 
 .sv-inline-actions {

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -580,10 +580,10 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
               <label className="sv-label">Archive.org access key</label>
               <input
                 className="sv-input"
-                type="text"
+                type="password"
                 value={archiveAccessKey}
                 onChange={(e) => setArchiveAccessKey(e.target.value)}
-                autoComplete="off"
+                autoComplete="new-password"
                 disabled={!waybackEnabled}
               />
             </div>

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -80,6 +80,10 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
   const [panicWiping, setPanicWiping] = useState(false);
   const [screenshotFolderBytes, setScreenshotFolderBytes] = useState<number>(0);
 
+  const [archiveAccessKey, setArchiveAccessKey] = useState('');
+  const [archiveSecretKey, setArchiveSecretKey] = useState('');
+  const [archiveKeysSaved, setArchiveKeysSaved] = useState(false);
+
   const [autoBackupEnabled, setAutoBackupEnabled] = useState(false);
   const [autoBackupDestPath, setAutoBackupDestPath] = useState<string | null>(null);
   const [autoBackupMaxCount, setAutoBackupMaxCount] = useState(10);
@@ -113,6 +117,8 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
       setStalenessThresholdInput(String(user.staleness_threshold_days ?? 90));
       setRssPollIntervalHours(user.rss_poll_interval_hours ?? 6);
       setWaybackEnabled(user.wayback_enabled !== 0);
+      setArchiveAccessKey(user.archive_access_key ?? '');
+      setArchiveSecretKey(user.archive_secret_key ?? '');
     }
     window.sourcerer.getIdleTimeout().then(setIdleTimeout);
     window.sourcerer.getCalendarUrl().then(setCalendarUrl);
@@ -246,6 +252,13 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
     setWaybackEnabled(enabled);
     const updated = await window.sourcerer.setWaybackEnabled(enabled);
     onUserUpdated(updated);
+  }
+
+  async function handleArchiveKeysSave() {
+    const updated = await window.sourcerer.setArchiveKeys(archiveAccessKey, archiveSecretKey);
+    onUserUpdated(updated);
+    setArchiveKeysSaved(true);
+    setTimeout(() => setArchiveKeysSaved(false), 2000);
   }
 
   async function handleReminderNotificationsToggle(enabled: boolean) {
@@ -562,6 +575,43 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
             onChange={handleWaybackToggle}
             label="Submit URLs to the Wayback Machine"
           />
+          <div className="sv-key-row">
+            <div className="sv-field">
+              <label className="sv-label">Archive.org access key</label>
+              <input
+                className="sv-input"
+                type="text"
+                value={archiveAccessKey}
+                onChange={(e) => setArchiveAccessKey(e.target.value)}
+                autoComplete="off"
+                disabled={!waybackEnabled}
+              />
+            </div>
+            <div className="sv-field">
+              <label className="sv-label">Archive.org secret key</label>
+              <input
+                className="sv-input"
+                type="password"
+                value={archiveSecretKey}
+                onChange={(e) => setArchiveSecretKey(e.target.value)}
+                autoComplete="new-password"
+                disabled={!waybackEnabled}
+              />
+            </div>
+            <button className="sv-save-btn" onClick={handleArchiveKeysSave} disabled={!waybackEnabled}>
+              Save keys
+            </button>
+          </div>
+          {archiveKeysSaved && (
+            <p className="sv-success">Keys saved.</p>
+          )}
+          <p className="sv-hint sv-hint--top">
+            Required for Wayback Machine submissions. Get your keys at{' '}
+            <a href="https://archive.org/account/s3.php" target="_blank" rel="noreferrer">
+              archive.org/account/s3.php
+            </a>
+            . Keys are stored encrypted in your local database.
+          </p>
         </div>
 
         {/* Calendar */}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -50,6 +50,8 @@ export interface User {
   reminder_notifications_enabled: 0 | 1;
   rss_poll_interval_hours: number;
   wayback_enabled: 0 | 1;
+  archive_access_key: string | null;
+  archive_secret_key: string | null;
   auto_backup_enabled: 0 | 1;
   auto_backup_dest_path: string | null;
   auto_backup_max_count: number;

--- a/src/test/sanitize.test.ts
+++ b/src/test/sanitize.test.ts
@@ -4,6 +4,7 @@ import {
   validateEmail,
   normalizePhone,
   validateUrl,
+  detectLinkType,
 } from '../main/sanitize';
 
 describe('normalizeEmail', () => {
@@ -158,5 +159,43 @@ describe('validateUrl', () => {
 
   it('trims leading/trailing whitespace before validating', () => {
     expect(validateUrl('  https://example.com  ')).toBe(true);
+  });
+});
+
+describe('detectLinkType', () => {
+  it('detects linkedin.com', () => {
+    expect(detectLinkType('https://linkedin.com/in/someone')).toBe('linkedin');
+  });
+
+  it('detects linkedin.com with www prefix', () => {
+    expect(detectLinkType('https://www.linkedin.com/in/someone')).toBe('linkedin');
+  });
+
+  it('detects linkedin subdomains', () => {
+    expect(detectLinkType('https://ca.linkedin.com/in/someone')).toBe('linkedin');
+  });
+
+  it('detects x.com', () => {
+    expect(detectLinkType('https://x.com/someone')).toBe('x');
+  });
+
+  it('detects twitter.com', () => {
+    expect(detectLinkType('https://twitter.com/someone')).toBe('x');
+  });
+
+  it('detects instagram.com', () => {
+    expect(detectLinkType('https://instagram.com/someone')).toBe('instagram');
+  });
+
+  it('detects facebook.com', () => {
+    expect(detectLinkType('https://facebook.com/someone')).toBe('facebook');
+  });
+
+  it('returns website for an arbitrary URL', () => {
+    expect(detectLinkType('https://example.com')).toBe('website');
+  });
+
+  it('returns website for a malformed URL', () => {
+    expect(detectLinkType('not a url')).toBe('website');
   });
 });

--- a/src/test/sanitize.test.ts
+++ b/src/test/sanitize.test.ts
@@ -183,12 +183,24 @@ describe('detectLinkType', () => {
     expect(detectLinkType('https://twitter.com/someone')).toBe('x');
   });
 
+  it('detects mobile.twitter.com', () => {
+    expect(detectLinkType('https://mobile.twitter.com/someone')).toBe('x');
+  });
+
   it('detects instagram.com', () => {
     expect(detectLinkType('https://instagram.com/someone')).toBe('instagram');
   });
 
+  it('detects instagram subdomains', () => {
+    expect(detectLinkType('https://www.instagram.com/someone')).toBe('instagram');
+  });
+
   it('detects facebook.com', () => {
     expect(detectLinkType('https://facebook.com/someone')).toBe('facebook');
+  });
+
+  it('detects m.facebook.com', () => {
+    expect(detectLinkType('https://m.facebook.com/someone')).toBe('facebook');
   });
 
   it('returns website for an arbitrary URL', () => {


### PR DESCRIPTION
## Summary

- **Extension schema sync**: adds Title/Role and Source URL fields to the new-contact form; Source URL pre-fills from the active browser tab; empty state added to contact list; human-readable validation errors surfaced from server for invalid email/phone/URL
- **Wayback Machine rewrite**: replaces the broken redirect-following GET with the SPN2 async job API (POST to submit → poll with auth header until `success`/`error`/timeout); auth header is now also required on status poll requests (root cause of `status=undefined`)
- **Archive.org S3 keys**: new `archive_access_key` / `archive_secret_key` columns on `users`; Settings UI adds key inputs (disabled when toggle is off, styled to match profile fields); archiving is gated on toggle + both keys being set throughout (http-server, contacts IPC, contact detail hint)
- **Link type detection**: `detectLinkType()` in http-server classifies saved URLs as `linkedin`, `x`, `instagram`, `facebook`, or `website`; Wayback only fires for `website` links, consistent with main app behaviour

## Test plan

- [x] Add a contact via extension with Title, Email, Phone, and a source URL — verify all fields land correctly in Sourcerer
- [x] Test invalid email/phone/URL in extension new-contact form — verify human-readable error appears
- [x] Enable Wayback in Settings, enter Archive.org S3 keys, save a contact with a website URL — verify snapshot appears on the contact
- [x] Verify Wayback hint in contact detail only appears when toggle is on AND both keys are set
- [x] Disable Wayback toggle — verify key inputs and save button are grayed out
- [x] Verify contact list empty state appears in extension when there are no contacts or no search matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)