### PR TITLE
Add shields, direct download links, and Wayback API key docs

### DIFF
--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -7,20 +7,26 @@
 ## Installation
 
 ### macOS
-Download **`Sourcerer-{version}-arm64.dmg`**, open it, and drag Sourcerer to your Applications folder.
+**[Download Sourcerer-{version}-arm64.dmg](https://github.com/tomcardoso/sourcerer/releases/download/v{version}/Sourcerer-{version}-arm64.dmg)**
+
+Open the `.dmg` and drag Sourcerer to your Applications folder.
 
 > **First launch:** macOS may show a security warning. Go to **System Settings → Privacy & Security** and click **Open Anyway**, or right-click the app and choose **Open**.
 
 ### Linux
-Download the **`.AppImage`** file for this release, make it executable, and run it:
+**[Download Sourcerer-{version}.AppImage](https://github.com/tomcardoso/sourcerer/releases/download/v{version}/Sourcerer-{version}.AppImage)**
+
+Make it executable and run it:
 
 ```bash
-chmod +x Sourcerer-{version}*.AppImage
-./Sourcerer-{version}*.AppImage
+chmod +x Sourcerer-{version}.AppImage
+./Sourcerer-{version}.AppImage
 ```
 
 ### Windows
-Download **`Sourcerer Setup {version}.exe`** and run the installer.
+**[Download Sourcerer.Setup.{version}.exe](https://github.com/tomcardoso/sourcerer/releases/download/v{version}/Sourcerer.Setup.{version}.exe)**
+
+Run the installer.
 
 > **Note:** Windows may display a SmartScreen warning. Click **More info → Run anyway** to proceed.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Source and contact management for journalists and researchers — local-first, encrypted, no cloud.
 
+[![Latest release](https://img.shields.io/github/v/release/tomcardoso/sourcerer?label=version&color=4b5563)](https://github.com/tomcardoso/sourcerer/releases/latest)
+[![Build](https://img.shields.io/github/actions/workflow/status/tomcardoso/sourcerer/build.yml?label=build)](https://github.com/tomcardoso/sourcerer/actions/workflows/build.yml)
+[![License: AGPL-3.0](https://img.shields.io/github/license/tomcardoso/sourcerer?color=4b5563)](LICENSE)
+
 ![screenshot](docs/img/contact-details-2.png)
 
 _All names and details in the screenshot are fictional and generated for demonstration purposes only._
@@ -51,7 +55,7 @@ A Chrome extension captures full-page screenshots from any browser tab and links
 
 **Alerts**
 - RSS feed monitoring per contact; new mentions surfaced in a notification centre
-- Optional Wayback Machine snapshot on link save
+- Optional Wayback Machine snapshot on link save (requires free Archive.org S3 API keys)
 
 **Security**
 - AES-256 encryption via SQLCipher; master password derived with Argon2id
@@ -132,7 +136,7 @@ npm run rebuild        # restore Electron-targeted binaries before npm run dev
 
 ## Security notes
 
-- No network requests are made except: user-configured RSS feeds, optional Wayback Machine saves, and the local HTTP server that receives screenshots from the Chrome extension (localhost only, one-time token auth).
+- No network requests are made except: user-configured RSS feeds, optional Wayback Machine saves (requires Archive.org S3 API keys configured in Settings), and the local HTTP server that receives screenshots from the Chrome extension (localhost only, one-time token auth).
 - The master password cannot be recovered. Use a passphrase — four random words are easier to remember and just as strong as a complex string.
 - The Chrome extension communicates only with localhost and requires explicit one-time approval in the app.
 

--- a/docs/extension.html
+++ b/docs/extension.html
@@ -96,7 +96,8 @@
 
           <section id="new-contact">
             <h2>Adding a new contact</h2>
-            <p>Click <strong>New contact</strong> in the popup. Fill in the name (required), organisation, email, and phone fields, then click <strong>Add contact</strong>. The contact is created in your encrypted local database immediately.</p>
+            <p>Click <strong>New contact</strong> in the popup. Fill in the name (required), organisation, title/role, email, phone, and source URL, then click <strong>Add contact</strong>. The contact is created in your encrypted local database immediately.</p>
+            <p>The <strong>Source URL</strong> field pre-fills with the current tab's URL automatically. If you have <a href="guide.html#alerts">Wayback Machine archiving</a> enabled and configured in Sourcerer, saving a website URL will submit it to the Internet Archive in the background — the snapshot URL is then saved to the contact record.</p>
             <p>You can then open the app to add more details, link to a project, or take a screenshot.</p>
           </section>
 

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -206,7 +206,14 @@
             <p>The Alerts view shows all recent mentions across all your contacts, sorted by recency. Each item shows the article title, publication date, the source it is linked to, and the feed it came from.</p>
 
             <h3>Wayback Machine snapshots</h3>
-            <p>When saving a link in the alerts view, you can optionally trigger a Wayback Machine snapshot. This archives the page at the Internet Archive so you have a permanent record even if the original URL disappears.</p>
+            <p>When saving a website link on a contact, Sourcerer can optionally submit it to the <a href="https://web.archive.org" target="_blank" rel="noopener">Internet Archive's Wayback Machine</a>. This creates a permanent public snapshot of the page so you have a record even if the original URL disappears. The snapshot URL is saved to the contact and shown alongside the link.</p>
+            <p>Wayback archiving uses the <a href="https://docs.google.com/document/d/1Nsv52MvSjbLb2PCpHlat0gkzw0EvtSgpKHu4mk0MnrA/" target="_blank" rel="noopener">Save Page Now 2 (SPN2) API</a>, which requires free Archive.org S3 API keys. To set up archiving:</p>
+            <ol>
+              <li>Create a free account at <a href="https://archive.org" target="_blank" rel="noopener">archive.org</a>.</li>
+              <li>Visit <a href="https://archive.org/account/s3.php" target="_blank" rel="noopener">archive.org/account/s3.php</a> to generate your access key and secret key.</li>
+              <li>In Sourcerer, go to <strong>Settings → Website archiving</strong>, enable the toggle, and enter both keys.</li>
+            </ol>
+            <p>Archiving only fires for generic website links — social media profile URLs (LinkedIn, X, Instagram, Facebook) are excluded. Note that submitted URLs become public records on archive.org.</p>
           </section>
 
           <section id="import-export">

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sourcerer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Capture screenshots, save selected text as contact fields, and add new contacts to Sourcerer — the encrypted source management app.",
   "permissions": ["tabs", "storage", "activeTab", "scripting", "contextMenus"],
   "host_permissions": ["http://127.0.0.1:27371/*"],


### PR DESCRIPTION
## Summary

- **README**: adds version, build, and license shields; notes Archive.org S3 API keys requirement in Wayback bullet and security section
- **release-template.md**: adds direct per-platform download links with confirmed asset filenames (`Sourcerer-{version}-arm64.dmg`, `Sourcerer-{version}.AppImage`, `Sourcerer.Setup.{version}.exe`)
- **docs/guide.html**: expands Wayback Machine section from a stub into full setup instructions with numbered steps, links to archive.org account page and SPN2 docs, note about social media exclusion
- **docs/extension.html**: updates new-contact section to mention Title/Role field, Source URL auto-fill from active tab, and Wayback archiving behaviour

## Test plan

- [x] Shields render correctly on GitHub README (version, build status, license)
- [x] Release template download links resolve to correct assets on an existing release (e.g. v0.1.8)
- [x] Wayback setup steps in guide.html are accurate end-to-end
- [x] Extension new-contact section reflects current popup fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)