### PR TITLE
chore: combine What's new + PR list in release notes

### DIFF
--- a/.github/scripts/extract-whats-new.py
+++ b/.github/scripts/extract-whats-new.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Extract the 'What's new' section from a GitHub PR body.
+"""Extract the 'What's new' section from a GitHub PR body and combine it
+with the auto-generated PR changelog.
 
-Reads the PR body from stdin. Prints the content of the first
-'## What's new' section, stopping at the next heading, horizontal
-rule, or the Claude Code attribution line. Exits with no output if
-the section is not found.
+Reads the PR body from stdin. If a '## What's new' section is found,
+outputs the curated bullets followed by the raw PR list (read from
+/tmp/generated-changelog.md) wrapped in a <details> block. Exits with
+no output if the section is not found, leaving the raw changelog untouched.
 """
 
 import re
@@ -22,5 +23,16 @@ if not m:
 # Strip trailing boilerplate (e.g. "🤖 Generated with [Claude Code](...)")
 content = m.group(1).strip()
 content = re.sub(r"\n*🤖.*$", "", content, flags=re.DOTALL).strip()
-if content:
+if not content:
+    sys.exit(0)
+
+try:
+    with open("/tmp/generated-changelog.md", encoding="utf-8") as f:
+        raw = f.read().strip()
+except OSError:
+    raw = ""
+
+if raw:
+    print(f"{content}\n\n<details>\n<summary>Details</summary>\n\n{raw}\n\n</details>")
+else:
     print(content)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Releases are triggered by pushing a version tag (`v*`). Because `main` is protec
    git push -u origin chore/v{VERSION}
    gh pr create ...
    ```
-4. Optionally add a `## What's new` section to the PR body — the release workflow will use it as the GitHub Release description instead of the auto-generated PR list
+4. Optionally add a `## What's new` section to the PR body — plain English, written for a lay audience. The release workflow will prepend it to the auto-generated PR list (which appears in a collapsible Details block below). If omitted, only the PR list is shown.
 5. Once the PR is merged, push the tag to trigger the build:
    ```bash
    git checkout main && git pull


### PR DESCRIPTION
When a version bump PR includes a `## What's new` section, the current script discards the auto-generated PR list entirely. This PR changes `extract-whats-new.py` to instead prepend the curated bullets and wrap the PR list in a collapsible `<details>` block below — matching the style of earlier releases like v0.1.9.

`build.yml` is untouched; the construction logic stays in the script where it belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)