### PR TITLE
Use CalendarPicker for all date inputs; improve reminders UX

### DIFF
--- a/src/main/ipc/reminders.ts
+++ b/src/main/ipc/reminders.ts
@@ -95,10 +95,14 @@ export function registerReminderHandlers(): void {
 
   ipcMain.handle(
     'reminders:update',
-    (_, { id, dueDate, note }: { id: string; dueDate: number; note: string }): Reminder => {
+    (_, { id, dueDate, note }: { id: string; dueDate: number; note: string | null }): Reminder => {
       const db = getDatabase();
       if (!Number.isFinite(dueDate) || dueDate <= 0) throw new Error('invalid due_date');
-      db.prepare('UPDATE reminders SET due_date = ?, note = ? WHERE id = ?').run(dueDate, note, id);
+      const normalizedNote = note?.trim() || null;
+      const result = db
+        .prepare('UPDATE reminders SET due_date = ?, note = ? WHERE id = ? AND is_auto_outreach = 0')
+        .run(dueDate, normalizedNote, id);
+      if (result.changes === 0) throw new Error('reminder not found or not editable');
       const reminder = db
         .prepare(
           `SELECT ${SELECT_COLS}

--- a/src/main/ipc/reminders.ts
+++ b/src/main/ipc/reminders.ts
@@ -87,4 +87,24 @@ export function registerReminderHandlers(): void {
     getDatabase().prepare(`DELETE FROM reminders WHERE id = ?`).run(id);
     broadcastRemindersChanged();
   });
+
+  ipcMain.handle(
+    'reminders:update',
+    (_, { id, dueDate, note }: { id: string; dueDate: number; note: string }): Reminder => {
+      const db = getDatabase();
+      if (!Number.isFinite(dueDate) || dueDate <= 0) throw new Error('invalid due_date');
+      db.prepare('UPDATE reminders SET due_date = ?, note = ? WHERE id = ?').run(dueDate, note, id);
+      const reminder = db
+        .prepare(
+          `SELECT ${SELECT_COLS}
+           FROM reminders r
+           JOIN contacts c ON c.id = r.contact_id
+           JOIN projects p ON p.id = r.project_id
+           WHERE r.id = ?`,
+        )
+        .get(id) as Reminder;
+      broadcastRemindersChanged();
+      return reminder;
+    },
+  );
 }

--- a/src/main/ipc/reminders.ts
+++ b/src/main/ipc/reminders.ts
@@ -83,6 +83,11 @@ export function registerReminderHandlers(): void {
     broadcastRemindersChanged();
   });
 
+  ipcMain.handle('reminders:uncomplete', (_, id: string): void => {
+    getDatabase().prepare(`UPDATE reminders SET completed_at = NULL WHERE id = ?`).run(id);
+    broadcastRemindersChanged();
+  });
+
   ipcMain.handle('reminders:delete', (_, id: string): void => {
     getDatabase().prepare(`DELETE FROM reminders WHERE id = ?`).run(id);
     broadcastRemindersChanged();

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -286,7 +286,7 @@ const sourcererApi = {
   completeReminder: (id: string): Promise<void> => ipcRenderer.invoke('reminders:complete', id),
   uncompleteReminder: (id: string): Promise<void> => ipcRenderer.invoke('reminders:uncomplete', id),
   deleteReminder: (id: string): Promise<void> => ipcRenderer.invoke('reminders:delete', id),
-  updateReminder: (data: { id: string; dueDate: number; note: string }): Promise<Reminder> =>
+  updateReminder: (data: { id: string; dueDate: number; note: string | null }): Promise<Reminder> =>
     ipcRenderer.invoke('reminders:update', data),
 
   // vCard export

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -285,6 +285,8 @@ const sourcererApi = {
   }): Promise<Reminder> => ipcRenderer.invoke('reminders:create', data),
   completeReminder: (id: string): Promise<void> => ipcRenderer.invoke('reminders:complete', id),
   deleteReminder: (id: string): Promise<void> => ipcRenderer.invoke('reminders:delete', id),
+  updateReminder: (data: { id: string; dueDate: number; note: string }): Promise<Reminder> =>
+    ipcRenderer.invoke('reminders:update', data),
 
   // vCard export
   exportVCardContact: (contactId: string): Promise<void> =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -284,6 +284,7 @@ const sourcererApi = {
     note?: string;
   }): Promise<Reminder> => ipcRenderer.invoke('reminders:create', data),
   completeReminder: (id: string): Promise<void> => ipcRenderer.invoke('reminders:complete', id),
+  uncompleteReminder: (id: string): Promise<void> => ipcRenderer.invoke('reminders:uncomplete', id),
   deleteReminder: (id: string): Promise<void> => ipcRenderer.invoke('reminders:delete', id),
   updateReminder: (data: { id: string; dueDate: number; note: string }): Promise<Reminder> =>
     ipcRenderer.invoke('reminders:update', data),

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -1193,6 +1193,24 @@
   transform: rotate(45deg);
 }
 
+.pt-reminder-delete-btn {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-danger);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  margin-left: auto;
+}
+
+.pt-reminder-delete-btn:hover {
+  opacity: 0.75;
+}
+
 .pt-reminder-edit-btn {
   font-family: var(--font-mono);
   font-size: 10px;

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -1193,6 +1193,30 @@
   transform: rotate(45deg);
 }
 
+.pt-reminder-edit-btn {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-text-dim);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.pt-reminder-row:hover .pt-reminder-edit-btn {
+  opacity: 1;
+}
+
+.pt-reminder-edit-btn:hover {
+  color: var(--color-primary);
+}
+
 /* ── Add reminder form ── */
 .pt-reminder-form {
   display: flex;

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -1183,8 +1183,8 @@
 .pt-reminder-check:checked::after {
   content: '';
   position: absolute;
-  left: 2px;
-  top: -1px;
+  left: 2.5px;
+  top: -0.5px;
   width: 5px;
   height: 8px;
   border: 1.5px solid var(--color-text-muted);

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -449,9 +449,13 @@ function RemindersSection({
   async function handleSaveEdit(id: string) {
     if (!editDueDate || !editNote.trim()) return;
     const ts = Math.floor(new Date(`${editDueDate}T09:00:00`).getTime() / 1000);
-    const updated = await window.sourcerer.updateReminder({ id, dueDate: ts, note: editNote.trim() });
-    setReminders((prev) => prev.map((r) => (r.id === id ? updated : r)).sort(sortReminders));
-    setEditingId(null);
+    try {
+      const updated = await window.sourcerer.updateReminder({ id, dueDate: ts, note: editNote.trim() });
+      setReminders((prev) => prev.map((r) => (r.id === id ? updated : r)).sort(sortReminders));
+      setEditingId(null);
+    } catch {
+      // leave edit form open so the user can retry
+    }
   }
 
   async function handleComplete(id: string) {
@@ -473,7 +477,11 @@ function RemindersSection({
   }
 
   async function handleDelete(id: string) {
-    await window.sourcerer.deleteReminder(id);
+    try {
+      await window.sourcerer.deleteReminder(id);
+    } catch {
+      return;
+    }
     setReminders((prev) => prev.filter((r) => r.id !== id));
     setEditingId(null);
   }

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { fmtDateFull } from '../utils/fmtDate';
 import { useClickOutside } from '../hooks/useClickOutside';
+import { CalendarPicker } from '../views/CalendarPicker';
 import './ContactDetail.css';
 import type {
   ContactDetail as ContactDetailType,
@@ -244,12 +245,11 @@ function LogSection({
         <div className="pt-log-compose">
           <div className="pt-log-date-row">
             <label className="pt-log-date-label">Date</label>
-            <input
-              type="date"
-              className="pt-log-date-input"
+            <CalendarPicker
+              label="Select date"
               value={logDate}
-              onChange={(e) => setLogDate(e.target.value)}
-              max={today}
+              onChange={setLogDate}
+              showYear
             />
           </div>
           <textarea
@@ -488,12 +488,11 @@ function RemindersSection({
       })}
       {adding && (
         <div className="pt-reminder-form">
-          <input
-            type="date"
-            className="pt-date"
+          <CalendarPicker
+            label="Due date"
             value={dueDate}
-            onChange={(e) => setDueDate(e.target.value)}
-            autoFocus
+            onChange={setDueDate}
+            showYear
           />
           <input
             className="pt-input"

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -250,6 +250,7 @@ function LogSection({
               value={logDate}
               onChange={setLogDate}
               showYear
+              maxDate={today}
             />
           </div>
           <textarea
@@ -415,6 +416,10 @@ function RemindersSection({
     });
   }, [contactId, projectId, refreshToken]);
 
+  function sortReminders(a: Reminder, b: Reminder) {
+    return b.is_auto_outreach - a.is_auto_outreach || a.due_date - b.due_date;
+  }
+
   async function handleAdd() {
     if (!dueDate || !note.trim()) return;
     const ts = Math.floor(new Date(`${dueDate}T09:00:00`).getTime() / 1000);
@@ -424,7 +429,7 @@ function RemindersSection({
       dueDate: ts,
       note: note.trim(),
     });
-    setReminders((prev) => [...prev, r].sort((a, b) => b.is_auto_outreach - a.is_auto_outreach || a.due_date - b.due_date));
+    setReminders((prev) => [...prev, r].sort(sortReminders));
     setDueDate('');
     setNote('');
     setAdding(false);
@@ -445,20 +450,26 @@ function RemindersSection({
     if (!editDueDate || !editNote.trim()) return;
     const ts = Math.floor(new Date(`${editDueDate}T09:00:00`).getTime() / 1000);
     const updated = await window.sourcerer.updateReminder({ id, dueDate: ts, note: editNote.trim() });
-    setReminders((prev) =>
-      prev.map((r) => (r.id === id ? updated : r)).sort((a, b) => b.is_auto_outreach - a.is_auto_outreach || a.due_date - b.due_date),
-    );
+    setReminders((prev) => prev.map((r) => (r.id === id ? updated : r)).sort(sortReminders));
     setEditingId(null);
   }
 
-  function handleComplete(id: string) {
+  async function handleComplete(id: string) {
     setCompleting((prev) => new Set(prev).add(id));
-    window.sourcerer.completeReminder(id);
+    try {
+      await window.sourcerer.completeReminder(id);
+    } catch {
+      setCompleting((prev) => { const next = new Set(prev); next.delete(id); return next; });
+    }
   }
 
-  function handleUncomplete(id: string) {
+  async function handleUncomplete(id: string) {
     setCompleting((prev) => { const next = new Set(prev); next.delete(id); return next; });
-    window.sourcerer.uncompleteReminder(id);
+    try {
+      await window.sourcerer.uncompleteReminder(id);
+    } catch {
+      setCompleting((prev) => new Set(prev).add(id));
+    }
   }
 
   async function handleDelete(id: string) {
@@ -520,7 +531,6 @@ function RemindersSection({
                 value={editNote}
                 onChange={(e) => setEditNote(e.target.value)}
                 placeholder="Note"
-                autoFocus
               />
               <div className="pt-reminder-form-actions">
                 <button

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -401,10 +401,14 @@ function RemindersSection({
   const [dueDate, setDueDate] = useState('');
   const [note, setNote] = useState('');
   const [adding, setAdding] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDueDate, setEditDueDate] = useState('');
+  const [editNote, setEditNote] = useState('');
 
   useEffect(() => {
     setReminders([]);
     setCompleting(new Set());
+    setEditingId(null);
     window.sourcerer.listRemindersForContactProject(contactId, projectId).then((loaded) => {
       setReminders(loaded);
       setCompleting(new Set(loaded.filter((r) => r.completed_at !== null).map((r) => r.id)));
@@ -412,18 +416,39 @@ function RemindersSection({
   }, [contactId, projectId, refreshToken]);
 
   async function handleAdd() {
-    if (!dueDate) return;
+    if (!dueDate || !note.trim()) return;
     const ts = Math.floor(new Date(`${dueDate}T09:00:00`).getTime() / 1000);
     const r = await window.sourcerer.createReminder({
       contactId,
       projectId,
       dueDate: ts,
-      note: note.trim() || undefined,
+      note: note.trim(),
     });
     setReminders((prev) => [...prev, r].sort((a, b) => a.due_date - b.due_date));
     setDueDate('');
     setNote('');
     setAdding(false);
+  }
+
+  function handleStartEdit(r: Reminder) {
+    const d = new Date(r.due_date * 1000);
+    const yyyy = d.getFullYear();
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    setEditDueDate(`${yyyy}-${mm}-${dd}`);
+    setEditNote(r.note ?? '');
+    setEditingId(r.id);
+    setAdding(false);
+  }
+
+  async function handleSaveEdit(id: string) {
+    if (!editDueDate || !editNote.trim()) return;
+    const ts = Math.floor(new Date(`${editDueDate}T09:00:00`).getTime() / 1000);
+    const updated = await window.sourcerer.updateReminder({ id, dueDate: ts, note: editNote.trim() });
+    setReminders((prev) =>
+      prev.map((r) => (r.id === id ? updated : r)).sort((a, b) => a.due_date - b.due_date),
+    );
+    setEditingId(null);
   }
 
   function handleComplete(id: string) {
@@ -450,7 +475,7 @@ function RemindersSection({
     <div className="pt-section">
       <div className="pt-reminders-header">
         <span className="pt-reminders-label">Reminders</span>
-        <button className="pt-reminder-add-btn" onClick={() => setAdding((v) => !v)}>
+        <button className="pt-reminder-add-btn" onClick={() => { setAdding((v) => !v); setEditingId(null); }}>
           {adding ? '× CANCEL' : '+ ADD'}
         </button>
       </div>
@@ -470,12 +495,48 @@ function RemindersSection({
           );
         }
         const done = completing.has(r.id);
+        if (editingId === r.id) {
+          return (
+            <div key={r.id} className="pt-reminder-form">
+              <CalendarPicker
+                label="Due date"
+                value={editDueDate}
+                onChange={setEditDueDate}
+                showYear
+              />
+              <input
+                className="pt-input"
+                value={editNote}
+                onChange={(e) => setEditNote(e.target.value)}
+                placeholder="Note"
+                autoFocus
+              />
+              <div className="pt-reminder-form-actions">
+                <button
+                  className="pt-log-submit"
+                  onClick={() => handleSaveEdit(r.id)}
+                  disabled={!editDueDate || !editNote.trim()}
+                >
+                  Save
+                </button>
+                <button className="pt-reminder-cancel" onClick={() => setEditingId(null)}>
+                  Cancel
+                </button>
+              </div>
+            </div>
+          );
+        }
         return (
           <div key={r.id} className={`pt-reminder-row${overdue ? ' pt-reminder-row--overdue' : ''}${done ? ' pt-reminder-row--completing' : ''}`}>
             <div className={`pt-reminder-row-date${overdue && !done ? ' pt-reminder-row-date--overdue' : ''}`}>
               {fmtReminderDate(r.due_date, overdue)}
             </div>
             <div className="pt-reminder-row-note">{r.note || ''}</div>
+            {!done && (
+              <button className="pt-reminder-edit-btn" onClick={() => handleStartEdit(r)} title="Edit">
+                Edit
+              </button>
+            )}
             <input
               type="checkbox"
               className="pt-reminder-check"
@@ -498,10 +559,10 @@ function RemindersSection({
             className="pt-input"
             value={note}
             onChange={(e) => setNote(e.target.value)}
-            placeholder="Note (optional)"
+            placeholder="Note"
           />
           <div className="pt-reminder-form-actions">
-            <button className="pt-log-submit" onClick={handleAdd} disabled={!dueDate}>
+            <button className="pt-log-submit" onClick={handleAdd} disabled={!dueDate || !note.trim()}>
               Add
             </button>
             <button className="pt-reminder-cancel" onClick={() => setAdding(false)}>

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -424,7 +424,7 @@ function RemindersSection({
       dueDate: ts,
       note: note.trim(),
     });
-    setReminders((prev) => [...prev, r].sort((a, b) => a.due_date - b.due_date));
+    setReminders((prev) => [...prev, r].sort((a, b) => b.is_auto_outreach - a.is_auto_outreach || a.due_date - b.due_date));
     setDueDate('');
     setNote('');
     setAdding(false);
@@ -446,7 +446,7 @@ function RemindersSection({
     const ts = Math.floor(new Date(`${editDueDate}T09:00:00`).getTime() / 1000);
     const updated = await window.sourcerer.updateReminder({ id, dueDate: ts, note: editNote.trim() });
     setReminders((prev) =>
-      prev.map((r) => (r.id === id ? updated : r)).sort((a, b) => a.due_date - b.due_date),
+      prev.map((r) => (r.id === id ? updated : r)).sort((a, b) => b.is_auto_outreach - a.is_auto_outreach || a.due_date - b.due_date),
     );
     setEditingId(null);
   }

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -456,6 +456,17 @@ function RemindersSection({
     window.sourcerer.completeReminder(id);
   }
 
+  function handleUncomplete(id: string) {
+    setCompleting((prev) => { const next = new Set(prev); next.delete(id); return next; });
+    window.sourcerer.uncompleteReminder(id);
+  }
+
+  async function handleDelete(id: string) {
+    await window.sourcerer.deleteReminder(id);
+    setReminders((prev) => prev.filter((r) => r.id !== id));
+    setEditingId(null);
+  }
+
   const now = Math.floor(Date.now() / 1000);
 
   function fmtReminderDate(ts: number, overdue: boolean): string {
@@ -522,6 +533,9 @@ function RemindersSection({
                 <button className="pt-reminder-cancel" onClick={() => setEditingId(null)}>
                   Cancel
                 </button>
+                <button className="pt-reminder-delete-btn" onClick={() => handleDelete(r.id)}>
+                  Delete
+                </button>
               </div>
             </div>
           );
@@ -541,8 +555,8 @@ function RemindersSection({
               type="checkbox"
               className="pt-reminder-check"
               checked={done}
-              onChange={() => { if (!done) handleComplete(r.id); }}
-              title="Mark complete"
+              onChange={() => { if (done) handleUncomplete(r.id); else handleComplete(r.id); }}
+              title={done ? 'Mark incomplete' : 'Mark complete'}
             />
           </div>
         );

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -172,7 +172,7 @@ declare global {
       completeReminder: (id: string) => Promise<void>;
       uncompleteReminder: (id: string) => Promise<void>;
       deleteReminder: (id: string) => Promise<void>;
-      updateReminder: (data: { id: string; dueDate: number; note: string }) => Promise<Reminder>;
+      updateReminder: (data: { id: string; dueDate: number; note: string | null }) => Promise<Reminder>;
 
       // vCard export
       exportVCardContact: (contactId: string) => Promise<void>;

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -171,6 +171,7 @@ declare global {
       }) => Promise<Reminder>;
       completeReminder: (id: string) => Promise<void>;
       deleteReminder: (id: string) => Promise<void>;
+      updateReminder: (data: { id: string; dueDate: number; note: string }) => Promise<Reminder>;
 
       // vCard export
       exportVCardContact: (contactId: string) => Promise<void>;

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -170,6 +170,7 @@ declare global {
         note?: string;
       }) => Promise<Reminder>;
       completeReminder: (id: string) => Promise<void>;
+      uncompleteReminder: (id: string) => Promise<void>;
       deleteReminder: (id: string) => Promise<void>;
       updateReminder: (data: { id: string; dueDate: number; note: string }) => Promise<Reminder>;
 

--- a/src/renderer/src/views/CalendarPicker.css
+++ b/src/renderer/src/views/CalendarPicker.css
@@ -171,6 +171,12 @@
   font-weight: 600;
 }
 
+.cal-day--disabled {
+  opacity: 0.25;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 /* ── Footer clear link ─────────────────────────────────────── */
 
 .cal-footer {

--- a/src/renderer/src/views/CalendarPicker.tsx
+++ b/src/renderer/src/views/CalendarPicker.tsx
@@ -69,11 +69,13 @@ export function CalendarPicker({
   value,
   onChange,
   showYear = false,
+  maxDate,
 }: {
   label: string;
   value: string;
   onChange: (v: string) => void;
   showYear?: boolean;
+  maxDate?: string;
 }) {
   const [open, setOpen] = useState(false);
   const [mode, setMode] = useState<'days' | 'months' | 'years'>('days');
@@ -222,6 +224,7 @@ export function CalendarPicker({
                 const iso = `${cell.y}-${String(cell.m).padStart(2, '0')}-${String(cell.d).padStart(2, '0')}`;
                 const isSelected = iso === value;
                 const isToday = iso === todayStr && !isSelected;
+                const isDisabled = !!maxDate && iso > maxDate;
                 return (
                   <button
                     type="button"
@@ -231,8 +234,10 @@ export function CalendarPicker({
                       cell.overflow ? 'cal-day--overflow' : '',
                       isSelected ? 'cal-day--selected' : '',
                       isToday ? 'cal-day--today' : '',
+                      isDisabled ? 'cal-day--disabled' : '',
                     ].filter(Boolean).join(' ')}
-                    onClick={() => selectDay(cell.y, cell.m, cell.d)}
+                    onClick={() => !isDisabled && selectDay(cell.y, cell.m, cell.d)}
+                    disabled={isDisabled}
                   >
                     {cell.d}
                   </button>

--- a/src/renderer/src/views/CalendarPicker.tsx
+++ b/src/renderer/src/views/CalendarPicker.tsx
@@ -70,12 +70,14 @@ export function CalendarPicker({
   onChange,
   showYear = false,
   maxDate,
+  ariaLabel,
 }: {
   label: string;
   value: string;
   onChange: (v: string) => void;
   showYear?: boolean;
   maxDate?: string;
+  ariaLabel?: string;
 }) {
   const [open, setOpen] = useState(false);
   const [mode, setMode] = useState<'days' | 'months' | 'years'>('days');
@@ -138,6 +140,8 @@ export function CalendarPicker({
   const todayStr = todayISO();
   const thisYear = new Date().getFullYear();
   const showNav = mode === 'days';
+  const maxY = maxDate ? parseInt(maxDate.slice(0, 4), 10) : undefined;
+  const maxM = maxDate ? parseInt(maxDate.slice(5, 7), 10) : undefined;
 
   return (
     <div ref={wrapRef} className="cal-wrap">
@@ -145,6 +149,7 @@ export function CalendarPicker({
         type="button"
         className={`project-meta-action-btn${value ? ' project-meta-action-btn--active' : ''}`}
         onClick={openCalendar}
+        aria-label={ariaLabel ?? label}
       >
         {value ? fmtShort(value, showYear) : label}
       </button>
@@ -183,24 +188,32 @@ export function CalendarPicker({
 
           {mode === 'years' ? (
             <div className="cal-year-grid">
-              {yearRange.map((y) => (
-                <button
-                  type="button"
-                  key={y}
-                  className={[
-                    'cal-year-cell',
-                    y === viewYear ? 'cal-year-cell--selected' : '',
-                    y === thisYear && y !== viewYear ? 'cal-year-cell--today' : '',
-                  ].filter(Boolean).join(' ')}
-                  onClick={() => selectYear(y)}
-                >
-                  {y}
-                </button>
-              ))}
+              {yearRange.map((y) => {
+                const yearDisabled = maxY !== undefined && y > maxY;
+                return (
+                  <button
+                    type="button"
+                    key={y}
+                    className={[
+                      'cal-year-cell',
+                      y === viewYear ? 'cal-year-cell--selected' : '',
+                      y === thisYear && y !== viewYear ? 'cal-year-cell--today' : '',
+                      yearDisabled ? 'cal-day--disabled' : '',
+                    ].filter(Boolean).join(' ')}
+                    onClick={() => selectYear(y)}
+                    disabled={yearDisabled}
+                  >
+                    {y}
+                  </button>
+                );
+              })}
             </div>
           ) : mode === 'months' ? (
             <div className="cal-month-grid">
-              {MONTHS_SHORT.map((name, i) => (
+              {MONTHS_SHORT.map((name, i) => {
+                const monthDisabled = maxY !== undefined && maxM !== undefined &&
+                  (viewYear > maxY || (viewYear === maxY && i + 1 > maxM));
+                return (
                 <button
                   type="button"
                   key={name}
@@ -208,12 +221,15 @@ export function CalendarPicker({
                     'cal-month-cell',
                     i + 1 === viewMonth ? 'cal-month-cell--selected' : '',
                     i + 1 === new Date().getMonth() + 1 && viewYear === thisYear ? 'cal-month-cell--today' : '',
+                    monthDisabled ? 'cal-day--disabled' : '',
                   ].filter(Boolean).join(' ')}
                   onClick={() => selectMonth(i + 1)}
+                  disabled={monthDisabled}
                 >
                   {name}
                 </button>
-              ))}
+                );
+              })}
             </div>
           ) : (
             <div className="cal-grid">

--- a/src/renderer/src/views/ColumnHeader.css
+++ b/src/renderer/src/views/ColumnHeader.css
@@ -278,4 +278,5 @@
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--color-text-muted);
+  font-family: var(--font-mono);
 }

--- a/src/renderer/src/views/ColumnHeader.css
+++ b/src/renderer/src/views/ColumnHeader.css
@@ -265,3 +265,17 @@
   color: var(--color-text-muted);
   padding: 6px 8px 2px;
 }
+
+/* Date range filter */
+.date-filter-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.date-filter-label {
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}

--- a/src/renderer/src/views/ContactsTable.tsx
+++ b/src/renderer/src/views/ContactsTable.tsx
@@ -9,6 +9,7 @@ import type {
   User,
 } from '@shared/types';
 import ColumnHeader, { TextFilter, ToggleFilter, PresetFilter, MultiSelectFilter } from './ColumnHeader';
+import { CalendarPicker } from './CalendarPicker';
 
 // ─── Shared types ────────────────────────────────────────────────────────────
 
@@ -365,20 +366,20 @@ export default function ContactsTable(props: ContactsTableProps) {
                 filterOpen={openFilter === 'date_added'}
                 onFilterToggle={() => toggleFilter('date_added')}
                 filterContent={
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                    <label style={{ fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--color-text-muted)' }}>From</label>
-                    <input
-                      type="date"
+                  <div className="date-filter-stack">
+                    <label className="date-filter-label">From</label>
+                    <CalendarPicker
+                      label="From"
                       value={pf?.dateAddedFrom ?? ''}
-                      onChange={(e) => setFilter('dateAddedFrom', e.target.value)}
-                      style={{ height: 28, padding: '0 6px', border: '1px solid var(--color-border)', fontSize: 12, fontFamily: 'var(--font-mono)', background: 'var(--color-bg)', color: 'var(--color-text)', outline: 'none', width: '100%' }}
+                      onChange={(v) => setFilter('dateAddedFrom', v)}
+                      showYear
                     />
-                    <label style={{ fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--color-text-muted)' }}>To</label>
-                    <input
-                      type="date"
+                    <label className="date-filter-label">To</label>
+                    <CalendarPicker
+                      label="To"
                       value={pf?.dateAddedTo ?? ''}
-                      onChange={(e) => setFilter('dateAddedTo', e.target.value)}
-                      style={{ height: 28, padding: '0 6px', border: '1px solid var(--color-border)', fontSize: 12, fontFamily: 'var(--font-mono)', background: 'var(--color-bg)', color: 'var(--color-text)', outline: 'none', width: '100%' }}
+                      onChange={(v) => setFilter('dateAddedTo', v)}
+                      showYear
                     />
                   </div>
                 }
@@ -495,20 +496,20 @@ export default function ContactsTable(props: ContactsTableProps) {
                 filterOpen={openFilter === 'date_added'}
                 onFilterToggle={() => toggleFilter('date_added')}
                 filterContent={
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                    <label style={{ fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--color-text-muted)' }}>From</label>
-                    <input
-                      type="date"
+                  <div className="date-filter-stack">
+                    <label className="date-filter-label">From</label>
+                    <CalendarPicker
+                      label="From"
                       value={af?.dateAddedFrom ?? ''}
-                      onChange={(e) => setFilter('dateAddedFrom', e.target.value)}
-                      style={{ height: 28, padding: '0 6px', border: '1px solid var(--color-border)', fontSize: 12, fontFamily: 'var(--font-mono)', background: 'var(--color-bg)', color: 'var(--color-text)', outline: 'none', width: '100%' }}
+                      onChange={(v) => setFilter('dateAddedFrom', v)}
+                      showYear
                     />
-                    <label style={{ fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--color-text-muted)' }}>To</label>
-                    <input
-                      type="date"
+                    <label className="date-filter-label">To</label>
+                    <CalendarPicker
+                      label="To"
                       value={af?.dateAddedTo ?? ''}
-                      onChange={(e) => setFilter('dateAddedTo', e.target.value)}
-                      style={{ height: 28, padding: '0 6px', border: '1px solid var(--color-border)', fontSize: 12, fontFamily: 'var(--font-mono)', background: 'var(--color-bg)', color: 'var(--color-text)', outline: 'none', width: '100%' }}
+                      onChange={(v) => setFilter('dateAddedTo', v)}
+                      showYear
                     />
                   </div>
                 }

--- a/src/renderer/src/views/ContactsTable.tsx
+++ b/src/renderer/src/views/ContactsTable.tsx
@@ -369,14 +369,14 @@ export default function ContactsTable(props: ContactsTableProps) {
                   <div className="date-filter-stack">
                     <label className="date-filter-label">From</label>
                     <CalendarPicker
-                      label="From"
+                      label="Pick date"
                       value={pf?.dateAddedFrom ?? ''}
                       onChange={(v) => setFilter('dateAddedFrom', v)}
                       showYear
                     />
                     <label className="date-filter-label">To</label>
                     <CalendarPicker
-                      label="To"
+                      label="Pick date"
                       value={pf?.dateAddedTo ?? ''}
                       onChange={(v) => setFilter('dateAddedTo', v)}
                       showYear
@@ -499,14 +499,14 @@ export default function ContactsTable(props: ContactsTableProps) {
                   <div className="date-filter-stack">
                     <label className="date-filter-label">From</label>
                     <CalendarPicker
-                      label="From"
+                      label="Pick date"
                       value={af?.dateAddedFrom ?? ''}
                       onChange={(v) => setFilter('dateAddedFrom', v)}
                       showYear
                     />
                     <label className="date-filter-label">To</label>
                     <CalendarPicker
-                      label="To"
+                      label="Pick date"
                       value={af?.dateAddedTo ?? ''}
                       onChange={(v) => setFilter('dateAddedTo', v)}
                       showYear

--- a/src/renderer/src/views/ContactsTable.tsx
+++ b/src/renderer/src/views/ContactsTable.tsx
@@ -370,6 +370,7 @@ export default function ContactsTable(props: ContactsTableProps) {
                     <label className="date-filter-label">From</label>
                     <CalendarPicker
                       label="Pick date"
+                      ariaLabel="Date added from"
                       value={pf?.dateAddedFrom ?? ''}
                       onChange={(v) => setFilter('dateAddedFrom', v)}
                       showYear
@@ -377,6 +378,7 @@ export default function ContactsTable(props: ContactsTableProps) {
                     <label className="date-filter-label">To</label>
                     <CalendarPicker
                       label="Pick date"
+                      ariaLabel="Date added to"
                       value={pf?.dateAddedTo ?? ''}
                       onChange={(v) => setFilter('dateAddedTo', v)}
                       showYear
@@ -500,6 +502,7 @@ export default function ContactsTable(props: ContactsTableProps) {
                     <label className="date-filter-label">From</label>
                     <CalendarPicker
                       label="Pick date"
+                      ariaLabel="Date added from"
                       value={af?.dateAddedFrom ?? ''}
                       onChange={(v) => setFilter('dateAddedFrom', v)}
                       showYear
@@ -507,6 +510,7 @@ export default function ContactsTable(props: ContactsTableProps) {
                     <label className="date-filter-label">To</label>
                     <CalendarPicker
                       label="Pick date"
+                      ariaLabel="Date added to"
                       value={af?.dateAddedTo ?? ''}
                       onChange={(v) => setFilter('dateAddedTo', v)}
                       showYear


### PR DESCRIPTION
## Summary

Closes #46.

- Replaces the two raw `<input type="date">` elements in `ProjectTab.tsx` (log entry date, reminder due date) with the `<CalendarPicker>` component
- Replaces both date-range filter blocks in `ContactsTable.tsx` with `<CalendarPicker>` components, removing all inline styles
- Adds `.date-filter-stack` and `.date-filter-label` CSS classes to `ColumnHeader.css` for the filter UI
- Makes the reminder note field required (Add button disabled until both date and note are filled)
- Adds inline edit for reminders: hover a row to reveal an Edit button; edit form allows updating date and note in place
- Edit form includes a Delete button for removing the reminder
- Completed reminders can be unchecked (toggling back to incomplete)
- Adds `reminders:update` and `reminders:uncomplete` IPC handlers

## Test plan

- [x] In a project: add a log entry and verify the CalendarPicker opens correctly with year navigation
- [x] In a project: try to add a reminder without a note — confirm the Add button stays disabled
- [x] In a project: add a reminder with both a date and a note
- [x] Hover a reminder row and click Edit; change the date and/or note and save
- [x] In the edit form, click Delete and confirm the reminder is removed
- [x] Check off a reminder, then uncheck it; confirm it returns to active
- [x] In All Contacts and a project view: use the "first outreach" date filter; verify range selection works
- [x] Confirm no inline styles remain on date filter blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)