### PR TITLE
Fix macOS auto-updater + add electron-log

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,7 @@ jobs:
           name: dist-${{ matrix.os }}
           path: |
             dist-electron/*.dmg
+            dist-electron/*.zip
             dist-electron/*.blockmap
             dist-electron/latest-mac.yml
           retention-days: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
           path: |
             dist-electron/*.dmg
             dist-electron/*.zip
-            dist-electron/*.blockmap
+            dist-electron/*.zip.blockmap
             dist-electron/latest-mac.yml
           retention-days: 5
           if-no-files-found: error

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@electron-toolkit/utils": "^3.0.0",
         "argon2": "^0.41.1",
         "better-sqlite3-multiple-ciphers": "^12.9.0",
+        "electron-log": "^5.4.4",
         "electron-updater": "^6.8.3",
         "libphonenumber-js": "^1.12.42",
         "qrcode": "^1.5.4",
@@ -3759,6 +3760,15 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.4.tgz",
+      "integrity": "sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-publish": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,12 @@
           "arch": [
             "arm64"
           ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "arm64"
+          ]
         }
       ],
       "category": "public.app-category.productivity",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@electron-toolkit/utils": "^3.0.0",
     "argon2": "^0.41.1",
     "better-sqlite3-multiple-ciphers": "^12.9.0",
+    "electron-log": "^5.4.4",
     "electron-updater": "^6.8.3",
     "libphonenumber-js": "^1.12.42",
     "qrcode": "^1.5.4",

--- a/src/main/ipc/updater.ts
+++ b/src/main/ipc/updater.ts
@@ -1,6 +1,10 @@
 import { app, BrowserWindow, dialog, ipcMain } from 'electron';
 import { is } from '@electron-toolkit/utils';
 import { autoUpdater } from 'electron-updater';
+import log from 'electron-log/main';
+
+log.initialize();
+autoUpdater.logger = log;
 
 // Cache the latest update event so renderers that mount after the event fires
 // (e.g. the user was on the lock screen when the 10 s auto-check fired) can
@@ -162,7 +166,14 @@ export function registerUpdaterHandlers(): void {
   });
 
   ipcMain.handle('update:check', () => autoUpdater.checkForUpdates());
-  ipcMain.handle('update:download', () => autoUpdater.downloadUpdate());
+  ipcMain.handle('update:download', () => {
+    // Mark cache as downloading immediately so an early error (before any
+    // progress events fire) is correctly classified and surfaced to the user.
+    if (cachedUpdateInfo) {
+      cachedUpdateInfo = { event: 'downloading', version: cachedUpdateInfo.version };
+    }
+    return autoUpdater.downloadUpdate();
+  });
   ipcMain.handle('update:quit-and-install', () => {
     autoUpdater.quitAndInstall(false, true);
   });

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -196,9 +196,11 @@ export default function AppShell() {
                 setUpdateState('downloading');
                 try {
                   await window.sourcerer.downloadUpdate();
-                } catch {
+                } catch (err) {
                   setUpdatePercent(null);
                   setUpdateState('available');
+                  const message = err instanceof Error ? err.message : String(err);
+                  window.sourcerer.showUpdateError(message);
                 }
               }}
             >


### PR DESCRIPTION
## Summary

- **Root cause fix**: `electron-updater` on macOS requires a ZIP artifact for in-app updates — the DMG is only for manual installation. Adds a `zip` target to the mac build config and uploads it in CI. Without this, clicking "Update available" always fails with `ERR_UPDATER_ZIP_FILE_NOT_FOUND`.
- **Logging**: Wires `electron-log` to `autoUpdater.logger` so update activity is written to `~/Library/Logs/Sourcerer/main.log` in production builds.
- **Silent error fix**: Sets `cachedUpdateInfo` to `'downloading'` before calling `downloadUpdate()` so early failures are correctly classified and shown to the user rather than swallowed silently. Also shows an error dialog from the renderer catch path as a second safety net.

## Test plan

- [ ] Install 0.1.9, then release 0.1.10 and confirm "Update available" → download → "Restart to update" flow works end to end
- [ ] Confirm `~/Library/Logs/Sourcerer/main.log` is created and contains updater output after launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)