### PR TITLE
Show shared project indicator in sidebar

### DIFF
--- a/src/renderer/src/shell/Sidebar.css
+++ b/src/renderer/src/shell/Sidebar.css
@@ -290,6 +290,15 @@
   display: inline-block;
 }
 
+.sidebar-project-shared-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #34d399;
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+
 .sidebar-project-name {
   flex: 1;
   overflow: hidden;

--- a/src/renderer/src/shell/Sidebar.tsx
+++ b/src/renderer/src/shell/Sidebar.tsx
@@ -229,6 +229,9 @@ export default function Sidebar({
                       style={{ background: DOT_COLORS[idx % DOT_COLORS.length] }}
                     />
                     <span className="sidebar-project-name">{project.name}</span>
+                    {project.is_shared === 1 && (
+                      <span className="sidebar-project-shared-dot" title="Shared project" />
+                    )}
                     {project.is_archived === 1 ? (
                       <span
                         className="sidebar-project-delete"


### PR DESCRIPTION
## Summary

The sidebar project list currently gives no visual indication of which projects are shared vs. local. Users have to open a project to find out.

We already use a green dot (●) language elsewhere in the app (e.g. sync status). Apply the same convention to the sidebar: a small green dot alongside any shared project's name.

## Design notes

- Dot should match the existing green dot style used for sync status — same size, same colour
- Position: inline to the left or right of the project name in the sidebar list item
- Should not appear on local-only projects
- Archived shared projects: TBD (probably show the dot, greyed out, consistent with the archived treatment)
- Tooltip on hover would be a nice touch: "Shared project"

## Implementation notes

- `sidebar-project-btn` in `Sidebar.tsx` renders each project row — that's where the dot goes
- Project objects already carry enough info to distinguish shared vs. local (check `is_shared` or equivalent flag on the project type in `src/shared/types.ts`)
- No new IPC needed; data is already available in the sidebar's project list

🤖 Generated with [Claude Code](https://claude.com/claude-code)