### PR TITLE
Fix Firefox manifest version + rename extension to v1.1.1

### DIFF
--- a/extension/manifest.firefox.json
+++ b/extension/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
-  "name": "Sourcerer – Contact Manager",
-  "version": "1.1.0",
+  "name": "Sourcerer – Journalist Contact Management",
+  "version": "1.1.1",
   "description": "Capture full-page screenshots, save selected text as contact fields, and add new contacts to Sourcerer — the encrypted source management app for journalists.",
   "browser_specific_settings": {
     "gecko": {

--- a/extension/manifest.firefox.json
+++ b/extension/manifest.firefox.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Sourcerer – Contact Management for Journalists",
+  "name": "Sourcerer – Contact Manager",
   "version": "1.1.0",
   "description": "Capture full-page screenshots, save selected text as contact fields, and add new contacts to Sourcerer — the encrypted source management app for journalists.",
   "browser_specific_settings": {

--- a/extension/manifest.firefox.json
+++ b/extension/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sourcerer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Capture full-page screenshots, save selected text as contact fields, and add new contacts to Sourcerer — the encrypted source management app for journalists.",
   "browser_specific_settings": {
     "gecko": {

--- a/extension/manifest.firefox.json
+++ b/extension/manifest.firefox.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Sourcerer",
+  "name": "Sourcerer – Contact Management for Journalists",
   "version": "1.1.0",
   "description": "Capture full-page screenshots, save selected text as contact fields, and add new contacts to Sourcerer — the encrypted source management app for journalists.",
   "browser_specific_settings": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Sourcerer – Contact Management for Journalists",
+  "name": "Sourcerer – Contact Manager",
   "version": "1.1.0",
   "description": "Capture screenshots, save selected text as contact fields, and add new contacts to Sourcerer — the encrypted source management app.",
   "permissions": ["tabs", "storage", "activeTab", "scripting", "contextMenus"],

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
-  "name": "Sourcerer – Contact Manager",
-  "version": "1.1.0",
+  "name": "Sourcerer – Journalist Contact Management",
+  "version": "1.1.1",
   "description": "Capture screenshots, save selected text as contact fields, and add new contacts to Sourcerer — the encrypted source management app.",
   "permissions": ["tabs", "storage", "activeTab", "scripting", "contextMenus"],
   "host_permissions": ["http://127.0.0.1:27371/*"],

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Sourcerer",
+  "name": "Sourcerer – Contact Management for Journalists",
   "version": "1.1.0",
   "description": "Capture screenshots, save selected text as contact fields, and add new contacts to Sourcerer — the encrypted source management app.",
   "permissions": ["tabs", "storage", "activeTab", "scripting", "contextMenus"],


### PR DESCRIPTION
## Summary

- Fixes Firefox manifest version which was left at 1.0.0 when Chrome was bumped to 1.1.0
- Renames both manifests to "Sourcerer – Journalist Contact Management" (43 chars, within Chrome Web Store limit)
- Bumps both manifests to 1.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)