### PR TITLE
chore: bump to v0.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sourcerer",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sourcerer",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcerer",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "description": "Encrypted source management for journalists",
   "author": "Tom Cardoso",


### PR DESCRIPTION
## What's new

**Bug fixes only in this release.**

- New contacts now appear immediately in All Contacts after being created. Previously the list didn't refresh, so the new contact was invisible until something else triggered a reload.
- The Add Contact modal no longer freezes if saving fails. If an error occurs mid-save, the form re-enables and shows an inline error message so you can retry.
- The "Restart and install update" flow is more reliable on Electron 39. A timing issue with Squirrel.Mac could cause a silent error when clicking Restart immediately after an update downloaded — the app still updated, but it took an unnecessary extra cycle. This is now handled cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)