### PR TITLE
Show 'Today' instead of '0d ago' for reminders due today

### DIFF
--- a/src/renderer/src/views/RemindersView.tsx
+++ b/src/renderer/src/views/RemindersView.tsx
@@ -217,7 +217,7 @@ export default function RemindersView({ onCountChange, user }: Props) {
                   <ReminderRow
                     key={r.id}
                     reminder={r}
-                    daysLabel={`${Math.abs(relDays(r.due_date))}d ago`}
+                    daysLabel={relDays(r.due_date) === 0 ? 'Today' : `${Math.abs(relDays(r.due_date))}d ago`}
                     overdue
                     onDelete={handleDelete}
                     onContactClick={openContact}


### PR DESCRIPTION
## Summary

- `relDays()` returns 0 for reminders due within the current day, producing the confusing label "0d ago"
- The upcoming section already uses `'Today'` for `days === 0`; this brings the overdue section into line

## Test plan

- [x] Mark a reminder as due today and confirm it shows "Today" in the Overdue group, not "0d ago"

🤖 Generated with [Claude Code](https://claude.com/claude-code)