### PR TITLE
chore: bump to v0.1.12

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Releases are triggered by pushing a version tag (`v*`). Because `main` is protec
    git push -u origin chore/v{VERSION}
    gh pr create ...
    ```
-4. Optionally add a `## What's new` section to the PR body — plain English, written for a lay audience. The release workflow will prepend it to the auto-generated PR list (which appears in a collapsible Details block below). If omitted, only the PR list is shown.
+4. Add a `## What's new` section to the PR body — plain English, written for a lay audience (not a developer changelog). This becomes the public release notes, so it should cover **all meaningful changes since the previous version tag**: new features, significant fixes, removals, and anything a user would notice. Run `git log v{PREV_VERSION}..HEAD --oneline` to get the full list of commits to draw from. The release workflow will prepend it to the auto-generated PR list (which appears in a collapsible Details block below).
 5. Once the PR is merged, push the tag to trigger the build:
    ```bash
    git checkout main && git pull

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ A Chrome extension captures full-page screenshots from any browser tab and links
 - Export to CSV, Excel (.xlsx), or vCard (.vcf) — per project or all contacts
 - Sanitised export mode strips notes and interaction logs for sharing
 
-**[Chrome extension](https://chromewebstore.google.com/detail/sourcerer/pipgdnekoknjbghnmhilapocpchdcadm)** (Firefox Add-ons listing coming soon)
+**[Chrome extension](https://chromewebstore.google.com/detail/sourcerer/pipgdnekoknjbghnmhilapocpchdcadm)** · **[Firefox extension](https://addons.mozilla.org/en-CA/firefox/addon/sourcerer-for-journalists/)**
 - Full-page screenshot capture from any tab
 - Contact picker links screenshots to a source record
 - Screenshots stored encrypted alongside the database

--- a/docs/extension.html
+++ b/docs/extension.html
@@ -65,7 +65,7 @@
             <p><a href="https://chromewebstore.google.com/detail/sourcerer/pipgdnekoknjbghnmhilapocpchdcadm" target="_blank" rel="noopener">Install from the Chrome Web Store ↗</a></p>
 
             <h3>Firefox (142 or later)</h3>
-            <p><em>Firefox Add-ons listing — under review.</em></p>
+            <p><a href="https://addons.mozilla.org/en-CA/firefox/addon/sourcerer-for-journalists/" target="_blank" rel="noopener">Install from Firefox Add-ons ↗</a></p>
           </section>
 
           <section id="connecting">

--- a/docs/index.html
+++ b/docs/index.html
@@ -243,7 +243,7 @@
         <div class="feature-row-body">
           <h3>Research without leaving your browser</h3>
           <p>The Sourcerer browser extension brings your source database into every tab. Capture full-page screenshots and link them to a contact record, save selected text directly as an email, phone number, or note on an existing contact, or add a new contact without switching apps. A right-click context menu puts all of these actions one step away. Everything goes straight into the encrypted local database — no cloud upload, no third-party storage.</p>
-          <p><a href="https://chromewebstore.google.com/detail/sourcerer/pipgdnekoknjbghnmhilapocpchdcadm" target="_blank" rel="noopener">Install from the Chrome Web Store ↗</a></p>
+          <p><a href="https://chromewebstore.google.com/detail/sourcerer/pipgdnekoknjbghnmhilapocpchdcadm" target="_blank" rel="noopener">Install from the Chrome Web Store ↗</a> · <a href="https://addons.mozilla.org/en-CA/firefox/addon/sourcerer-for-journalists/" target="_blank" rel="noopener">Install from Firefox Add-ons ↗</a></p>
         </div>
       </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sourcerer",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sourcerer",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcerer",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "description": "Encrypted source management for journalists",
   "author": "Tom Cardoso",


### PR DESCRIPTION
## What's new

**Date of birth field.** Contacts now have an optional date of birth field, visible in the detail panel and included in CSV and Excel exports.

**Multiple RSS feeds per contact.** You can now attach more than one Google Alerts RSS feed to a contact — useful when a source has a common name or goes by multiple names.

**Export improvements.** You can now export only the contacts you've selected via bulk selection (rather than always exporting the whole project). vCard export is now available from the All Contacts view, not just individual projects. Social handles, website links, and other URLs are included in CSV and Excel exports. All exported filenames now include a date stamp.

**Firefox extension.** The Sourcerer browser extension is now available on [Firefox Add-ons](https://addons.mozilla.org/en-CA/firefox/addon/sourcerer-for-journalists/) in addition to the [Chrome Web Store](https://chromewebstore.google.com/detail/sourcerer/pipgdnekoknjbghnmhilapocpchdcadm).

**All Contacts performance.** The All Contacts table is now virtualised — large contact lists scroll smoothly regardless of how many records you have.

**Accessibility improvements.** Focus management, ARIA labels, and semantic HTML have been overhauled throughout the app.

**Input validation.** Email addresses, URLs, and phone numbers are now validated when saving contacts, importing from CSV or vCard, and configuring settings — invalid values are caught before they reach the database.

**Security updates.** All 27 open Dependabot alerts are resolved in this release: Electron updated from 32 to 39, Vite from 5 to 6, and the SheetJS spreadsheet library replaced with exceljs (which is actively maintained and has no known CVEs).

**Bug fixes.** "Today" now appears instead of "0d ago" for reminders due today. Wayback Machine status indicators are hidden when Wayback is disabled in Settings. Sticky table headers and bulk-selection dropdowns no longer overlap incorrectly. Phone and email labels no longer wrap unexpectedly in the detail view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)