### PR TITLE
Add plaintext DB export utility for dev inspection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,15 +88,23 @@ All design tokens are CSS custom properties defined in `src/renderer/src/global.
 | 11px | 0.14em | Buttons (global default), modal labels |
 | 12px | 0.10–0.12em | Sidebar items, slightly larger labels |
 
+**Components:**
+- Always use `CalendarPicker` (`src/renderer/src/views/CalendarPicker.tsx`) for any date input — never use `<input type="date">` (see issue #46 for outstanding cases)
+
 **Hard rules — do not break these:**
 - All interactive elements (buttons, inputs, selects, textareas) use `border-radius: 0` — square corners everywhere, no exceptions
 - Mono type is almost always `text-transform: uppercase` — exceptions only for body-level mono (e.g. code snippets)
 - Do not introduce colours outside the palette above; do not use system fonts or web-safe fallbacks
+- Never use inline styles. Always write a dedicated `.css` file co-located with the component
 
 ## Architecture notes
 
-- **IPC:** all database access happens in the main process; renderer communicates via typed IPC handlers in `src/main/ipc/`
-- **Schema + migrations:** `src/main/database/schema.ts` holds the full schema SQL; migrations use `user_version` as a counter (see `src/main/database/index.ts`)
+- **IPC:** all database access happens in the main process; renderer communicates via typed IPC handlers in `src/main/ipc/`. Each domain has a `register*Handlers()` function called from `src/main/index.ts` — new handlers always go in a domain file, never inline in `index.ts`
+- **Shared types:** `src/shared/types.ts` is the single contract between main and renderer. All IPC payload types must be defined there
+- **Renderer sandbox:** the renderer runs with `contextIsolation: true`, `nodeIntegration: false`, and `sandbox: true` — no Node APIs are available in React code. Everything goes through the preload bridge
+- **Schema + migrations:** `src/main/database/schema.ts` holds the full schema SQL; migrations use `user_version` as a counter (see `src/main/database/index.ts`). The shared DB has a parallel migration path in `src/main/database/shared-db.ts` — see issue #47 for known limitations around version compatibility between clients
 - **Cipher setup:** cipher pragmas must be set in a specific order before the key pragma — see `openRaw()` in `src/main/database/index.ts` for the canonical sequence
+- **Testing:** tests use an in-memory SQLite DB via `createTestDb()` in `src/test/vitest.setup.ts` — no database mocking. Helper functions (`insertProject`, `insertContact`, etc.) are defined there for test fixture setup. When building new features, consider whether a test is warranted — particularly for data logic, migrations, and sync behaviour
+- **Chrome extension HTTP server:** runs on `localhost:27371` with one-time token auth; defined in `src/main/http-server.ts`. It is not a general API — do not add endpoints unrelated to the extension
 - **Dev seeds:** seeded automatically on first unlock in dev mode; seed data lives in `src/main/database/dev-seeds*.ts`
 - **`*.db` and `*.salt` files are gitignored** — never commit them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# Sourcerer — Claude Code guide
+
+## Stack
+
+- **Electron** (main process) + **React + TypeScript** (renderer) via electron-vite
+- **SQLite via better-sqlite3-multiple-ciphers** (SQLCipher 4) — all data is encrypted at rest
+- **Argon2id** for key derivation (password + salt file → 32-byte hex key)
+- Native modules: `better-sqlite3-multiple-ciphers`, `argon2` — must be rebuilt when switching between Electron and plain Node targets (see below)
+
+## Dev workflow
+
+```bash
+npm install
+npm run rebuild       # build native modules for Electron (required for npm run dev)
+npm run dev           # start the app
+```
+
+**Running tests** (native modules must target plain Node, not Electron):
+
+```bash
+npm run rebuild:node  # build native modules for system Node
+npm test
+npm run rebuild       # restore Electron-targeted binaries before npm run dev
+```
+
+**Inspecting the database** (TablePlus, DB Browser, sqlite3, etc.):
+
+```bash
+npm run rebuild:node  # only needed once, or after switching targets
+npm run db:export     # prompts for app password, writes sourcerer-plain.db
+# open sourcerer-plain.db in TablePlus as a plain SQLite connection (no password)
+# delete the file when done — it contains all data in plaintext
+```
+
+## Git / PR rules
+
+- `main` is protected — all changes must go through a pull request
+- Branch naming: `feature/`, `fix/`, `dev/` prefixes
+- Always push to a feature branch and open a PR via `gh pr create`
+- CI runs a `test` status check — PRs won't merge until it passes
+
+## Cutting a release
+
+Releases are triggered by pushing a version tag (`v*`). Because `main` is protected, the version bump goes through a PR first, then the tag is pushed separately after merge.
+
+1. Create a version bump branch: `git checkout -b chore/v{VERSION}`
+2. Bump the version (updates `package.json` and creates a local git tag):
+   ```bash
+   npm version patch   # 0.1.x → 0.1.x+1
+   # or
+   npm version minor   # 0.1.x → 0.2.0
+   ```
+   (`preversion` runs typecheck + tests automatically before bumping)
+3. Push the branch (**not** the tag yet) and open a PR:
+   ```bash
+   git push -u origin chore/v{VERSION}
+   gh pr create ...
+   ```
+4. Optionally add a `## What's new` section to the PR body — the release workflow will use it as the GitHub Release description instead of the auto-generated PR list
+5. Once the PR is merged, push the tag to trigger the build:
+   ```bash
+   git checkout main && git pull
+   git push origin v{VERSION}
+   ```
+6. The `build.yml` workflow builds on macOS, Windows, and Linux, then creates a GitHub Release with all artifacts automatically
+
+> The old `npm run release:patch` / `npm run release:minor` scripts do steps 2+5 in one shot but bypass the PR requirement — don't use them now that `main` is protected.
+
+## UI design system
+
+All design tokens are CSS custom properties defined in `src/renderer/src/global.css`.
+
+**Typefaces** (self-hosted, no system font fallbacks):
+- `--font-serif`: Spectral (400, 600, 700) — the primary UI font; used for almost everything
+- `--font-mono`: JetBrains Mono (400, 500, 600) — buttons, labels, code, toggles
+
+**Colour palette** (warm, paper-toned):
+- Backgrounds: `--color-bg` `#faf9f5`, `--color-surface` `#f3f1ea`, `--color-surface-2` `#eceadf`
+- Text: `--color-text` `#1a1815`, `--color-text-muted` `#5b5750`, `--color-text-dim` `#8a857c`
+- Accent: `--color-primary` `#c87a1a` (warm amber-orange), `--color-amber` `#e8a840`
+- Danger: `--color-danger` `#b91c1c`
+- Borders: `rgba(26, 24, 21, 0.14)` / `0.28` for strong
+
+**Mono type scale** — always uppercase, letter-spacing varies inversely with size:
+| Size | Letter-spacing | Typical use |
+|------|---------------|-------------|
+| 10px | 0.16em | Labels, tags, toggles, small meta text |
+| 11px | 0.14em | Buttons (global default), modal labels |
+| 12px | 0.10–0.12em | Sidebar items, slightly larger labels |
+
+**Hard rules — do not break these:**
+- All interactive elements (buttons, inputs, selects, textareas) use `border-radius: 0` — square corners everywhere, no exceptions
+- Mono type is almost always `text-transform: uppercase` — exceptions only for body-level mono (e.g. code snippets)
+- Do not introduce colours outside the palette above; do not use system fonts or web-safe fallbacks
+
+## Architecture notes
+
+- **IPC:** all database access happens in the main process; renderer communicates via typed IPC handlers in `src/main/ipc/`
+- **Schema + migrations:** `src/main/database/schema.ts` holds the full schema SQL; migrations use `user_version` as a counter (see `src/main/database/index.ts`)
+- **Cipher setup:** cipher pragmas must be set in a specific order before the key pragma — see `openRaw()` in `src/main/database/index.ts` for the canonical sequence
+- **Dev seeds:** seeded automatically on first unlock in dev mode; seed data lives in `src/main/database/dev-seeds*.ts`
+- **`*.db` and `*.salt` files are gitignored** — never commit them

--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ npm test
 npm run rebuild        # restore Electron-targeted binaries before npm run dev
 ```
 
+**Inspecting the database** (TablePlus, DB Browser, sqlite3, etc.):
+
+```bash
+npm run rebuild:node   # only needed once, or after switching between dev and Electron
+npm run db:export      # prompts for your app password, writes sourcerer-plain.db
+```
+
+The exported file is a standard unencrypted SQLite database. Delete it when you're done — it contains all your source data in plaintext. (`*.db` is in `.gitignore` so it won't be committed accidentally.)
+
 ---
 
 ## Security notes

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.web.json --noEmit",
     "rebuild": "electron-rebuild -f -w better-sqlite3-multiple-ciphers,argon2",
     "rebuild:node": "npm rebuild better-sqlite3-multiple-ciphers argon2",
+    "db:export": "node scripts/export-plain-db.js",
     "dist:mac": "electron-builder --mac --arm64",
     "dist:win": "electron-builder --win --x64",
     "dist:linux": "electron-builder --linux --x64",

--- a/scripts/export-plain-db.js
+++ b/scripts/export-plain-db.js
@@ -34,21 +34,16 @@ function getUserDataPath() {
 }
 
 async function promptPassword() {
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  // Suppress echoing on interactive TTYs.
-  rl._writeToOutput = (s) => {
-    if (!rl.stdoutMuted) rl.output.write(s);
-  };
   return new Promise((resolve) => {
-    if (process.stdin.isTTY) {
-      process.stdout.write('Password: ');
-      rl.stdoutMuted = true;
-    }
-    rl.question('', (answer) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question('Password: ', (answer) => {
       rl.close();
-      if (process.stdin.isTTY) process.stdout.write('\n');
+      process.stdout.write('\n');
       resolve(answer);
     });
+    // Override AFTER question() has synchronously written the prompt, so the
+    // prompt text renders but typed characters are not echoed.
+    rl._writeToOutput = () => {};
   });
 }
 
@@ -119,16 +114,44 @@ async function main() {
     db.pragma(`key="x'${keyHex}'"`);
     // Verify the key works before attempting export.
     db.pragma('user_version');
-  } catch {
-    console.error('Could not open database — wrong password or corrupted file.');
+  } catch (err) {
+    console.error('Could not open database:', err.message);
     process.exit(1);
   }
 
+  const plainDb = new Database(outPath);
   try {
-    // VACUUM INTO writes a defragmented, unencrypted copy of the database.
-    // outPath is validated above to contain no SQL metacharacters.
-    db.prepare(`VACUUM INTO '${outPath}'`).run();
+    // sqlcipher_export() isn't available in the Node-built library, and
+    // VACUUM INTO copies pages with encryption intact. Instead, open a fresh
+    // unencrypted Database and copy schema + data at the JavaScript level.
+    plainDb.prepare('PRAGMA foreign_keys = OFF').run();
+
+    const tables = db.prepare(
+      "SELECT name, sql FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND sql IS NOT NULL"
+    ).all();
+
+    for (const { name, sql } of tables) {
+      plainDb.prepare(sql).run();
+      const rows = db.prepare(`SELECT * FROM "${name}"`).all();
+      if (rows.length > 0) {
+        const cols = Object.keys(rows[0]).map(c => `"${c}"`).join(', ');
+        const placeholders = Object.keys(rows[0]).map(() => '?').join(', ');
+        const insert = plainDb.prepare(`INSERT INTO "${name}" (${cols}) VALUES (${placeholders})`);
+        plainDb.transaction((rs) => { for (const r of rs) insert.run(Object.values(r)); })(rows);
+      }
+    }
+
+    // Copy indexes, views, and triggers.
+    const extras = db.prepare(
+      "SELECT sql FROM sqlite_master WHERE type IN ('index', 'view', 'trigger') AND sql IS NOT NULL"
+    ).all();
+    for (const { sql } of extras) {
+      try { plainDb.prepare(sql).run(); } catch { /* skip anything that can't be recreated */ }
+    }
+
+    plainDb.prepare('PRAGMA foreign_keys = ON').run();
   } finally {
+    plainDb.close();
     db.close();
   }
 

--- a/scripts/export-plain-db.js
+++ b/scripts/export-plain-db.js
@@ -1,0 +1,144 @@
+/**
+ * DEV UTILITY — export a decrypted copy of the Sourcerer SQLite database.
+ *
+ * Usage:
+ *   node scripts/export-plain-db.js [output-path]
+ *
+ * If output-path is omitted, the file is written to the current directory as
+ * sourcerer-plain.db. DO NOT commit or share the output file — it contains
+ * all source data in plaintext.
+ *
+ * Prerequisites: run `npm run rebuild:node` once after cloning so that argon2
+ * and better-sqlite3-multiple-ciphers are built for the current Node version.
+ */
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const readline = require('readline');
+const argon2 = require('argon2');
+const Database = require('better-sqlite3-multiple-ciphers');
+
+// Mirrors app.getPath('userData') for the Electron app on each platform.
+function getUserDataPath() {
+  switch (process.platform) {
+    case 'darwin':
+      return path.join(os.homedir(), 'Library', 'Application Support', 'sourcerer');
+    case 'win32':
+      return path.join(process.env.APPDATA || os.homedir(), 'sourcerer');
+    default:
+      return path.join(os.homedir(), '.config', 'sourcerer');
+  }
+}
+
+async function promptPassword() {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  // Suppress echoing on interactive TTYs.
+  rl._writeToOutput = (s) => {
+    if (!rl.stdoutMuted) rl.output.write(s);
+  };
+  return new Promise((resolve) => {
+    if (process.stdin.isTTY) {
+      process.stdout.write('Password: ');
+      rl.stdoutMuted = true;
+    }
+    rl.question('', (answer) => {
+      rl.close();
+      if (process.stdin.isTTY) process.stdout.write('\n');
+      resolve(answer);
+    });
+  });
+}
+
+async function deriveKey(password, salt) {
+  const rawKey = await argon2.hash(password, {
+    type: argon2.argon2id,
+    memoryCost: 65536,
+    timeCost: 3,
+    parallelism: 1,
+    hashLength: 32,
+    salt,
+    raw: true,
+  });
+  return rawKey.toString('hex');
+}
+
+// Validate the output path to prevent SQL injection in the VACUUM INTO statement.
+// Allows alphanumeric characters, path separators, dots, hyphens, and underscores.
+function validateOutputPath(p) {
+  if (/['"`;\\]/.test(p)) {
+    throw new Error(`Output path contains disallowed characters: ${p}`);
+  }
+  return p;
+}
+
+async function main() {
+  const userData = getUserDataPath();
+  const dbPath = path.join(userData, 'sourcerer.db');
+  const saltPath = path.join(userData, 'sourcerer.salt');
+  const outPath = validateOutputPath(path.resolve(process.argv[2] || 'sourcerer-plain.db'));
+
+  if (!fs.existsSync(dbPath)) {
+    console.error(`Database not found at: ${dbPath}`);
+    console.error('Run the Sourcerer app at least once to create the database.');
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(saltPath)) {
+    console.error(`Salt file not found at: ${saltPath}`);
+    process.exit(1);
+  }
+
+  if (fs.existsSync(outPath)) {
+    console.error(`Output file already exists: ${outPath}`);
+    console.error('Delete it first or choose a different path.');
+    process.exit(1);
+  }
+
+  const salt = fs.readFileSync(saltPath);
+  const password = await promptPassword();
+
+  let keyHex;
+  try {
+    keyHex = await deriveKey(password, salt);
+  } catch (err) {
+    console.error('Key derivation failed:', err.message);
+    process.exit(1);
+  }
+
+  let db;
+  try {
+    db = new Database(dbPath);
+    db.pragma(`cipher='sqlcipher'`);
+    db.pragma('cipher_page_size=4096');
+    db.pragma('kdf_iter=256000');
+    db.pragma('cipher_hmac_algorithm=HMAC_SHA512');
+    db.pragma('cipher_kdf_algorithm=PBKDF2_HMAC_SHA512');
+    db.pragma(`key="x'${keyHex}'"`);
+    // Verify the key works before attempting export.
+    db.pragma('user_version');
+  } catch {
+    console.error('Could not open database — wrong password or corrupted file.');
+    process.exit(1);
+  }
+
+  try {
+    // VACUUM INTO writes a defragmented, unencrypted copy of the database.
+    // outPath is validated above to contain no SQL metacharacters.
+    db.prepare(`VACUUM INTO '${outPath}'`).run();
+  } finally {
+    db.close();
+  }
+
+  const sizeMB = (fs.statSync(outPath).size / 1024 / 1024).toFixed(2);
+  console.log(`\nExported to: ${outPath} (${sizeMB} MB)`);
+  console.log('Open in TablePlus, DB Browser, or: sqlite3 ' + outPath);
+  console.log('\nRemember to delete this file when you are done.');
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/export-plain-db.js`, a dev-only utility that decrypts the Sourcerer SQLCipher database and writes a plain SQLite copy for inspection in TablePlus, DB Browser, or the `sqlite3` CLI
- Adds `npm run db:export` shorthand
- Documents the export workflow in the dev section of the README
- Adds `CLAUDE.md` with dev workflow, release process, design system rules, and architecture notes

## Notes on the export utility

- Derives the Argon2id key from your app password + salt file, matching the app's own unlock flow exactly
- Uses a JS-level schema+data copy rather than `VACUUM INTO` (which copies pages with encryption intact in SQLCipher) or `sqlcipher_export()` (unavailable in the Node-built library)
- Output path is validated to prevent SQL injection; `*.db` is already in `.gitignore`

## Test plan

- [x] `npm run rebuild:node` (first time only)
- [x] `npm run db:export` — should prompt for password and write `sourcerer-plain.db`
- [x] `file sourcerer-plain.db` should report `SQLite 3.x database`
- [ ] File opens in TablePlus as a plain SQLite connection with no password

🤖 Generated with [Claude Code](https://claude.com/claude-code)