### PR TITLE
Fix: reactive updates for contact table, sidebar counters

### DIFF
--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -135,6 +135,12 @@ function runDedupScan(): void {
   }, 500);
 }
 
+export function broadcastContactsChanged(): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send('contacts:changed');
+  }
+}
+
 export function registerContactHandlers(): void {
   ipcMain.handle('contacts:list', (): ContactListItem[] => {
     const rows = getDatabase()
@@ -333,6 +339,7 @@ export function registerContactHandlers(): void {
 
   ipcMain.handle('contacts:delete', (_, id: string): void => {
     getDatabase().prepare('DELETE FROM contacts WHERE id = ?').run(id);
+    broadcastContactsChanged();
   });
 
   ipcMain.handle(
@@ -478,6 +485,7 @@ export function registerContactHandlers(): void {
         triggerWaybackSave(data.id, url).catch(() => {});
       }
     }
+    broadcastContactsChanged();
   });
 
   ipcMain.handle('memberships:update', (_, data: UpdateMembershipInput): void => {

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -365,6 +365,7 @@ export function registerContactHandlers(): void {
         Math.floor(Date.now() / 1000),
         Math.floor(Date.now() / 1000),
       );
+      broadcastContactsChanged();
     },
   );
 
@@ -374,6 +375,7 @@ export function registerContactHandlers(): void {
       getDatabase()
         .prepare('DELETE FROM project_memberships WHERE contact_id = ? AND project_id = ?')
         .run(contactId, projectId);
+      broadcastContactsChanged();
     },
   );
 
@@ -530,6 +532,7 @@ export function registerContactHandlers(): void {
       ).run(data.membershipId);
       broadcastRemindersChanged();
     }
+    broadcastContactsChanged();
   });
 
   ipcMain.handle(
@@ -548,6 +551,7 @@ export function registerContactHandlers(): void {
           for (const id of membershipIds) stmt.run(priority ?? null, now, id);
         }
       })();
+      broadcastContactsChanged();
     },
   );
 
@@ -590,6 +594,7 @@ export function registerContactHandlers(): void {
       ).run(id, membershipId, user.email, reporterName, body.trim(), ts);
       // Clear any auto-outreach calendar reminder — source is no longer overdue.
       db.prepare('DELETE FROM reminders WHERE membership_id = ? AND is_auto_outreach = 1').run(membershipId);
+      broadcastContactsChanged();
       return {
         id,
         membership_id: membershipId,
@@ -745,6 +750,7 @@ export function registerContactHandlers(): void {
         mergeContactsDb(db, winnerId, loserId, strategy);
       }
       setImmediate(runDedupScan);
+      broadcastContactsChanged();
     },
   );
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -55,6 +55,11 @@ const sourcererApi = {
     ipcRenderer.on('reminders:changed', handler);
     return () => ipcRenderer.removeListener('reminders:changed', handler);
   },
+  onContactsChanged: (callback: () => void): (() => void) => {
+    const handler = () => callback();
+    ipcRenderer.on('contacts:changed', handler);
+    return () => ipcRenderer.removeListener('contacts:changed', handler);
+  },
   onScreenshotReceived: (callback: (tempId: string) => void): (() => void) => {
     const handler = (_e: Electron.IpcRendererEvent, tempId: string) => callback(tempId);
     ipcRenderer.on('extension:screenshot-received', handler);

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -196,6 +196,7 @@ declare global {
       searchGlobal: (query: string) => Promise<SearchResult[]>;
 
       onRemindersChanged: (callback: () => void) => () => void;
+      onContactsChanged: (callback: () => void) => () => void;
 
       // Screenshots
       onScreenshotReceived: (callback: (tempId: string) => void) => () => void;

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -96,6 +96,13 @@ export default function AppShell() {
   }, [refreshOverdue]);
 
   useEffect(() => {
+    return window.sourcerer.onContactsChanged(() => {
+      window.sourcerer.getContactCount().then(setTotalContacts);
+      refreshOverdue();
+    });
+  }, [refreshOverdue]);
+
+  useEffect(() => {
     const offAvailable = window.sourcerer.onUpdateAvailable(({ version }) => {
       setUpdateVersion(version);
       setUpdateState('available');

--- a/src/renderer/src/views/AllContacts.tsx
+++ b/src/renderer/src/views/AllContacts.tsx
@@ -62,6 +62,10 @@ export default function AllContacts({ projects, user, openContactId, onOpenConta
   }, [refreshTrigger, refresh]);
 
   useEffect(() => {
+    return window.sourcerer.onContactsChanged(refresh);
+  }, [refresh]);
+
+  useEffect(() => {
     window.sourcerer.getDuplicatePairs().then((pairs) => {
       setDupPairs(pairs);
       setDupCount(pairs.length);

--- a/src/renderer/src/views/ProjectView.tsx
+++ b/src/renderer/src/views/ProjectView.tsx
@@ -128,6 +128,10 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
   }, [refreshTrigger, refresh]);
 
   useEffect(() => {
+    return window.sourcerer.onContactsChanged(refresh);
+  }, [refresh]);
+
+  useEffect(() => {
     if (!project?.is_shared) return;
     return window.sourcerer.onSyncStatus((event) => {
       if (event.projectId !== project.id) return;


### PR DESCRIPTION
## Summary

Closes #55, #56, #57.

- Contact table view does not update reactively when a contact is edited (name, org, etc.)
- Sidebar contact counter does not update reactively after contact deletion
- Sidebar reminder counter does not update reactively after contact deletion

All three likely share the same root cause: the relevant views re-fetch on mount but don't subscribe to contact mutation events.

## Approach

Wire up a `contacts-changed` event (emitted from the `contacts:update` and `contacts:delete` IPC handlers) that the sidebar and contact table both listen to, triggering a re-fetch when fired.

## Test plan

- [x] Edit a contact's name; verify the table row updates immediately
- [x] Delete a contact; verify the sidebar contact counter decrements immediately
- [x] Delete a contact with reminders; verify the sidebar reminder counter decrements immediately
- [x] Typecheck passes (`npm run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)