### PR TITLE
Accessibility audit: focus management, ARIA labels, semantic HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Source and contact management for journalists and researchers — local-first, encrypted, no cloud.
 
 [![Latest release](https://img.shields.io/github/v/release/tomcardoso/sourcerer?label=version&color=4b5563)](https://github.com/tomcardoso/sourcerer/releases/latest)
-[![Build](https://img.shields.io/github/actions/workflow/status/tomcardoso/sourcerer/build.yml?label=build)](https://github.com/tomcardoso/sourcerer/actions/workflows/build.yml)
+[![Build](https://img.shields.io/github/actions/workflow/status/tomcardoso/sourcerer/ci.yml?label=build)](https://github.com/tomcardoso/sourcerer/actions/workflows/ci.yml)
 [![License: AGPL-3.0](https://img.shields.io/github/license/tomcardoso/sourcerer?color=4b5563)](LICENSE)
 
 ![screenshot](docs/img/contact-details-2.png)

--- a/src/renderer/src/contacts/ContactDetail.tsx
+++ b/src/renderer/src/contacts/ContactDetail.tsx
@@ -19,6 +19,7 @@ interface Props {
 type Tab = 'global' | 'project';
 
 export default function ContactDetail({ contactId, onClose, onDeleted, onUpdated, user, closing }: Props) {
+  const panelRef = useRef<HTMLDivElement>(null);
   const [contact, setContact] = useState<ContactDetailType | null>(null);
   const [allProjects, setAllProjects] = useState<Project[]>([]);
   const [statusOptions, setStatusOptions] = useState<StatusOption[]>([]);
@@ -33,6 +34,10 @@ export default function ContactDetail({ contactId, onClose, onDeleted, onUpdated
   const isEditingRef = useRef(isEditing);
   onCloseRef.current = onClose;
   isEditingRef.current = isEditing;
+
+  useEffect(() => {
+    panelRef.current?.focus();
+  }, [contactId]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -92,7 +97,7 @@ export default function ContactDetail({ contactId, onClose, onDeleted, onUpdated
   }
 
   return (
-    <div className={`detail-panel${closing ? ' detail-panel--closing' : ''}`}>
+    <div ref={panelRef} tabIndex={-1} className={`detail-panel${closing ? ' detail-panel--closing' : ''}`}>
       <div className="detail-header">
         <div className="detail-header-main">
           {contact ? (
@@ -114,7 +119,7 @@ export default function ContactDetail({ contactId, onClose, onDeleted, onUpdated
             <div className="detail-loading">Loading…</div>
           )}
         </div>
-        <button className="detail-close" onClick={onClose}>×</button>
+        <button className="detail-close" onClick={onClose} aria-label="Close">×</button>
       </div>
       <div className="view-rule-thick" />
       <div className="view-rule-thin" />

--- a/src/renderer/src/global.css
+++ b/src/renderer/src/global.css
@@ -88,7 +88,7 @@
   --sidebar-active-text:   #faf9f5;
   --sidebar-hover-bg:      #e4e1d7;
   --sidebar-border:        rgba(26, 24, 21, 0.14);
-  --sidebar-width:         224px;
+  --sidebar-width:         250px;
 
   /* ── Typography ───────────────────────────────── */
   --font-serif: 'Spectral', serif;

--- a/src/renderer/src/global.css
+++ b/src/renderer/src/global.css
@@ -88,7 +88,7 @@
   --sidebar-active-text:   #faf9f5;
   --sidebar-hover-bg:      #e4e1d7;
   --sidebar-border:        rgba(26, 24, 21, 0.14);
-  --sidebar-width:         250px;
+  --sidebar-width:         224px;
 
   /* ── Typography ───────────────────────────────── */
   --font-serif: 'Spectral', serif;

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -215,7 +215,7 @@ export default function AppShell() {
             </button>
           )}
           {updateState === 'downloading' && (
-            <span className="app-update-downloading">
+            <span className="app-update-downloading" role="status" aria-live="polite" aria-atomic="true">
               Downloading update{updatePercent !== null ? ` ${updatePercent}%` : '\u2026'}
             </span>
           )}
@@ -228,7 +228,7 @@ export default function AppShell() {
             </button>
           )}
           Sourcerer&nbsp;·&nbsp;Local vault&nbsp;·&nbsp;Encrypted
-          <button className="app-titlebar-lock" onClick={() => window.sourcerer.lock()} title="Lock Sourcerer">
+          <button className="app-titlebar-lock" onClick={() => window.sourcerer.lock()} aria-label="Lock Sourcerer">
             🔒
           </button>
         </div>

--- a/src/renderer/src/shell/Modal.tsx
+++ b/src/renderer/src/shell/Modal.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useId, useRef, useState, type ReactNode } from 'react';
 import './Modal.css';
 
 const CLOSE_MS = 120;
+
+const FOCUSABLE = 'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])';
 
 interface Props {
   title: string;
@@ -15,8 +17,19 @@ export default function Modal({ title, onDismiss, className, children }: Props) 
   const closingRef = useRef(false);
   const onDismissRef = useRef(onDismiss);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const prevFocusRef = useRef<HTMLElement | null>(null);
+  const titleId = useId();
 
   useEffect(() => { onDismissRef.current = onDismiss; }, [onDismiss]);
+
+  // Save caller's focus, auto-focus first modal element, restore on unmount
+  useEffect(() => {
+    prevFocusRef.current = document.activeElement as HTMLElement;
+    const first = cardRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE)[0];
+    first?.focus();
+    return () => { prevFocusRef.current?.focus(); };
+  }, []);
 
   const dismiss = useCallback(() => {
     if (closingRef.current) return;
@@ -34,16 +47,34 @@ export default function Modal({ title, onDismiss, className, children }: Props) 
     };
   }, [dismiss]);
 
+  function handleTabTrap(e: React.KeyboardEvent) {
+    if (e.key !== 'Tab' || !cardRef.current) return;
+    const focusable = Array.from(cardRef.current.querySelectorAll<HTMLElement>(FOCUSABLE));
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey) {
+      if (document.activeElement === first) { e.preventDefault(); last.focus(); }
+    } else {
+      if (document.activeElement === last) { e.preventDefault(); first.focus(); }
+    }
+  }
+
   return (
     <div
       className={`modal-overlay${closing ? ' modal-overlay--closing' : ''}`}
       onClick={dismiss}
     >
       <div
+        ref={cardRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
         className={`modal-card${closing ? ' modal-card--closing' : ''}${className ? ` ${className}` : ''}`}
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleTabTrap}
       >
-        <h2 className="modal-title">{title}</h2>
+        <h2 id={titleId} className="modal-title">{title}</h2>
         {children}
       </div>
     </div>

--- a/src/renderer/src/shell/SearchModal.css
+++ b/src/renderer/src/shell/SearchModal.css
@@ -75,6 +75,11 @@
   align-items: flex-start;
   gap: 8px;
   transition: background 0.1s;
+  width: 100%;
+  background: none;
+  border: none;
+  border-radius: 0;
+  text-align: left;
 }
 
 .search-result-body {

--- a/src/renderer/src/shell/SearchModal.tsx
+++ b/src/renderer/src/shell/SearchModal.tsx
@@ -59,7 +59,7 @@ export default function SearchModal({ onClose, onNav, onOpenContact }: Props) {
 
   return (
     <div className="search-overlay" onClick={onClose}>
-      <div className="search-card" onClick={(e) => e.stopPropagation()}>
+      <div role="dialog" aria-modal="true" aria-label="Search" className="search-card" onClick={(e) => e.stopPropagation()}>
         <div className="search-input-row">
           <input
             ref={inputRef}
@@ -68,6 +68,7 @@ export default function SearchModal({ onClose, onNav, onOpenContact }: Props) {
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Search contacts and projects…"
+            aria-label="Search contacts and projects"
           />
         </div>
 
@@ -154,7 +155,8 @@ function ResultRow({ result, selected, onMouseEnter, onClick }: {
   const excerpt = result.type === 'log' ? result.excerpt.replace(/\[\[/g, '').replace(/\]\]/g, '') : null;
 
   return (
-    <div
+    <button
+      type="button"
       className={`search-result-row${selected ? ' search-result-row--selected' : ''}`}
       onMouseEnter={onMouseEnter}
       onClick={onClick}
@@ -171,6 +173,6 @@ function ResultRow({ result, selected, onMouseEnter, onClick }: {
           <span className="search-result-excerpt">{excerpt}</span>
         )}
       </span>
-    </div>
+    </button>
   );
 }

--- a/src/renderer/src/shell/Sidebar.css
+++ b/src/renderer/src/shell/Sidebar.css
@@ -291,7 +291,9 @@
   color: var(--color-text-muted);
   opacity: 0;
   padding: 0 2px;
+  border: none;
   border-radius: 0;
+  background: none;
   cursor: pointer;
   transition: opacity 0.1s, color 0.1s;
 }

--- a/src/renderer/src/shell/Sidebar.css
+++ b/src/renderer/src/shell/Sidebar.css
@@ -203,8 +203,13 @@
   align-items: center;
 }
 
-.sidebar-project-row:hover {
+.sidebar-project-row:hover,
+.sidebar-project-row--active {
   background: var(--color-surface);
+}
+
+.sidebar-project-row--active {
+  background: var(--color-surface-2);
 }
 
 .sidebar-project-btn {
@@ -227,10 +232,8 @@
 }
 
 .sidebar-project-btn.active {
-  background: var(--color-surface-2);
   box-shadow: inset 3px 0 0 var(--color-text);
   color: var(--color-text);
-  border-radius: 0;
 }
 
 /* Timeline sub-item under a selected project */

--- a/src/renderer/src/shell/Sidebar.css
+++ b/src/renderer/src/shell/Sidebar.css
@@ -198,10 +198,20 @@
   margin-bottom: 1px;
 }
 
+.sidebar-project-row {
+  display: flex;
+  align-items: center;
+}
+
+.sidebar-project-row:hover {
+  background: var(--color-surface);
+}
+
 .sidebar-project-btn {
   display: flex;
   align-items: center;
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   padding: 7px 8px;
   border: none;
   border-radius: 0;
@@ -213,12 +223,7 @@
   letter-spacing: normal;
   text-align: left;
   cursor: pointer;
-  transition: background 0.1s;
   gap: 8px;
-}
-
-.sidebar-project-btn:hover {
-  background: var(--color-surface);
 }
 
 .sidebar-project-btn.active {
@@ -298,8 +303,8 @@
   transition: opacity 0.1s, color 0.1s;
 }
 
-.sidebar-project-btn:hover .sidebar-project-delete,
-.sidebar-project-btn:hover .sidebar-project-archive {
+.sidebar-project-row:hover .sidebar-project-delete,
+.sidebar-project-row:hover .sidebar-project-archive {
   opacity: 1;
 }
 
@@ -311,11 +316,11 @@
   color: var(--color-text);
 }
 
-.sidebar-project-item--archived .sidebar-project-btn {
+.sidebar-project-item--archived .sidebar-project-row {
   opacity: 0.45;
 }
 
-.sidebar-project-item--archived .sidebar-project-btn:hover {
+.sidebar-project-item--archived .sidebar-project-row:hover {
   opacity: 0.75;
 }
 

--- a/src/renderer/src/shell/Sidebar.tsx
+++ b/src/renderer/src/shell/Sidebar.tsx
@@ -219,27 +219,30 @@ export default function Sidebar({
                   </div>
                 ) : (
                   <>
-                  <button
-                    className={`sidebar-project-btn ${isActive({ view: 'project', projectId: project.id }) ? 'active' : ''}`}
-                    onClick={() => onNav({ view: 'project', projectId: project.id })}
-                    onDoubleClick={() => project.is_archived === 0 && startRename(project)}
-                    title={project.is_archived === 0 ? 'Double-click to rename' : undefined}
-                  >
-                    <span
-                      className="sidebar-project-dot"
-                      style={{ background: DOT_COLORS[idx % DOT_COLORS.length] }}
-                      aria-hidden="true"
-                    />
-                    <span className="sidebar-project-name">{project.name}</span>
-                    {project.is_shared === 1 && (
-                      <span className="sidebar-project-shared-dot" aria-label="Shared" role="img" />
-                    )}
+                  <div className="sidebar-project-row">
+                    <button
+                      className={`sidebar-project-btn ${isActive({ view: 'project', projectId: project.id }) ? 'active' : ''}`}
+                      onClick={() => onNav({ view: 'project', projectId: project.id })}
+                      onDoubleClick={() => project.is_archived === 0 && startRename(project)}
+                      title={project.is_archived === 0 ? 'Double-click to rename' : undefined}
+                    >
+                      <span
+                        className="sidebar-project-dot"
+                        style={{ background: DOT_COLORS[idx % DOT_COLORS.length] }}
+                        aria-hidden="true"
+                      />
+                      <span className="sidebar-project-name">{project.name}</span>
+                      {project.is_shared === 1 && (
+                        <span className="sidebar-project-shared-dot" aria-label="Shared" role="img" />
+                      )}
+                    </button>
                     {project.is_archived === 1 ? (
                       <button
                         type="button"
                         className="sidebar-project-delete"
                         aria-label="Unarchive project"
-                        onClick={(e) => { e.stopPropagation(); handleUnarchive(project.id); }}
+                        title="Unarchive project"
+                        onClick={() => handleUnarchive(project.id)}
                       >↩</button>
                     ) : (
                       <>
@@ -247,17 +250,19 @@ export default function Sidebar({
                           type="button"
                           className="sidebar-project-archive"
                           aria-label="Archive project"
-                          onClick={(e) => { e.stopPropagation(); handleArchive(project.id); }}
+                          title="Archive project"
+                          onClick={() => handleArchive(project.id)}
                         >⊘</button>
                         <button
                           type="button"
                           className="sidebar-project-delete"
                           aria-label="Delete project"
-                          onClick={(e) => { e.stopPropagation(); setDeletingId(project.id); }}
+                          title="Delete project"
+                          onClick={() => setDeletingId(project.id)}
                         >×</button>
                       </>
                     )}
-                  </button>
+                  </div>
                   {isActive({ view: 'project', projectId: project.id }) && (
                     <button
                       className={`sidebar-project-sub-btn${'projectId' in nav && nav.view === 'timeline' && nav.projectId === project.id ? ' active' : ''}`}

--- a/src/renderer/src/shell/Sidebar.tsx
+++ b/src/renderer/src/shell/Sidebar.tsx
@@ -219,7 +219,7 @@ export default function Sidebar({
                   </div>
                 ) : (
                   <>
-                  <div className="sidebar-project-row">
+                  <div className={`sidebar-project-row${isActive({ view: 'project', projectId: project.id }) ? ' sidebar-project-row--active' : ''}`}>
                     <button
                       className={`sidebar-project-btn ${isActive({ view: 'project', projectId: project.id }) ? 'active' : ''}`}
                       onClick={() => onNav({ view: 'project', projectId: project.id })}

--- a/src/renderer/src/shell/Sidebar.tsx
+++ b/src/renderer/src/shell/Sidebar.tsx
@@ -187,7 +187,7 @@ export default function Sidebar({
         <div className="sidebar-section">
           <div className="sidebar-section-header-row">
             <span className="sidebar-section-label">Projects</span>
-            <button className="sidebar-header-add" onClick={() => setShowNewProject(true)} title="New project">+</button>
+            <button className="sidebar-header-add" onClick={() => setShowNewProject(true)} aria-label="New project">+</button>
           </div>
 
           {projects.length === 0 && (
@@ -228,32 +228,33 @@ export default function Sidebar({
                     <span
                       className="sidebar-project-dot"
                       style={{ background: DOT_COLORS[idx % DOT_COLORS.length] }}
+                      aria-hidden="true"
                     />
                     <span className="sidebar-project-name">{project.name}</span>
                     {project.is_shared === 1 && (
-                      <span className="sidebar-project-shared-dot" title="Shared project" />
+                      <span className="sidebar-project-shared-dot" aria-label="Shared" role="img" />
                     )}
                     {project.is_archived === 1 ? (
-                      <span
+                      <button
+                        type="button"
                         className="sidebar-project-delete"
-                        role="button"
-                        title="Unarchive project"
+                        aria-label="Unarchive project"
                         onClick={(e) => { e.stopPropagation(); handleUnarchive(project.id); }}
-                      >↩</span>
+                      >↩</button>
                     ) : (
                       <>
-                        <span
+                        <button
+                          type="button"
                           className="sidebar-project-archive"
-                          role="button"
-                          title="Archive project"
+                          aria-label="Archive project"
                           onClick={(e) => { e.stopPropagation(); handleArchive(project.id); }}
-                        >⊘</span>
-                        <span
+                        >⊘</button>
+                        <button
+                          type="button"
                           className="sidebar-project-delete"
-                          role="button"
-                          title="Delete project"
+                          aria-label="Delete project"
                           onClick={(e) => { e.stopPropagation(); setDeletingId(project.id); }}
-                        >×</span>
+                        >×</button>
                       </>
                     )}
                   </button>

--- a/src/renderer/src/views/ColumnHeader.tsx
+++ b/src/renderer/src/views/ColumnHeader.tsx
@@ -59,7 +59,8 @@ export default function ColumnHeader({
           ref={filterBtnRef}
           className={`col-filter-btn ${filterActive ? 'col-filter-btn-on' : ''}`}
           onClick={handleFilterClick}
-          title={filterActive ? `${label}: filter on` : `Filter ${label}`}
+          aria-label={filterActive ? `${label}: filter on` : `Filter ${label}`}
+          aria-pressed={filterActive ?? false}
         >
           {filterActive ? '●' : '▾'}
         </button>
@@ -68,7 +69,7 @@ export default function ColumnHeader({
         filterContent &&
         createPortal(
           <>
-            <div className="col-filter-overlay" onClick={() => onFilterToggle?.()} />
+            <div className="col-filter-overlay" aria-hidden="true" onClick={() => onFilterToggle?.()} />
             <div
               className="col-filter-dropdown"
               style={{ top: dropdownPos.top, left: dropdownPos.left }}
@@ -105,7 +106,7 @@ export function TextFilter({
         placeholder={placeholder}
       />
       {value && (
-        <button className="col-filter-clear" onClick={() => onChange('')}>
+        <button className="col-filter-clear" onClick={() => onChange('')} aria-label="Clear filter">
           ×
         </button>
       )}


### PR DESCRIPTION
Closes #67

## What changed

**Focus management**
- `Modal`: focus trap (Tab/Shift+Tab cycles within modal), auto-focuses first interactive element on open, restores caller's focus on close
- `ContactDetail`: panel receives focus when a contact is opened (`tabIndex=-1` + `focus()`); Escape still closes as before

**ARIA / semantic HTML**
- `Modal`: `role="dialog"`, `aria-modal="true"`, `aria-labelledby` wired to the title `<h2>`
- `SearchModal`: `role="dialog"`/`aria-modal` on the card; `aria-label` on search input; `ResultRow` converted from `<div>` to `<button>` — keyboard-accessible without any extra handlers since navigation is already managed at the input level
- `Sidebar`: project archive/delete/unarchive `<span role="button">` → real `<button>` elements with `aria-label`; `aria-label` on the New project `+` button; decorative dot gets `aria-hidden="true"`; CSS reset (`background: none; border: none`) for the new button elements
- `ColumnHeader`: `aria-label` + `aria-pressed` on the filter toggle button; `aria-label="Clear filter"` on the `×` button; `aria-hidden="true"` on the click-to-close backdrop overlay
- `AppShell`: `aria-label="Lock Sourcerer"` on the lock button; `role="status"` + `aria-live="polite"` on the update download progress span
- `ContactDetail`: `aria-label="Close"` on the `×` button

## Not addressed (out of scope / too complex for this pass)
- Full keyboard navigation for custom dropdowns (reporter/project search fields)
- Drag-handle keyboard reordering
- `aria-live` on search results count (would be noisy on every keystroke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)