### PR TITLE
Fix phone/email/handle labels wrapping to next line in detail view

### DIFF
--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -144,7 +144,9 @@
 }
 
 .detail-value {
-  display: block;
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
   font-size: 13px;
   color: var(--color-text);
   margin-bottom: 2px;
@@ -1096,7 +1098,7 @@
 .detail-phone-label {
   font-size: 12px;
   color: var(--color-text-muted);
-  margin-left: 5px;
+  white-space: nowrap;
 }
 
 .detail-website-row {


### PR DESCRIPTION
## Summary

- `.detail-value` was `display: block`, which allowed long values (phone numbers, email addresses, handles) to wrap within the block and push the label span onto a visually separate line
- Switched to `display: flex; align-items: baseline; gap: 4px` so the value and its label are always inline on the same row
- Removed `margin-left` from `.detail-phone-label` (now handled by `gap`) and added `white-space: nowrap` so labels never break mid-word

## Test plan

- [x] Open a contact with a labelled phone number — label should appear inline next to the number
- [x] Confirm same for email labels and messaging handle labels
- [x] Verify behaviour holds in split-panel (narrow) mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)