### PR TITLE
0.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sourcerer",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sourcerer",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcerer",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "description": "Encrypted source management for journalists",
   "author": "Tom Cardoso",


### PR DESCRIPTION
## What's new

Windows builds are now code-signed, so the SmartScreen warning on first install is gone. A GitHub Sponsors button has also been added to the repo for anyone who wants to help cover the cost of the signing certificates.