### PR TITLE
Allow text selection in contact detail panel

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -50,6 +50,18 @@ function createWindow(): BrowserWindow {
 
   win.on('ready-to-show', () => win.show());
 
+  win.webContents.on('context-menu', (_e, params) => {
+    const items: Electron.MenuItemConstructorOptions[] = [];
+    if (params.selectionText.trim()) {
+      items.push({ role: 'copy' });
+    }
+    if (params.isEditable) {
+      if (items.length) items.push({ type: 'separator' });
+      items.push({ role: 'cut' }, { role: 'paste' });
+    }
+    if (items.length) Menu.buildFromTemplate(items).popup({ window: win });
+  });
+
   win.webContents.setWindowOpenHandler((details) => {
     try {
       const parsed = new URL(details.url);

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -122,6 +122,11 @@
   user-select: text;
 }
 
+.detail-body button,
+.detail-body label {
+  user-select: none;
+}
+
 .detail-section {
   margin-bottom: 18px;
 }

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -123,7 +123,11 @@
 }
 
 .detail-body button,
-.detail-body label {
+.detail-body label,
+.detail-section-label,
+.detail-phone-label,
+.detail-wayback-pending,
+.detail-wayback-failed {
   user-select: none;
 }
 

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -119,6 +119,7 @@
   flex: 1;
   overflow-y: auto;
   padding: 12px 16px 20px;
+  user-select: text;
 }
 
 .detail-section {


### PR DESCRIPTION
## Summary

- `body { user-select: none }` in `global.css` disables selection app-wide (intentional for navigation/chrome). Adding `user-select: text` to `.detail-body` re-enables it scoped to the scrollable contact detail content area only.
- The two existing `user-select: none` rules inside `ContactDetail.css` are on screenshot viewer images and are unaffected.
- Right-click context menu added via `webContents.on('context-menu')` in the main process: shows Copy when text is selected, Cut/Paste on editable fields, and nothing otherwise (so right-clicking nav/buttons stays silent).

## Test plan

- [x] Open a contact and verify you can click-drag to select name, org, emails, phones, URLs, notes, and log entries
- [x] Verify Cmd+C copies the selection correctly
- [x] Right-click on selected text — verify a Copy menu appears
- [x] Right-click on an input field — verify Cut/Paste appear
- [x] Right-click on a button or nav area — verify no menu appears
- [x] Verify sidebar, project list, and other nav areas remain non-selectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)