### PR TITLE
Fix sticky table header and bulk-bar dropdown z-index

### DIFF
--- a/src/renderer/src/views/AllContacts.css
+++ b/src/renderer/src/views/AllContacts.css
@@ -46,7 +46,7 @@
   text-align: left;
   padding: 8px 12px;
   background: var(--color-bg);
-  border-bottom: 1px solid var(--color-border-strong);
+  box-shadow: inset 0 -1px 0 var(--color-border-strong);
   position: sticky;
   top: 0;
   z-index: 1;

--- a/src/renderer/src/views/AllContacts.css
+++ b/src/renderer/src/views/AllContacts.css
@@ -6,6 +6,7 @@
 
 .contacts-table-area {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   overflow-x: auto;
   display: flex;
@@ -189,6 +190,8 @@
 
 /* Bulk action bar */
 .bulk-bar {
+  position: relative;
+  z-index: 2;
   display: flex;
   align-items: center;
   justify-content: flex-start;


### PR DESCRIPTION
## Summary

- **Sticky header (new bug):** `.contacts-table-area` lacked `min-height: 0`. Flex items default to `min-height: auto`, which lets the scroll container grow to fit all table content instead of clipping it — so `position: sticky` on `th` had nothing to stick to. One line fix.
- **Dropdown z-index (issue #73):** `.bulk-bar` had no stacking context, so its descendant `.bulk-project-wrap` (position: relative, no z-index) was painted at stacking step 6 ("z-index: auto"), while the sticky `th` (z-index: 1) was painted at step 7 and covered the dropdown. Adding `position: relative; z-index: 2` to `.bulk-bar` creates a stacking context that outranks the `th`, so dropdowns ("Remove from…", "Add to project") now render above the header row.

## Test plan

- [x] Scroll a long contacts list — header row stays pinned at the top with its border intact
- [x] Select one or more contacts, open "Add to project" and "Remove from…" dropdowns — both render above the table header row

🤖 Generated with [Claude Code](https://claude.com/claude-code)