### PR TITLE
fix: new contacts not appearing in All Contacts after creation

### DIFF
--- a/src/main/ipc/updater.ts
+++ b/src/main/ipc/updater.ts
@@ -177,18 +177,29 @@ export function registerUpdaterHandlers(): void {
   ipcMain.handle('update:quit-and-install', async () => {
     // On Electron 39+, Squirrel.Mac may not be ready to handle quitAndInstall
     // immediately after electron-updater fires update-downloaded. Retry with
-    // backoff until Squirrel accepts the command.
+    // backoff until Squirrel accepts the command, but only for the known
+    // transient error — fail fast for anything else.
     let delay = 200;
     for (let i = 0; i < 8; i++) {
       try {
         autoUpdater.quitAndInstall(false, true);
         return;
-      } catch {
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (!msg.includes('command is disabled')) {
+          log.error('quitAndInstall failed with unexpected error:', err);
+          return;
+        }
         await new Promise((r) => setTimeout(r, delay));
         delay = Math.min(delay * 2, 2000);
       }
     }
-    autoUpdater.quitAndInstall(false, true);
+    try {
+      autoUpdater.quitAndInstall(false, true);
+    } catch (err) {
+      log.error('quitAndInstall failed after retries:', err);
+      sendToWindow('update:error', { message: 'Unable to restart and install the update. Please restart Sourcerer manually.' });
+    }
   });
   ipcMain.handle('update:get-state', () => cachedUpdateInfo);
   ipcMain.handle('update:show-error', (_event, message: string) => {

--- a/src/main/ipc/updater.ts
+++ b/src/main/ipc/updater.ts
@@ -174,7 +174,20 @@ export function registerUpdaterHandlers(): void {
     }
     return autoUpdater.downloadUpdate();
   });
-  ipcMain.handle('update:quit-and-install', () => {
+  ipcMain.handle('update:quit-and-install', async () => {
+    // On Electron 39+, Squirrel.Mac may not be ready to handle quitAndInstall
+    // immediately after electron-updater fires update-downloaded. Retry with
+    // backoff until Squirrel accepts the command.
+    let delay = 200;
+    for (let i = 0; i < 8; i++) {
+      try {
+        autoUpdater.quitAndInstall(false, true);
+        return;
+      } catch {
+        await new Promise((r) => setTimeout(r, delay));
+        delay = Math.min(delay * 2, 2000);
+      }
+    }
     autoUpdater.quitAndInstall(false, true);
   });
   ipcMain.handle('update:get-state', () => cachedUpdateInfo);

--- a/src/renderer/src/contacts/AddContactModal.css
+++ b/src/renderer/src/contacts/AddContactModal.css
@@ -159,6 +159,15 @@
   font-family: var(--font-mono);
 }
 
+.ac-submit-error {
+  font-size: 10px;
+  color: var(--color-danger);
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  padding: 0 20px 8px;
+}
+
 .ac-field-hint {
   font-size: 12px;
   color: var(--color-text-dim);

--- a/src/renderer/src/contacts/AddContactModal.tsx
+++ b/src/renderer/src/contacts/AddContactModal.tsx
@@ -51,6 +51,7 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
   const [handles, setHandles] = useState<Array<{ type: string; handle: string }>>([]);
   const [notes, setNotes] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const [emailCollisions, setEmailCollisions] = useState<Record<string, string>>({});
   const [phoneCollisions, setPhoneCollisions] = useState<Record<string, string>>({});
   const [emailFormatWarnings, setEmailFormatWarnings] = useState<Record<string, true>>({});
@@ -183,6 +184,7 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
       onCreated(contact);
     } catch (err) {
       console.error('Failed to create contact:', err);
+      setSubmitError('Something went wrong. Please try again.');
       setSubmitting(false);
     }
   }
@@ -537,6 +539,8 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
             />
           </div>
 
+          {submitError && <div className="ac-submit-error">{submitError}</div>}
+
           <div className="ac-actions">
             <Button type="button" variant="secondary" onClick={onCancel} disabled={submitting}>
               Cancel
@@ -545,6 +549,7 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
               type="submit"
               variant="primary"
               disabled={!name.trim() || submitting || Object.keys(emailFormatWarnings).length > 0 || Object.keys(phoneFormatWarnings).length > 0 || Object.keys(urlFormatWarnings).length > 0}
+              onClick={() => setSubmitError(null)}
             >
               {submitting ? 'Saving…' : 'Add contact'}
             </Button>

--- a/src/renderer/src/contacts/AddContactModal.tsx
+++ b/src/renderer/src/contacts/AddContactModal.tsx
@@ -177,9 +177,14 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
       handles: handles.filter((h) => h.handle.trim() && h.type.trim()),
     };
 
-    const contact = await window.sourcerer.createContact(data);
-    await Promise.all([...selectedProjectIds].map((pid) => window.sourcerer.addToProject(contact.id, pid)));
-    onCreated(contact);
+    try {
+      const contact = await window.sourcerer.createContact(data);
+      await Promise.all([...selectedProjectIds].map((pid) => window.sourcerer.addToProject(contact.id, pid)));
+      onCreated(contact);
+    } catch (err) {
+      console.error('Failed to create contact:', err);
+      setSubmitting(false);
+    }
   }
 
   return (

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -325,6 +325,7 @@ export default function AppShell() {
         <AddContactModal
           onCreated={(contact) => {
             setShowAddContact(false);
+            setImportRefreshTrigger((n) => n + 1);
             setNav({ view: 'all-contacts' });
             setOpenContactId(contact.id);
             window.sourcerer.getContactCount().then(setTotalContacts);


### PR DESCRIPTION
Three bugs in the Add Contact flow and auto-updater:

**New contacts not appearing in All Contacts.** After creating a contact, the app navigated to All Contacts and opened the detail panel, but never triggered a list refresh — so the new contact was absent until something else caused a reload. Fix: increment the refresh trigger in the `onCreated` callback.

**Modal freezing on submit.** If the `createContact` or `addToProject` IPC call threw an error, `submitting` stayed `true` with no recovery path — button permanently disabled, modal stuck. Fix: wrap the async block in `try/catch`, reset `submitting` on failure, and show an inline error message so the user knows something went wrong.

**"The command is disabled" error on restart after update.** On Electron 39, electron-updater fires its `update-downloaded` event before Squirrel.Mac has finished processing the zip internally. If the user clicks "Restart and install" in that window, `quitAndInstall` throws "The command is disabled and cannot be executed." Fix: retry `quitAndInstall` with exponential backoff, but only for that specific error — other errors fail fast. If all retries are exhausted, log the failure and surface a message to the user rather than leaving an unhandled rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)