### PR TITLE
Virtualize All Contacts table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/utils": "^3.0.0",
+        "@tanstack/react-virtual": "^3.13.24",
         "argon2": "^0.41.1",
         "better-sqlite3-multiple-ciphers": "^12.9.0",
         "electron-log": "^5.4.4",
@@ -2088,6 +2089,33 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^3.0.0",
+    "@tanstack/react-virtual": "^3.13.24",
     "argon2": "^0.41.1",
     "better-sqlite3-multiple-ciphers": "^12.9.0",
     "electron-log": "^5.4.4",

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -21,6 +21,7 @@
   overflow: hidden;
   z-index: 10;
   box-shadow: -8px 0 32px rgba(0, 0, 0, 0.08);
+  will-change: transform;
   animation: detail-slide-in 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
 }
 

--- a/src/renderer/src/contacts/ContactDetail.tsx
+++ b/src/renderer/src/contacts/ContactDetail.tsx
@@ -36,7 +36,7 @@ export default function ContactDetail({ contactId, onClose, onDeleted, onUpdated
   isEditingRef.current = isEditing;
 
   useEffect(() => {
-    panelRef.current?.focus();
+    panelRef.current?.focus({ preventScroll: true });
   }, [contactId]);
 
   useEffect(() => {

--- a/src/renderer/src/views/AllContacts.css
+++ b/src/renderer/src/views/AllContacts.css
@@ -24,6 +24,10 @@
   color: var(--color-text-muted);
 }
 
+.virt-spacer {
+  padding: 0;
+}
+
 .contacts-table {
   width: 100%;
   border-collapse: collapse;

--- a/src/renderer/src/views/AllContacts.tsx
+++ b/src/renderer/src/views/AllContacts.tsx
@@ -42,6 +42,7 @@ export default function AllContacts({ projects, user, openContactId, onOpenConta
   const exportMenuRef = useRef<HTMLDivElement>(null);
   const bulkProjectMenuRef = useRef<HTMLDivElement>(null);
   const selectAllRef = useRef<HTMLInputElement>(null);
+  const tableAreaRef = useRef<HTMLDivElement>(null);
 
   const refresh = useCallback(() => {
     window.sourcerer.listContacts().then(setContacts);
@@ -401,7 +402,7 @@ export default function AllContacts({ projects, user, openContactId, onOpenConta
       )}
 
       <div className={`contacts-body${detailId && checkedIds.size <= 1 ? ' contacts-body--detail-open' : ''}`}>
-        <div className="contacts-table-area">
+        <div className="contacts-table-area" ref={tableAreaRef}>
           <ContactsTable
             mode="all"
             rows={displayed}
@@ -421,6 +422,8 @@ export default function AllContacts({ projects, user, openContactId, onOpenConta
             selectAllRef={selectAllRef}
             user={user}
             projects={projects}
+            virtualize
+            scrollContainerRef={tableAreaRef}
           />
         </div>
       </div>

--- a/src/renderer/src/views/ContactsTable.tsx
+++ b/src/renderer/src/views/ContactsTable.tsx
@@ -1,4 +1,5 @@
 import { useEffect, type RefObject } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { fmtDate } from '../utils/fmtDate';
 import type {
   ContactListItem,
@@ -144,6 +145,8 @@ interface BaseTableProps {
   user: User | null;
   /** Total rows before filtering — used to distinguish "no data" from "no match" */
   totalCount: number;
+  virtualize?: boolean;
+  scrollContainerRef?: RefObject<HTMLDivElement>;
 }
 
 interface AllContactsTableProps extends BaseTableProps {
@@ -187,6 +190,8 @@ export default function ContactsTable(props: ContactsTableProps) {
     user,
     filters,
     totalCount,
+    virtualize = false,
+    scrollContainerRef,
   } = props;
 
   const isProject = mode === 'project';
@@ -215,6 +220,20 @@ export default function ContactsTable(props: ContactsTableProps) {
     if (!stalenessEnabled) return false;
     return ts === null || ts < now - stalenessThresholdSecs;
   }
+
+  const virtualizer = useVirtualizer({
+    count: virtualize ? rows.length : 0,
+    getScrollElement: () => scrollContainerRef?.current ?? null,
+    estimateSize: () => 41,
+    overscan: 10,
+  });
+
+  const virtualItems = virtualize ? virtualizer.getVirtualItems() : null;
+  const paddingTop = virtualItems?.length ? virtualItems[0].start : 0;
+  const paddingBottom = virtualItems?.length
+    ? virtualizer.getTotalSize() - virtualItems[virtualItems.length - 1].end
+    : 0;
+  const rowsToRender = virtualItems ? virtualItems.map((vi) => rows[vi.index]) : rows;
 
   const sd = (key: string) => (sort.key === key ? sort.dir : null);
   const colSpan = isProject ? 13 : 10;
@@ -568,116 +587,130 @@ export default function ContactsTable(props: ContactsTableProps) {
             </td>
           </tr>
         ) : (
-          rows.map((row) => {
-            const pr = isProject ? (row as ProjectContactRow) : null;
-            const ar = !isProject ? (row as ContactListItem) : null;
-            const isMe =
-              isProject && pp?.userEmail && (row as ProjectContactRow).reporter_email === pp.userEmail;
-            return (
-              <tr
-                key={row.id}
-                className={[
-                  selectedId === row.id ? 'selected' : '',
-                  checkedIds.has(row.id) ? 'checked' : '',
-                  isMe ? 'row row-mine' : 'row',
-                ]
-                  .filter(Boolean)
-                  .join(' ')}
-                onClick={() => onRowClick(row.id)}
-              >
-                <td className="contact-check-cell" onClick={(e) => onCheck(row.id, e)}>
-                  <input type="checkbox" checked={checkedIds.has(row.id)} onChange={() => {}} />
-                </td>
-
-                <td className="contact-name-cell">{row.name}</td>
-                <td className="contact-org-cell">{row.organization ?? '—'}</td>
-
-                {/* Project-only cells */}
-                {isProject && (
-                  <td className="contact-org-cell">
-                    {pr?.theme ?? <span className="contact-cell-muted">—</span>}
-                  </td>
-                )}
-                {isProject && (
-                  <td>{pr?.status ?? <span className="contact-cell-muted">—</span>}</td>
-                )}
-                {isProject && (
-                  <td>{pr?.priority ?? <span className="contact-cell-muted">—</span>}</td>
-                )}
-                {isProject && (
-                  <td className="contact-org-cell">{pr?.reporter_name}</td>
-                )}
-
-                {/* Project-only: Date Added */}
-                {isProject && (
-                  <td className="contact-date-cell">
-                    {fmtDate((pr as ProjectContactRow).membership_created_at)}
-                  </td>
-                )}
-
-                {/* Shared cells */}
-                <td className="contact-bool-cell">
-                  {row.has_email ? (
-                    <span className="contact-bool-yes">✓</span>
-                  ) : (
-                    <span className="contact-cell-muted">—</span>
-                  )}
-                </td>
-                <td className="contact-bool-cell">
-                  {row.has_phone ? (
-                    <span className="contact-bool-yes">✓</span>
-                  ) : (
-                    <span className="contact-cell-muted">—</span>
-                  )}
-                </td>
-                <td className="contact-bool-cell">
-                  {row.notes ? (
-                    <span className="contact-notes-icon">✎</span>
-                  ) : (
-                    <span className="contact-cell-muted">—</span>
-                  )}
-                </td>
-                <td className="contact-date-cell">
-                  {row.date_first_contacted === null ? (
-                    <span className="contact-cell-muted">—</span>
-                  ) : (
-                    fmtDate(row.date_first_contacted)
-                  )}
-                </td>
-                <td
-                  className={`contact-date-cell${isStale(row.date_last_contacted) ? ' contact-date-stale' : ''}`}
+          <>
+            {paddingTop > 0 && (
+              <tr aria-hidden="true">
+                {/* eslint-disable-next-line react/forbid-dom-props */}
+                <td colSpan={colSpan} className="virt-spacer" style={{ height: paddingTop }} />
+              </tr>
+            )}
+            {rowsToRender.map((row) => {
+              const pr = isProject ? (row as ProjectContactRow) : null;
+              const ar = !isProject ? (row as ContactListItem) : null;
+              const isMe =
+                isProject && pp?.userEmail && (row as ProjectContactRow).reporter_email === pp.userEmail;
+              return (
+                <tr
+                  key={row.id}
+                  className={[
+                    selectedId === row.id ? 'selected' : '',
+                    checkedIds.has(row.id) ? 'checked' : '',
+                    isMe ? 'row row-mine' : 'row',
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
+                  onClick={() => onRowClick(row.id)}
                 >
-                  {row.date_last_contacted === null ? (
-                    <span className="contact-cell-muted">Never</span>
-                  ) : (
-                    fmtDate(row.date_last_contacted)
-                  )}
-                </td>
-
-                {/* AllContacts-only: Date Added */}
-                {!isProject && (
-                  <td className="contact-date-cell">
-                    {fmtDate((ar as ContactListItem).created_at)}
+                  <td className="contact-check-cell" onClick={(e) => onCheck(row.id, e)}>
+                    <input type="checkbox" checked={checkedIds.has(row.id)} onChange={() => {}} />
                   </td>
-                )}
 
-                {/* AllContacts-only: Projects */}
-                {!isProject && (
-                  <td className="contact-projects-cell">
-                    {(ar?.projects.length ?? 0) === 0 ? (
-                      <span className="contact-no-projects">—</span>
+                  <td className="contact-name-cell">{row.name}</td>
+                  <td className="contact-org-cell">{row.organization ?? '—'}</td>
+
+                  {/* Project-only cells */}
+                  {isProject && (
+                    <td className="contact-org-cell">
+                      {pr?.theme ?? <span className="contact-cell-muted">—</span>}
+                    </td>
+                  )}
+                  {isProject && (
+                    <td>{pr?.status ?? <span className="contact-cell-muted">—</span>}</td>
+                  )}
+                  {isProject && (
+                    <td>{pr?.priority ?? <span className="contact-cell-muted">—</span>}</td>
+                  )}
+                  {isProject && (
+                    <td className="contact-org-cell">{pr?.reporter_name}</td>
+                  )}
+
+                  {/* Project-only: Date Added */}
+                  {isProject && (
+                    <td className="contact-date-cell">
+                      {fmtDate((pr as ProjectContactRow).membership_created_at)}
+                    </td>
+                  )}
+
+                  {/* Shared cells */}
+                  <td className="contact-bool-cell">
+                    {row.has_email ? (
+                      <span className="contact-bool-yes">✓</span>
                     ) : (
-                      ar?.projects.map((p) => (
-                        <span key={p.id} className="project-tag">
-                          {p.name}
-                        </span>
-                      ))
+                      <span className="contact-cell-muted">—</span>
                     )}
                   </td>
-                )}
+                  <td className="contact-bool-cell">
+                    {row.has_phone ? (
+                      <span className="contact-bool-yes">✓</span>
+                    ) : (
+                      <span className="contact-cell-muted">—</span>
+                    )}
+                  </td>
+                  <td className="contact-bool-cell">
+                    {row.notes ? (
+                      <span className="contact-notes-icon">✎</span>
+                    ) : (
+                      <span className="contact-cell-muted">—</span>
+                    )}
+                  </td>
+                  <td className="contact-date-cell">
+                    {row.date_first_contacted === null ? (
+                      <span className="contact-cell-muted">—</span>
+                    ) : (
+                      fmtDate(row.date_first_contacted)
+                    )}
+                  </td>
+                  <td
+                    className={`contact-date-cell${isStale(row.date_last_contacted) ? ' contact-date-stale' : ''}`}
+                  >
+                    {row.date_last_contacted === null ? (
+                      <span className="contact-cell-muted">Never</span>
+                    ) : (
+                      fmtDate(row.date_last_contacted)
+                    )}
+                  </td>
+
+                  {/* AllContacts-only: Date Added */}
+                  {!isProject && (
+                    <td className="contact-date-cell">
+                      {fmtDate((ar as ContactListItem).created_at)}
+                    </td>
+                  )}
+
+                  {/* AllContacts-only: Projects */}
+                  {!isProject && (
+                    <td className="contact-projects-cell">
+                      {(ar?.projects.length ?? 0) === 0 ? (
+                        <span className="contact-no-projects">—</span>
+                      ) : (
+                        ar?.projects.map((p) => (
+                          <span key={p.id} className="project-tag">
+                            {p.name}
+                          </span>
+                        ))
+                      )}
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
+            {paddingBottom > 0 && (
+              <tr aria-hidden="true">
+                {/* eslint-disable-next-line react/forbid-dom-props */}
+                <td colSpan={colSpan} className="virt-spacer" style={{ height: paddingBottom }} />
               </tr>
-            );
-          })
+            )}
+          </>
         )}
       </tbody>
     </table>

--- a/src/renderer/src/views/ContactsTable.tsx
+++ b/src/renderer/src/views/ContactsTable.tsx
@@ -226,6 +226,23 @@ export default function ContactsTable(props: ContactsTableProps) {
     getScrollElement: () => scrollContainerRef?.current ?? null,
     estimateSize: () => 41,
     overscan: 10,
+    // Only notify on height changes — width changes (e.g. detail panel open/close)
+    // are irrelevant for vertical virtualization and would cause a spurious re-render
+    // that blocks the first animation frame of the detail panel slide-in.
+    observeElementRect: (instance, cb) => {
+      const el = instance.scrollElement;
+      if (!el) return () => {};
+      let prevH = 0;
+      const ro = new ResizeObserver(([entry]) => {
+        const h = Math.round(entry.contentRect.height);
+        if (h !== prevH) {
+          prevH = h;
+          cb({ height: h, width: entry.contentRect.width });
+        }
+      });
+      ro.observe(el);
+      return () => ro.disconnect();
+    },
   });
 
   const virtualItems = virtualize ? virtualizer.getVirtualItems() : null;


### PR DESCRIPTION
## What's new

Adds row virtualization to the All Contacts table using `@tanstack/react-virtual`. Only the rows currently visible in the viewport are rendered in the DOM — everything else is represented by spacer rows. This keeps the list fast and responsive no matter how many contacts are in the database, since React only has to reconcile ~25 rows at a time instead of potentially thousands.

The virtualizer is opt-in via a `virtualize` + `scrollContainerRef` prop pair on `ContactsTable`, so project views (which are bounded by project membership size) are unaffected and continue rendering normally.

Sorting, filtering, bulk selection (including Select All), and the contact detail drawer all work without any changes — they operate on the full `displayed` array, not just the visible slice.

## Test plan

- [x] Open All Contacts with the dev seed (100 contacts) — table renders and scrolls
- [x] Sort by any column — list reorders correctly, scroll resets naturally
- [x] Apply a text filter — only matching rows appear, virtualizer adapts to new count
- [x] Select All — all `displayed` contacts checked, not just visible rows
- [x] Bulk delete a selection — rows removed correctly
- [x] Click a row to open the detail drawer — selected state highlights correctly
- [x] Clear filters — full list reappears
- [x] Resize window — virtualizer adapts to new viewport height

🤖 Generated with [Claude Code](https://claude.com/claude-code)