### PR TITLE
Add Windows code signing and GitHub Sponsors button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: tomcardoso

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,8 +72,18 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: npm run dist:mac -- --publish never
 
+      - name: Install Azure Artifact Signing module (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Install-Module -Name TrustedSigning -Force -AllowClobber -Scope CurrentUser
+
       - name: Package (Windows)
         if: runner.os == 'Windows'
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_PUBLISHER_NAME: ${{ secrets.AZURE_PUBLISHER_NAME }}
         run: npm run dist:win -- --publish never
 
       - name: Package (Linux)

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -1,0 +1,13 @@
+const { build } = require("./package.json")
+
+/** @type {import('electron-builder').Configuration} */
+module.exports = {
+  ...build,
+  win: {
+    ...build.win,
+    azureSignOptions: {
+      ...build.win.azureSignOptions,
+      publisherName: process.env.AZURE_PUBLISHER_NAME,
+    },
+  },
+}

--- a/package.json
+++ b/package.json
@@ -125,6 +125,11 @@
     },
     "win": {
       "icon": "build/icons/256x256.png",
+      "azureSignOptions": {
+        "endpoint": "https://eus.codesigning.azure.net",
+        "certificateProfileName": "sourcerer-public",
+        "codeSigningAccountName": "sourcerer-signing"
+      },
       "target": [
         {
           "target": "nsis",


### PR DESCRIPTION
## Summary

- Adds Windows code signing via Azure Artifact Signing (electron-builder's built-in `azureSignOptions`)
- Moves electron-builder config to `electron-builder.config.js` so the signing publisher name is injected at build time via `AZURE_PUBLISHER_NAME` secret rather than committed to the repo
- CI workflow installs the `TrustedSigning` PowerShell module and passes Azure credentials on the Windows packaging step
- Adds `.github/FUNDING.yml` to display the GitHub Sponsors button on the repo

## Required secrets (already added to repo)
`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_PUBLISHER_NAME`