### PR TITLE
Contact form: surface required fields, collapse optional ones

### DIFF
--- a/src/renderer/src/contacts/AddContactModal.css
+++ b/src/renderer/src/contacts/AddContactModal.css
@@ -43,6 +43,56 @@
   padding: 16px 20px 20px;
 }
 
+.ac-description {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  margin-bottom: 16px;
+  line-height: 1.5;
+}
+
+.ac-expand-toggle {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin-bottom: 16px;
+  padding: 0;
+  gap: 0;
+}
+
+.ac-expand-toggle::before,
+.ac-expand-toggle::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
+
+.ac-expand-toggle-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-text-dim);
+  padding: 0 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: color 0.1s;
+}
+
+.ac-expand-toggle:hover .ac-expand-toggle-label {
+  color: var(--color-primary);
+}
+
+.ac-expand-toggle-icon {
+  font-size: 8px;
+  line-height: 1;
+}
+
 .ac-field {
   margin-bottom: 14px;
 }

--- a/src/renderer/src/contacts/AddContactModal.tsx
+++ b/src/renderer/src/contacts/AddContactModal.tsx
@@ -50,6 +50,7 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
   });
   const [handles, setHandles] = useState<Array<{ type: string; handle: string }>>([]);
   const [notes, setNotes] = useState('');
+  const [expanded, setExpanded] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [emailCollisions, setEmailCollisions] = useState<Record<string, string>>({});
@@ -201,6 +202,8 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
         </div>
 
         <form ref={formRef} onSubmit={handleSubmit} className="ac-form">
+          <p className="ac-description">Only a name is required — everything else can be filled in later.</p>
+
           <div className="ac-field">
             <label htmlFor="ac-name" className="modal-label">
               Name <span className="modal-required">*</span>
@@ -230,6 +233,19 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
             />
           </div>
 
+          <button
+            type="button"
+            className="ac-expand-toggle"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+          >
+            <span className="ac-expand-toggle-label">
+              {expanded ? 'Fewer details' : 'More details'}
+              <span className="ac-expand-toggle-icon">{expanded ? '▴' : '▾'}</span>
+            </span>
+          </button>
+
+          {expanded && <>
           <div className="ac-field">
             <label htmlFor="ac-title" className="modal-label">Title / Role</label>
             <input
@@ -538,6 +554,8 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
               disabled={submitting}
             />
           </div>
+
+          </>}
 
           {submitError && <div className="ac-submit-error">{submitError}</div>}
 


### PR DESCRIPTION
Closes #100.

## Summary

- Adds intro text at the top of the form: *"Only a name is required — everything else can be filled in later."*
- Name and Organization fields remain visible immediately on open
- All other fields (Title/Role, DOB, Email, Phone, Messaging handles, Website, Social links, Projects, Notes) are hidden behind a **More details ▾** toggle button
- The toggle uses the existing mono/uppercase design language and sits as a ruled divider between the always-visible fields and the collapsible section
- State for all optional fields is preserved whether the section is expanded or collapsed

## Test plan

- [x] Open Add Contact — only Name, Org, and the More details toggle are visible
- [x] Description text appears above the Name field
- [x] Click **More details** — all optional fields expand; button reads "Fewer details ▴"
- [x] Click **Fewer details** — section collapses; any data entered is preserved in state and submitted correctly
- [x] Submitting with only a name works; submitting with optional fields filled works
- [x] Validation warnings (email collision, phone format, etc.) still appear when expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)