### PR TITLE
Update vCard import modal to list Title and IMPP fields

### DIFF
--- a/src/renderer/src/views/ImportCsvModal.tsx
+++ b/src/renderer/src/views/ImportCsvModal.tsx
@@ -106,8 +106,9 @@ export default function ImportCsvModal({ projects, preselectedProjectId, onCompl
             <div className="icm-columns">
               <div className="icm-col-group">
                 <div className="icm-col-tags">
-                  {['Name (FN)', 'Organization (ORG)', 'Notes (NOTE)',
-                    'Email (EMAIL)', 'Phone (TEL)', 'Website (URL)'].map((h) => (
+                  {['Name (FN)', 'Organization (ORG)', 'Title (TITLE)',
+                    'Notes (NOTE)', 'Email (EMAIL)', 'Phone (TEL)',
+                    'Website (URL)', 'Messaging handles (IMPP)'].map((h) => (
                     <span key={h} className="icm-tag">{h}</span>
                   ))}
                 </div>


### PR DESCRIPTION
## Summary

- The import modal listed the original six vCard fields (FN, ORG, NOTE, EMAIL, TEL, URL)
- The importer was later extended to parse `TITLE` and `IMPP` (messaging handles like Signal, WhatsApp, Telegram) but the modal description was never updated
- Adds both fields to the displayed list

## Test plan

- [x] Open the import modal and switch to vCard tab — confirm Title and Messaging handles (IMPP) appear in the field list

🤖 Generated with [Claude Code](https://claude.com/claude-code)