### PR TITLE
0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sourcerer",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sourcerer",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcerer",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "description": "Encrypted source management for journalists",
   "author": "Tom Cardoso",


### PR DESCRIPTION
Version bump to 0.1.9.

## What's new

- **Wayback Machine archiving**: Save website URLs from the extension or contact detail and automatically submit them to the Internet Archive. Requires free Archive.org S3 API keys configured in Settings.
- **Extension v1.1.0**: New contact form now includes Title/Role and Organization fields; Source URL auto-fills from the active tab.
- **Text selection in contact detail**: Names, emails, phones, notes, and links are now selectable and copyable via right-click.
- **Shields and docs**: README shields for version, build status, and license; expanded Wayback setup guide; direct download links in release notes template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)