### PR TITLE
Add animations and transitions throughout the app

### DIFF
--- a/src/renderer/src/global.css
+++ b/src/renderer/src/global.css
@@ -269,3 +269,12 @@ code {
 .sv-toggle-row--has-hint > div {
   padding-top: 4px;
 }
+/* ── Reduced motion ───────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/src/renderer/src/shell/Modal.css
+++ b/src/renderer/src/shell/Modal.css
@@ -1,3 +1,20 @@
+@keyframes modal-overlay-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes modal-overlay-out {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+@keyframes modal-card-in {
+  from { opacity: 0; transform: scale(0.97); }
+  to   { opacity: 1; transform: scale(1); }
+}
+@keyframes modal-card-out {
+  from { opacity: 1; transform: scale(1); }
+  to   { opacity: 0; transform: scale(0.97); }
+}
+
 .modal-overlay {
   position: fixed;
   inset: 0;
@@ -6,6 +23,11 @@
   align-items: center;
   justify-content: center;
   z-index: 100;
+  animation: modal-overlay-in 150ms ease both;
+}
+
+.modal-overlay--closing {
+  animation: modal-overlay-out 120ms ease both;
 }
 
 .modal-card {
@@ -14,6 +36,11 @@
   padding: 24px;
   width: 420px;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+  animation: modal-card-in 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+}
+
+.modal-card--closing {
+  animation: modal-card-out 120ms cubic-bezier(0.55, 0, 1, 0.45) both;
 }
 
 .modal-title {

--- a/src/renderer/src/shell/Modal.tsx
+++ b/src/renderer/src/shell/Modal.tsx
@@ -1,5 +1,7 @@
-import { useEffect, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import './Modal.css';
+
+const CLOSE_MS = 120;
 
 interface Props {
   title: string;
@@ -9,16 +11,36 @@ interface Props {
 }
 
 export default function Modal({ title, onDismiss, className, children }: Props) {
+  const [closing, setClosing] = useState(false);
+  const closingRef = useRef(false);
+  const onDismissRef = useRef(onDismiss);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => { onDismissRef.current = onDismiss; }, [onDismiss]);
+
+  const dismiss = useCallback(() => {
+    if (closingRef.current) return;
+    closingRef.current = true;
+    setClosing(true);
+    timerRef.current = setTimeout(() => onDismissRef.current(), CLOSE_MS);
+  }, []);
+
   useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onDismiss(); };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') dismiss(); };
     window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onDismiss]);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [dismiss]);
 
   return (
-    <div className="modal-overlay" onClick={onDismiss}>
+    <div
+      className={`modal-overlay${closing ? ' modal-overlay--closing' : ''}`}
+      onClick={dismiss}
+    >
       <div
-        className={`modal-card${className ? ` ${className}` : ''}`}
+        className={`modal-card${closing ? ' modal-card--closing' : ''}${className ? ` ${className}` : ''}`}
         onClick={(e) => e.stopPropagation()}
       >
         <h2 className="modal-title">{title}</h2>

--- a/src/renderer/src/shell/SearchModal.css
+++ b/src/renderer/src/shell/SearchModal.css
@@ -1,3 +1,12 @@
+@keyframes search-overlay-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes search-card-in {
+  from { opacity: 0; transform: translateY(-10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 .search-overlay {
   position: fixed;
   inset: 0;
@@ -7,6 +16,7 @@
   justify-content: center;
   padding-top: 18vh;
   z-index: 9999;
+  animation: search-overlay-in 150ms ease both;
 }
 
 .search-card {
@@ -19,6 +29,7 @@
   flex-direction: column;
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
   overflow: hidden;
+  animation: search-card-in 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
 }
 
 .search-input-row {

--- a/src/renderer/src/views/AllContacts.css
+++ b/src/renderer/src/views/AllContacts.css
@@ -178,6 +178,11 @@
   background: var(--color-surface-2);
 }
 
+@keyframes bulk-bar-in {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 /* Bulk action bar */
 .bulk-bar {
   display: flex;
@@ -189,6 +194,7 @@
   border-bottom: 1px solid var(--color-border-strong);
   font-size: 13px;
   flex-shrink: 0;
+  animation: bulk-bar-in 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
 }
 
 .bulk-bar-element {

--- a/src/renderer/src/views/CalendarPicker.css
+++ b/src/renderer/src/views/CalendarPicker.css
@@ -37,6 +37,11 @@
 
 /* ── Dropdown panel ────────────────────────────────────────── */
 
+@keyframes cal-dropdown-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 .cal-dropdown {
   position: absolute;
   top: calc(100% + 4px);
@@ -48,6 +53,7 @@
   padding: 8px;
   width: 224px;
   user-select: none;
+  animation: cal-dropdown-in 120ms cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
 }
 
 /* ── Month / year header ───────────────────────────────────── */

--- a/src/renderer/src/views/ColumnHeader.css
+++ b/src/renderer/src/views/ColumnHeader.css
@@ -73,6 +73,11 @@
   z-index: 99;
 }
 
+@keyframes dropdown-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 .col-filter-dropdown {
   position: fixed;
   min-width: 190px;
@@ -82,6 +87,7 @@
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.2);
   z-index: 100;
   padding: 8px;
+  animation: dropdown-in 120ms cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
 }
 
 /* Spacing between stacked filter controls */

--- a/src/renderer/src/views/ProjectView.css
+++ b/src/renderer/src/views/ProjectView.css
@@ -72,6 +72,11 @@
   position: relative;
 }
 
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
 /* Sync error banner */
 .sync-error-banner {
   background: color-mix(in srgb, var(--color-danger) 10%, transparent);
@@ -82,5 +87,6 @@
   font-size: 12px;
   color: var(--color-danger);
   line-height: 1.4;
+  animation: fade-in 200ms ease both;
 }
 


### PR DESCRIPTION
Closes #60

Adds short, purposeful entry/exit animations across the main interactive surfaces while respecting `prefers-reduced-motion`.

## What's animated

| Surface | Animation |
|---|---|
| **Modal** (all instances) | Overlay fade + card scale-fade on open and close |
| **Search modal** | Overlay fade + card slide-up on open |
| **Bulk action bar** | Slide-down fade-in on appear |
| **Sync error banner** | Fade-in on appear |
| **Column filter dropdowns** | Fade + tiny Y-shift on open |
| **Calendar picker dropdown** | Fade + tiny Y-shift on open |

## Implementation notes

- Modal close animation is handled internally in `Modal.tsx`: `dismiss()` intercepts `onDismiss`, sets a `closing` state for 120 ms while the CSS out-animation plays, then calls the real callback. All callers are unaffected.
- All other animations are pure CSS — elements that are conditionally rendered automatically play the entry keyframe on mount.
- `prefers-reduced-motion: reduce` collapses all animation/transition durations to 0.01 ms globally via a rule at the bottom of `global.css`, covering both new and existing animations (drawer slide, sync pulse, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)