### PR TITLE
feat: multiple Google Alert RSS feeds per contact

### DIFF
--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -90,7 +90,7 @@ export const LOCAL_SCHEMA_SQL = `
 
   CREATE TABLE IF NOT EXISTS contact_alert_rss (
     id             TEXT    PRIMARY KEY,
-    contact_id     TEXT    NOT NULL UNIQUE REFERENCES contacts(id) ON DELETE CASCADE,
+    contact_id     TEXT    NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
     rss_url        TEXT    NOT NULL,
     last_polled_at INTEGER,
     is_invalid     INTEGER NOT NULL DEFAULT 0,

--- a/src/main/database/shared-schema.ts
+++ b/src/main/database/shared-schema.ts
@@ -57,7 +57,7 @@ export const SHARED_SCHEMA_SQL = `
 
   CREATE TABLE IF NOT EXISTS contact_alert_rss (
     id             TEXT    PRIMARY KEY,
-    contact_id     TEXT    NOT NULL UNIQUE REFERENCES contacts(id) ON DELETE CASCADE,
+    contact_id     TEXT    NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
     rss_url        TEXT    NOT NULL,
     last_polled_at INTEGER,
     is_invalid     INTEGER NOT NULL DEFAULT 0

--- a/src/main/ipc/alerts.ts
+++ b/src/main/ipc/alerts.ts
@@ -17,6 +17,8 @@ export function registerAlertHandlers(): void {
     (_, { contactId, rssUrl }: { contactId: string; rssUrl: string }): void => {
       if (!validateUrl(rssUrl)) throw new Error('Invalid RSS URL');
       const db = getDatabase();
+      const existing = db.prepare(`SELECT 1 FROM contact_alert_rss WHERE contact_id = ? AND rss_url = ?`).get(contactId, rssUrl);
+      if (existing) return;
       const id = uuidv4();
       db.prepare(
         `INSERT INTO contact_alert_rss (id, contact_id, rss_url) VALUES (?, ?, ?)`,

--- a/src/main/ipc/alerts.ts
+++ b/src/main/ipc/alerts.ts
@@ -6,34 +6,30 @@ import { validateUrl } from '@shared/validation';
 import type { ContactAlertRss, ContactAlertMention } from '@shared/types';
 
 export function registerAlertHandlers(): void {
-  ipcMain.handle('alerts:get-rss', (_, contactId: string): ContactAlertRss | null => {
-    return (
-      (getDatabase()
-        .prepare(`SELECT * FROM contact_alert_rss WHERE contact_id = ?`)
-        .get(contactId) as ContactAlertRss | undefined) ?? null
-    );
+  ipcMain.handle('alerts:list-rss', (_, contactId: string): ContactAlertRss[] => {
+    return getDatabase()
+      .prepare(`SELECT * FROM contact_alert_rss WHERE contact_id = ? ORDER BY rowid`)
+      .all(contactId) as ContactAlertRss[];
   });
 
   ipcMain.handle(
-    'alerts:set-rss',
+    'alerts:add-rss',
     (_, { contactId, rssUrl }: { contactId: string; rssUrl: string }): void => {
       if (!validateUrl(rssUrl)) throw new Error('Invalid RSS URL');
       const db = getDatabase();
-      const existing = db
-        .prepare(`SELECT id FROM contact_alert_rss WHERE contact_id = ?`)
-        .get(contactId);
-      if (existing) {
-        db.prepare(
-          `UPDATE contact_alert_rss SET rss_url = ?, is_invalid = 0, last_polled_at = NULL WHERE contact_id = ?`,
-        ).run(rssUrl, contactId);
-      } else {
-        db.prepare(
-          `INSERT INTO contact_alert_rss (id, contact_id, rss_url) VALUES (?, ?, ?)`,
-        ).run(uuidv4(), contactId, rssUrl);
-      }
+      const id = uuidv4();
+      db.prepare(
+        `INSERT INTO contact_alert_rss (id, contact_id, rss_url) VALUES (?, ?, ?)`,
+      ).run(id, contactId, rssUrl);
       pollContactRss(contactId).catch(() => {});
     },
   );
+
+  ipcMain.handle('alerts:remove-rss', (_, id: string): void => {
+    getDatabase()
+      .prepare(`DELETE FROM contact_alert_rss WHERE id = ?`)
+      .run(id);
+  });
 
   ipcMain.handle('alerts:clear-rss', (_, contactId: string): void => {
     getDatabase()

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -271,6 +271,7 @@ export function registerContactHandlers(): void {
     const now = Math.floor(Date.now() / 1000);
     const { phone_country, wayback_enabled } = db.prepare('SELECT phone_country, wayback_enabled FROM users WHERE id = 1').get() as { phone_country: string; wayback_enabled: number };
 
+    let emails: { email: string; label: string | null }[] = [];
     let phones: { phone: string; label: string | null }[] = [];
 
     const insert = db.transaction(() => {
@@ -278,7 +279,7 @@ export function registerContactHandlers(): void {
         'INSERT INTO contacts (id, name, organization, title, notes, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
       ).run(id, data.name.trim(), data.organization?.trim() || null, data.title?.trim() || null, data.notes?.trim() || null, now, now);
 
-      const emails = (data.emails ?? [])
+      emails = (data.emails ?? [])
         .map((e) => ({ email: normalizeEmail(e.email), label: e.label?.trim() || null }))
         .filter((e) => e.email && validateEmail(e.email));
       emails.forEach((e, i) => {

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -196,14 +196,12 @@ function mergeSubTablesFromShared(
       .run(h.id, contactId, h.type, h.handle, i, h.created_at);
   });
 
-  // ── Alert RSS (one per contact — last-write-wins is fine here) ────────────
+  // ── Alert RSS ──────────────────────────────────────────────────────────────
   local.prepare('DELETE FROM contact_alert_rss WHERE contact_id = ?').run(contactId);
-  const rss = shared
+  const rssFeeds = shared
     .prepare('SELECT * FROM contact_alert_rss WHERE contact_id = ?')
-    .get(contactId) as
-    | { id: string; rss_url: string; last_polled_at: number | null; is_invalid: number }
-    | undefined;
-  if (rss) {
+    .all(contactId) as { id: string; rss_url: string; last_polled_at: number | null; is_invalid: number }[];
+  for (const rss of rssFeeds) {
     local
       .prepare(
         'INSERT INTO contact_alert_rss (id, contact_id, rss_url, last_polled_at, is_invalid) VALUES (?, ?, ?, ?, ?)',
@@ -445,12 +443,10 @@ function pushSubTablesToShared(
   }
 
   shared.prepare('DELETE FROM contact_alert_rss WHERE contact_id = ?').run(contactId);
-  const rss = local
+  const rssFeeds = local
     .prepare('SELECT * FROM contact_alert_rss WHERE contact_id = ?')
-    .get(contactId) as
-    | { id: string; rss_url: string; last_polled_at: number | null; is_invalid: number }
-    | undefined;
-  if (rss) {
+    .all(contactId) as { id: string; rss_url: string; last_polled_at: number | null; is_invalid: number }[];
+  for (const rss of rssFeeds) {
     shared
       .prepare(
         'INSERT INTO contact_alert_rss (id, contact_id, rss_url, last_polled_at, is_invalid) VALUES (?, ?, ?, ?, ?)',

--- a/src/main/sync/rss-poller.ts
+++ b/src/main/sync/rss-poller.ts
@@ -45,16 +45,16 @@ export async function pollAllRss(): Promise<void> {
 
   const feeds = db
     .prepare(
-      `SELECT car.contact_id, car.rss_url, c.name AS contact_name
+      `SELECT car.id, car.contact_id, car.rss_url, c.name AS contact_name
        FROM contact_alert_rss car
        JOIN contacts c ON c.id = car.contact_id
        WHERE car.is_invalid = 0`,
     )
-    .all() as { contact_id: string; rss_url: string; contact_name: string }[];
+    .all() as { id: string; contact_id: string; rss_url: string; contact_name: string }[];
 
   let anyNew = false;
   for (const feed of feeds) {
-    const newCount = await pollOneFeed(feed.contact_id, feed.rss_url);
+    const newCount = await pollOneFeed(feed.id, feed.contact_id, feed.rss_url);
     if (newCount > 0) {
       anyNew = true;
       if (alertNotificationsEnabled && Notification.isSupported()) {
@@ -80,15 +80,18 @@ export async function pollAllRss(): Promise<void> {
 export async function pollContactRss(contactId: string): Promise<void> {
   if (!isDatabaseOpen()) return;
   const db = getDatabase();
-  const row = db
-    .prepare(`SELECT rss_url FROM contact_alert_rss WHERE contact_id = ?`)
-    .get(contactId) as { rss_url: string } | undefined;
-  if (!row) return;
-  const newCount = await pollOneFeed(contactId, row.rss_url);
-  if (newCount > 0) emitMentionsUpdated();
+  const feeds = db
+    .prepare(`SELECT id, rss_url FROM contact_alert_rss WHERE contact_id = ? AND is_invalid = 0`)
+    .all(contactId) as { id: string; rss_url: string }[];
+  let anyNew = false;
+  for (const feed of feeds) {
+    const newCount = await pollOneFeed(feed.id, contactId, feed.rss_url);
+    if (newCount > 0) anyNew = true;
+  }
+  if (anyNew) emitMentionsUpdated();
 }
 
-async function pollOneFeed(contactId: string, rssUrl: string): Promise<number> {
+async function pollOneFeed(feedId: string, contactId: string, rssUrl: string): Promise<number> {
   // Reject non-HTTP(S) URLs and loopback/private addresses to prevent SSRF
   try {
     const parsed = new URL(rssUrl);
@@ -130,12 +133,12 @@ async function pollOneFeed(contactId: string, rssUrl: string): Promise<number> {
     }
 
     db.prepare(
-      `UPDATE contact_alert_rss SET last_polled_at = ?, is_invalid = 0 WHERE contact_id = ?`,
-    ).run(now, contactId);
+      `UPDATE contact_alert_rss SET last_polled_at = ?, is_invalid = 0 WHERE id = ?`,
+    ).run(now, feedId);
 
     return newCount;
   } catch {
-    db.prepare(`UPDATE contact_alert_rss SET is_invalid = 1 WHERE contact_id = ?`).run(contactId);
+    db.prepare(`UPDATE contact_alert_rss SET is_invalid = 1 WHERE id = ?`).run(feedId);
     return 0;
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -247,10 +247,12 @@ const sourcererApi = {
   },
 
   // Alerts / RSS mentions
-  getAlertRss: (contactId: string): Promise<ContactAlertRss | null> =>
-    ipcRenderer.invoke('alerts:get-rss', contactId),
-  setAlertRss: (contactId: string, rssUrl: string): Promise<void> =>
-    ipcRenderer.invoke('alerts:set-rss', { contactId, rssUrl }),
+  listAlertRss: (contactId: string): Promise<ContactAlertRss[]> =>
+    ipcRenderer.invoke('alerts:list-rss', contactId),
+  addAlertRss: (contactId: string, rssUrl: string): Promise<void> =>
+    ipcRenderer.invoke('alerts:add-rss', { contactId, rssUrl }),
+  removeAlertRss: (id: string): Promise<void> =>
+    ipcRenderer.invoke('alerts:remove-rss', id),
   clearAlertRss: (contactId: string): Promise<void> =>
     ipcRenderer.invoke('alerts:clear-rss', contactId),
   listMentions: (): Promise<ContactAlertMention[]> =>

--- a/src/renderer/src/contacts/AddContactModal.css
+++ b/src/renderer/src/contacts/AddContactModal.css
@@ -307,3 +307,29 @@
 .ac-project-option:hover {
   background: var(--color-surface-2);
 }
+
+.ac-rss-feed-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+  padding: 4px 6px;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+}
+
+.ac-rss-feed-url {
+  flex: 1;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ac-rss-add-row {
+  display: flex;
+  gap: 6px;
+  align-items: flex-start;
+}

--- a/src/renderer/src/contacts/AddContactModal.css
+++ b/src/renderer/src/contacts/AddContactModal.css
@@ -330,6 +330,11 @@
 
 .ac-rss-add-row {
   display: flex;
+  flex-direction: column;
   gap: 6px;
   align-items: flex-start;
+}
+
+.ac-rss-url-input {
+  width: 100%;
 }

--- a/src/renderer/src/contacts/AddContactModal.css
+++ b/src/renderer/src/contacts/AddContactModal.css
@@ -307,34 +307,3 @@
 .ac-project-option:hover {
   background: var(--color-surface-2);
 }
-
-.ac-rss-feed-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 4px;
-  padding: 4px 6px;
-  background: var(--color-surface-2);
-  border: 1px solid var(--color-border);
-}
-
-.ac-rss-feed-url {
-  flex: 1;
-  font-size: 11px;
-  font-family: var(--font-mono);
-  color: var(--color-text);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.ac-rss-add-row {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  align-items: flex-start;
-}
-
-.ac-rss-url-input {
-  width: 100%;
-}

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -902,6 +902,10 @@
 }
 
 
+.detail-rss-feed {
+  margin-bottom: 6px;
+}
+
 .detail-rss-invalid {
   color: var(--color-warning-border);
   margin-left: 4px;

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -284,6 +284,10 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         links,
         handles: editHandles.filter((h) => h.handle.trim() && h.type.trim()),
       });
+      const pendingRss = newRssUrl.trim();
+      if (pendingRss && isGoogleAlertUrl(pendingRss)) {
+        await window.sourcerer.addAlertRss(contact.id, pendingRss);
+      }
       onRefresh();
       setEditingAndNotify(false);
     } finally {

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -751,7 +751,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         </div>
 
         <div className="detail-edit-actions-bottom">
-          <Button variant="primary" size="sm" onClick={handleSave} disabled={saving || !editName.trim() || Object.keys(emailFormatWarnings).length > 0 || Object.keys(phoneFormatWarnings).length > 0 || Object.keys(urlFormatWarnings).length > 0}>
+          <Button variant="primary" size="sm" onClick={handleSave} disabled={saving || !editName.trim() || Object.keys(emailFormatWarnings).length > 0 || Object.keys(phoneFormatWarnings).length > 0 || Object.keys(urlFormatWarnings).length > 0 || (!!newRssUrl.trim() && !isGoogleAlertUrl(newRssUrl.trim()))}>
             {saving ? 'Saving…' : 'Save'}
           </Button>
           <Button variant="secondary" size="sm" onClick={() => setEditingAndNotify(false)} disabled={saving}>

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -712,10 +712,13 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         <div className="ac-field">
           <label className="ac-label">Alert RSS Feeds</label>
           {alertRssList.map((feed) => (
-            <div key={feed.id} className="ac-rss-feed-row">
-              <span className="ac-rss-feed-url" title={feed.rss_url}>
-                {feed.rss_url.length > 55 ? feed.rss_url.slice(0, 55) + '…' : feed.rss_url}
-              </span>
+            <div key={feed.id} className="ac-dynamic-row">
+              <input
+                className="ac-input"
+                value={feed.rss_url}
+                readOnly
+                title={feed.rss_url}
+              />
               <button
                 className="ac-remove"
                 type="button"
@@ -723,27 +726,26 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
               ></button>
             </div>
           ))}
-          <div className="ac-rss-add-row">
+          <div>
             <input
-              className="ac-input ac-rss-url-input"
-              type="url"
+              className="ac-input"
               value={newRssUrl}
               onChange={(e) => setNewRssUrl(e.target.value)}
               onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleAddRss(); } }}
               placeholder="https://news.google.com/rss/search?q=…"
             />
-            <Button
-              variant="ghost"
-              type="button"
-              onClick={handleAddRss}
-              disabled={!newRssUrl.trim() || !isGoogleAlertUrl(newRssUrl.trim())}
-            >
-              + Add
-            </Button>
+            {newRssUrl.trim() && !isGoogleAlertUrl(newRssUrl.trim()) && (
+              <div className="ac-collision-warn">Must be a Google Alerts or Google News RSS URL</div>
+            )}
           </div>
-          {newRssUrl.trim() && !isGoogleAlertUrl(newRssUrl.trim()) && (
-            <div className="ac-collision-warn">Must be a Google Alerts or Google News RSS URL</div>
-          )}
+          <Button
+            variant="ghost"
+            type="button"
+            onClick={handleAddRss}
+            disabled={!newRssUrl.trim() || !isGoogleAlertUrl(newRssUrl.trim())}
+          >
+            + Add
+          </Button>
           <p className="ac-field-hint">
             Paste a Google Alerts RSS URL to automatically track mentions.
             To get one: go to <strong>google.com/alerts</strong>, create an alert, click <strong>Show options</strong>, set Deliver to <strong>RSS feed</strong>, then create the alert and copy the feed URL.

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -870,7 +870,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
               <a
                 href={feed.rss_url}
                 className="detail-link detail-rss-url"
-                onClick={(e) => e.preventDefault()}
+                onClick={(e) => { e.preventDefault(); window.open(feed.rss_url); }}
                 title={feed.rss_url}
               >
                 {feed.rss_url.length > 60

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -6,6 +6,7 @@ import DynamicList, { useDragReorder } from './DynamicList';
 import {
   isValidEmail,
   isValidUrl,
+  isGoogleAlertUrl,
   hasDisallowedPhoneChars,
   normalizePhoneForComparison,
   sanitizeOtherLabel,
@@ -55,7 +56,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [addingToProject, setAddingToProject] = useState('');
   const [confirmRemoveProjectId, setConfirmRemoveProjectId] = useState<string | null>(null);
-  const [alertRss, setAlertRss] = useState<ContactAlertRss | null>(null);
+  const [alertRssList, setAlertRssList] = useState<ContactAlertRss[]>([]);
   const [screenshots, setScreenshots] = useState<ContactScreenshot[]>([]);
   const [screenshotImages, setScreenshotImages] = useState<Record<string, string>>({});
   const [viewingScreenshot, setViewingScreenshot] = useState<string | null>(null);
@@ -120,7 +121,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
   const { getDragProps: phoneDragProps, handleProps: phoneHandleProps } = useDragReorder(editPhones, setEditPhones);
   const { getDragProps: otherSocialDragProps, handleProps: otherSocialHandleProps } = useDragReorder(editOtherSocials, setEditOtherSocials);
   const [editWebsites, setEditWebsites] = useState<string[]>([]);
-  const [editRssUrl, setEditRssUrl] = useState('');
+  const [newRssUrl, setNewRssUrl] = useState('');
   const [emailCollisions, setEmailCollisions] = useState<Record<string, string>>({});
   const [phoneCollisions, setPhoneCollisions] = useState<Record<string, string>>({});
   const [emailFormatWarnings, setEmailFormatWarnings] = useState<Record<string, true>>({});
@@ -148,7 +149,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
   );
 
   useEffect(() => {
-    window.sourcerer.getAlertRss(contact.id).then(setAlertRss);
+    window.sourcerer.listAlertRss(contact.id).then(setAlertRssList);
     window.sourcerer.listScreenshots(contact.id).then(setScreenshots);
   }, [contact.id]);
 
@@ -204,7 +205,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
       contact.links.filter((l) => l.type === 'other').map((l) => ({ url: l.url, label: l.label ?? '' })),
     );
     setEditWebsites(contact.links.filter((l) => l.type === 'website').map((l) => l.url));
-    setEditRssUrl(alertRss?.rss_url ?? '');
+    setNewRssUrl('');
     setEmailCollisions({});
     setPhoneCollisions({});
     setEmailFormatWarnings({});
@@ -283,16 +284,6 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         links,
         handles: editHandles.filter((h) => h.handle.trim() && h.type.trim()),
       });
-      // Persist RSS URL change
-      const trimmedRss = editRssUrl.trim();
-      if (trimmedRss && trimmedRss !== alertRss?.rss_url) {
-        await window.sourcerer.setAlertRss(contact.id, trimmedRss);
-        const updated = await window.sourcerer.getAlertRss(contact.id);
-        setAlertRss(updated);
-      } else if (!trimmedRss && alertRss) {
-        await window.sourcerer.clearAlertRss(contact.id);
-        setAlertRss(null);
-      }
       onRefresh();
       setEditingAndNotify(false);
     } finally {
@@ -316,6 +307,20 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
   async function handleDelete() {
     await window.sourcerer.deleteContact(contact.id);
     onDeleted(contact.id);
+  }
+
+  async function handleAddRss() {
+    const url = newRssUrl.trim();
+    if (!url || !isGoogleAlertUrl(url)) return;
+    await window.sourcerer.addAlertRss(contact.id, url);
+    setNewRssUrl('');
+    const updated = await window.sourcerer.listAlertRss(contact.id);
+    setAlertRssList(updated);
+  }
+
+  async function handleRemoveRss(id: string) {
+    await window.sourcerer.removeAlertRss(id);
+    setAlertRssList((prev) => prev.filter((f) => f.id !== id));
   }
 
   // View mode: group links by type
@@ -705,16 +710,39 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         </div>
 
         <div className="ac-field">
-          <label className="ac-label">Alert RSS URL</label>
-          <input
-            className="ac-input"
-            type="url"
-            value={editRssUrl}
-            onChange={(e) => setEditRssUrl(e.target.value)}
-            placeholder="https://news.google.com/rss/search?q=…"
-          />
-          {editRssUrl.trim() && !isValidUrl(editRssUrl.trim()) && (
-            <div className="ac-collision-warn">Invalid URL — must be a valid https:// or http:// address</div>
+          <label className="ac-label">Alert RSS Feeds</label>
+          {alertRssList.map((feed) => (
+            <div key={feed.id} className="ac-rss-feed-row">
+              <span className="ac-rss-feed-url" title={feed.rss_url}>
+                {feed.rss_url.length > 55 ? feed.rss_url.slice(0, 55) + '…' : feed.rss_url}
+              </span>
+              <button
+                className="ac-remove"
+                type="button"
+                onClick={() => handleRemoveRss(feed.id)}
+              ></button>
+            </div>
+          ))}
+          <div className="ac-rss-add-row">
+            <input
+              className="ac-input"
+              type="url"
+              value={newRssUrl}
+              onChange={(e) => setNewRssUrl(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleAddRss(); } }}
+              placeholder="https://news.google.com/rss/search?q=…"
+            />
+            <Button
+              variant="ghost"
+              type="button"
+              onClick={handleAddRss}
+              disabled={!newRssUrl.trim() || !isGoogleAlertUrl(newRssUrl.trim())}
+            >
+              + Add
+            </Button>
+          </div>
+          {newRssUrl.trim() && !isGoogleAlertUrl(newRssUrl.trim()) && (
+            <div className="ac-collision-warn">Must be a Google Alerts or Google News RSS URL</div>
           )}
           <p className="ac-field-hint">
             Paste a Google Alerts RSS URL to automatically track mentions.
@@ -723,7 +751,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         </div>
 
         <div className="detail-edit-actions-bottom">
-          <Button variant="primary" size="sm" onClick={handleSave} disabled={saving || !editName.trim() || Object.keys(emailFormatWarnings).length > 0 || Object.keys(phoneFormatWarnings).length > 0 || Object.keys(urlFormatWarnings).length > 0 || (!!editRssUrl.trim() && !isValidUrl(editRssUrl.trim()))}>
+          <Button variant="primary" size="sm" onClick={handleSave} disabled={saving || !editName.trim() || Object.keys(emailFormatWarnings).length > 0 || Object.keys(phoneFormatWarnings).length > 0 || Object.keys(urlFormatWarnings).length > 0}>
             {saving ? 'Saving…' : 'Save'}
           </Button>
           <Button variant="secondary" size="sm" onClick={() => setEditingAndNotify(false)} disabled={saving}>
@@ -824,29 +852,31 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         </div>
       )}
 
-      {alertRss && (
+      {alertRssList.length > 0 && (
         <div className="detail-section">
-          <div className="detail-section-label">
-            Alert RSS
-            {alertRss.is_invalid === 1 && (
-              <span className="detail-rss-invalid" title="Feed could not be fetched"> ⚠</span>
-            )}
-          </div>
-          <a
-            href={alertRss.rss_url}
-            className="detail-link detail-rss-url"
-            onClick={(e) => e.preventDefault()}
-            title={alertRss.rss_url}
-          >
-            {alertRss.rss_url.length > 60
-              ? alertRss.rss_url.slice(0, 60) + '…'
-              : alertRss.rss_url}
-          </a>
-          {alertRss.last_polled_at && (
-            <span className="detail-rss-polled">
-              Last polled {new Date(alertRss.last_polled_at * 1000).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}
-            </span>
-          )}
+          <div className="detail-section-label">Alert RSS</div>
+          {alertRssList.map((feed) => (
+            <div key={feed.id} className="detail-rss-feed">
+              <a
+                href={feed.rss_url}
+                className="detail-link detail-rss-url"
+                onClick={(e) => e.preventDefault()}
+                title={feed.rss_url}
+              >
+                {feed.rss_url.length > 60
+                  ? feed.rss_url.slice(0, 60) + '…'
+                  : feed.rss_url}
+              </a>
+              {feed.is_invalid === 1 && (
+                <span className="detail-rss-invalid" title="Feed could not be fetched"> ⚠</span>
+              )}
+              {feed.last_polled_at && (
+                <span className="detail-rss-polled">
+                  Last polled {new Date(feed.last_polled_at * 1000).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}
+                </span>
+              )}
+            </div>
+          ))}
         </div>
       )}
 

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -725,7 +725,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
           ))}
           <div className="ac-rss-add-row">
             <input
-              className="ac-input"
+              className="ac-input ac-rss-url-input"
               type="url"
               value={newRssUrl}
               onChange={(e) => setNewRssUrl(e.target.value)}

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -285,7 +285,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         handles: editHandles.filter((h) => h.handle.trim() && h.type.trim()),
       });
       const pendingRss = newRssUrl.trim();
-      if (pendingRss && isGoogleAlertUrl(pendingRss)) {
+      if (pendingRss && isGoogleAlertUrl(pendingRss) && !alertRssList.some((f) => f.rss_url === pendingRss)) {
         await window.sourcerer.addAlertRss(contact.id, pendingRss);
       }
       onRefresh();
@@ -316,6 +316,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
   async function handleAddRss() {
     const url = newRssUrl.trim();
     if (!url || !isGoogleAlertUrl(url)) return;
+    if (alertRssList.some((f) => f.rss_url === url)) return;
     await window.sourcerer.addAlertRss(contact.id, url);
     setNewRssUrl('');
     const updated = await window.sourcerer.listAlertRss(contact.id);
@@ -741,12 +742,15 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
             {newRssUrl.trim() && !isGoogleAlertUrl(newRssUrl.trim()) && (
               <div className="ac-collision-warn">Must be a Google Alerts or Google News RSS URL</div>
             )}
+            {newRssUrl.trim() && isGoogleAlertUrl(newRssUrl.trim()) && alertRssList.some((f) => f.rss_url === newRssUrl.trim()) && (
+              <div className="ac-collision-warn">⚠ Already added</div>
+            )}
           </div>
           <Button
             variant="ghost"
             type="button"
             onClick={handleAddRss}
-            disabled={!newRssUrl.trim() || !isGoogleAlertUrl(newRssUrl.trim())}
+            disabled={!newRssUrl.trim() || !isGoogleAlertUrl(newRssUrl.trim()) || alertRssList.some((f) => f.rss_url === newRssUrl.trim())}
           >
             + Add
           </Button>
@@ -757,7 +761,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         </div>
 
         <div className="detail-edit-actions-bottom">
-          <Button variant="primary" size="sm" onClick={handleSave} disabled={saving || !editName.trim() || Object.keys(emailFormatWarnings).length > 0 || Object.keys(phoneFormatWarnings).length > 0 || Object.keys(urlFormatWarnings).length > 0 || (!!newRssUrl.trim() && !isGoogleAlertUrl(newRssUrl.trim()))}>
+          <Button variant="primary" size="sm" onClick={handleSave} disabled={saving || !editName.trim() || Object.keys(emailFormatWarnings).length > 0 || Object.keys(phoneFormatWarnings).length > 0 || Object.keys(urlFormatWarnings).length > 0 || (!!newRssUrl.trim() && !isGoogleAlertUrl(newRssUrl.trim())) || (!!newRssUrl.trim() && alertRssList.some((f) => f.rss_url === newRssUrl.trim()))}>
             {saving ? 'Saving…' : 'Save'}
           </Button>
           <Button variant="secondary" size="sm" onClick={() => setEditingAndNotify(false)} disabled={saving}>

--- a/src/renderer/src/contacts/contactValidation.ts
+++ b/src/renderer/src/contacts/contactValidation.ts
@@ -1,4 +1,4 @@
-export { validateEmail as isValidEmail, validateUrl as isValidUrl } from '@shared/validation';
+export { validateEmail as isValidEmail, validateUrl as isValidUrl, isGoogleAlertUrl } from '@shared/validation';
 
 // Allowed phone chars: digits, +, -, (, ), ., whitespace, # for US extensions,
 // and "ext"/"x" as an extension prefix. Strip any trailing extension first so

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -147,8 +147,9 @@ declare global {
       onSyncStatus: (callback: (event: SyncStatusEvent) => void) => () => void;
 
       // Alerts / RSS mentions
-      getAlertRss: (contactId: string) => Promise<ContactAlertRss | null>;
-      setAlertRss: (contactId: string, rssUrl: string) => Promise<void>;
+      listAlertRss: (contactId: string) => Promise<ContactAlertRss[]>;
+      addAlertRss: (contactId: string, rssUrl: string) => Promise<void>;
+      removeAlertRss: (id: string) => Promise<void>;
       clearAlertRss: (contactId: string) => Promise<void>;
       listMentions: () => Promise<ContactAlertMention[]>;
       markMentionSeen: (id: string) => Promise<void>;

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -4,6 +4,19 @@ export function validateEmail(raw: string): boolean {
   return /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(trimmed);
 }
 
+export function isGoogleAlertUrl(raw: string): boolean {
+  try {
+    const u = new URL(raw.trim());
+    if (u.protocol !== 'https:') return false;
+    if (u.hostname === 'news.google.com' && u.pathname.startsWith('/rss')) return true;
+    if ((u.hostname === 'www.google.com' || u.hostname === 'google.com') &&
+        u.pathname.startsWith('/alerts/feeds/')) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 export function validateUrl(raw: string): boolean {
   const trimmed = raw.trim();
   if (!trimmed || /\s/.test(trimmed)) return false;


### PR DESCRIPTION
## Summary

- Contacts can now have **multiple** Google Alert RSS feeds (was limited to one)
- Validates that URLs are genuine Google Alerts or Google News RSS addresses — other URLs are rejected
- Add/remove feeds is immediate (not tied to the contact save flow); existing feeds appear as a list with inline remove buttons in edit mode
- View mode shows all feeds with their last-polled timestamp and invalid indicator
- Fixes a pre-existing TypeScript scoping bug in `contacts:create` where `emails` was declared inside a transaction callback but referenced outside it

## Test plan

- [x] Open a contact, enter edit mode — RSS feed list should be empty for a new contact
- [x] Paste a Google Alerts URL (`https://www.google.com/alerts/feeds/…`) — Add button enables, feed appears in list immediately on click
- [x] Paste a Google News RSS URL (`https://news.google.com/rss/…`) — same
- [x] Paste a non-Google URL — Add button stays disabled; error message shown
- [x] Remove a feed — disappears immediately without a save
- [x] Add multiple feeds — all show up in both edit and view mode
- [x] Trigger a poll — each feed is polled independently; invalid feeds are flagged individually

🤖 Generated with [Claude Code](https://claude.com/claude-code)