### PR TITLE
fix: hide wayback status indicators when archiving is disabled

### DIFF
--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -911,10 +911,10 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                   archived ↗
                 </a>
               )}
-              {!l.wayback_url && waybackStatus.get(l.url) === 'pending' && (
+              {!l.wayback_url && user?.wayback_enabled !== 0 && user?.archive_access_key && user?.archive_secret_key && waybackStatus.get(l.url) === 'pending' && (
                 <span className="detail-wayback-pending">archiving…</span>
               )}
-              {!l.wayback_url && waybackStatus.get(l.url) === 'failed' && (
+              {!l.wayback_url && user?.wayback_enabled !== 0 && user?.archive_access_key && user?.archive_secret_key && waybackStatus.get(l.url) === 'failed' && (
                 <span className="detail-wayback-failed" title="Wayback Machine could not archive this URL">archive failed</span>
               )}
             </div>


### PR DESCRIPTION
## Summary

- "archiving…" and "archive failed" labels are now gated on the same condition as the edit-mode hint: Wayback must be enabled AND both archive keys must be set
- Previously, the status indicators could appear even when the user had no archive credentials or had toggled the feature off

## Test plan

- [x] With Wayback disabled (toggle off or missing keys): add a website URL — no status label should appear
- [x] With Wayback enabled and keys set: add a website URL — "archiving…" should appear while pending, "archive failed" if it fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)