### PR TITLE
0.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sourcerer",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sourcerer",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcerer",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "description": "Encrypted source management for journalists",
   "author": "Tom Cardoso",


### PR DESCRIPTION
Version bump to 0.1.10.

## What's new

- Fix macOS auto-updater: adds ZIP artifact required by electron-updater (DMG is for manual installation only)
- Add electron-log so update activity is written to `~/Library/Logs/Sourcerer/main.log` in production
- Surface silent download errors — failed updates now show an error dialog instead of the button silently resetting

🤖 Generated with [Claude Code](https://claude.com/claude-code)