### PR TITLE
fix: notarize config for electron-builder 26

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,9 +107,7 @@
       "category": "public.app-category.productivity",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
-      "notarize": {
-        "teamId": "6A628PNYB7"
-      }
+      "notarize": true
     },
     "dmg": {
       "contents": [


### PR DESCRIPTION
electron-builder 26 changed `mac.notarize` from an object (`{ teamId: "..." }`) to a boolean. The team ID and credentials are now supplied via env vars (`APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`), which are already set in the CI workflow.

Fixes the build failure introduced when upgrading electron-builder 24→26 in #88.

After merging, the v0.1.12 tag will need to be moved to HEAD:
\`\`\`bash
git tag -d v0.1.12
git push origin :refs/tags/v0.1.12
git tag v0.1.12
git push origin v0.1.12
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)