### PR TITLE
Fix workflow YAML syntax error

### DIFF
--- a/.github/scripts/extract-whats-new.py
+++ b/.github/scripts/extract-whats-new.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Extract the 'What's new' section from a GitHub PR body.
+
+Reads the PR body from stdin. Prints the content of the first
+'## What's new' section, stopping at the next heading, horizontal
+rule, or the Claude Code attribution line. Exits with no output if
+the section is not found.
+"""
+
+import re
+import sys
+
+body = sys.stdin.read()
+m = re.search(
+    r"(?i)##\s+What.s\s+new\s*\n(.*?)(?=\n##|\n---|\Z)",
+    body,
+    re.DOTALL,
+)
+if not m:
+    sys.exit(0)
+
+# Strip trailing boilerplate (e.g. "🤖 Generated with [Claude Code](...)")
+content = m.group(1).strip()
+content = re.sub(r"\n*🤖.*$", "", content, flags=re.DOTALL).strip()
+if content:
+    print(content)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,13 +162,7 @@ jobs:
             --json body \
             --jq '.[0].body // ""' 2>/dev/null || echo "")
           if [ -n "$PR_BODY" ]; then
-            WHATS_NEW=$(echo "$PR_BODY" | python3 -c "
-import sys, re
-body = sys.stdin.read()
-m = re.search(r\"(?i)##\s+What.s\s+new\s*\n(.*?)(?=\n##|\n---|🤖|\Z)\", body, re.DOTALL)
-if m:
-    print(m.group(1).strip())
-" 2>/dev/null || echo "")
+            WHATS_NEW=$(echo "$PR_BODY" | python3 .github/scripts/extract-whats-new.py 2>/dev/null || echo "")
             if [ -n "$WHATS_NEW" ]; then
               echo "$WHATS_NEW" > /tmp/generated-changelog.md
             fi


### PR DESCRIPTION
## Summary

The emoji character (`🤖`) in the inline `python3 -c` regex caused GitHub's YAML parser to reject the workflow file entirely, resulting in 0s failures on every push.

Moved the extraction logic to `.github/scripts/extract-whats-new.py` and call it from the workflow. Same behaviour, no inline Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)