### PR TITLE
chore: bump to v0.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sourcerer",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sourcerer",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcerer",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "description": "Encrypted source management for journalists",
   "author": "Tom Cardoso",


### PR DESCRIPTION
## What's new

- Shared project key rotation: generate a new encryption key and redistribute access out-of-band
- Modal open/close animations (fade + scale) with `prefers-reduced-motion` support
- Reusable `Button` component across all interactive surfaces
- Unshare and Rotate key actions moved into the Edit project modal danger zone; meta bar tidied to Edit → Export → Sync for shared projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)