### PR TITLE
Interactions: support zero or more project associations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ All design tokens are CSS custom properties defined in `src/renderer/src/global.
 
 **Hard rules — do not break these:**
 - All interactive elements (buttons, inputs, selects, textareas) use `border-radius: 0` — square corners everywhere, no exceptions
-- Mono type is almost always `text-transform: uppercase` — exceptions only for body-level mono (e.g. code snippets)
+- Mono type (`--font-mono`) is **always** `text-transform: uppercase` — the only exceptions are genuinely body-level mono like code snippets. If a string can't be uppercased (e.g. a proper noun, a project name), use serif instead.
 - **Never use `text-transform: uppercase` on serif (`--font-serif`) text** — all-caps serif is never used anywhere in the UI
 - Do not introduce colours outside the palette above; do not use system fonts or web-safe fallbacks
 - Never use inline styles. Always write a dedicated `.css` file co-located with the component

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ All design tokens are CSS custom properties defined in `src/renderer/src/global.
 **Hard rules — do not break these:**
 - All interactive elements (buttons, inputs, selects, textareas) use `border-radius: 0` — square corners everywhere, no exceptions
 - Mono type is almost always `text-transform: uppercase` — exceptions only for body-level mono (e.g. code snippets)
+- **Never use `text-transform: uppercase` on serif (`--font-serif`) text** — all-caps serif is never used anywhere in the UI
 - Do not introduce colours outside the palette above; do not use system fonts or web-safe fallbacks
 - Never use inline styles. Always write a dedicated `.css` file co-located with the component
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ All design tokens are CSS custom properties defined in `src/renderer/src/global.
 
 **Hard rules — do not break these:**
 - All interactive elements (buttons, inputs, selects, textareas) use `border-radius: 0` — square corners everywhere, no exceptions
-- Mono type (`--font-mono`) is **always** `text-transform: uppercase` — the only exceptions are genuinely body-level mono like code snippets. If a string can't be uppercased (e.g. a proper noun, a project name), use serif instead.
+- Mono type is almost always `text-transform: uppercase` — exceptions only for body-level mono (e.g. code snippets)
 - **Never use `text-transform: uppercase` on serif (`--font-serif`) text** — all-caps serif is never used anywhere in the UI
 - Do not introduce colours outside the palette above; do not use system fonts or web-safe fallbacks
 - Never use inline styles. Always write a dedicated `.css` file co-located with the component

--- a/src/main/database/dev-seeds.ts
+++ b/src/main/database/dev-seeds.ts
@@ -63,8 +63,11 @@ export function seedDevData(db: Database.Database, email: string, name: string):
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       ),
       insertLog: db.prepare(
-        `INSERT INTO interaction_log_entries (id, membership_id, reporter_email, reporter_name, body, created_at)
+        `INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at)
          VALUES (?, ?, ?, ?, ?, ?)`,
+      ),
+      insertInteractionProject: db.prepare(
+        `INSERT INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)`,
       ),
       insertReminder: db.prepare(
         `INSERT INTO reminders (id, contact_id, project_id, membership_id, due_date, note, is_auto_outreach, created_at, completed_at)
@@ -152,9 +155,27 @@ export function seedDevData(db: Database.Database, email: string, name: string):
       reporter: { name: string; email: string },
       body: string,
       daysAgo: number,
+      extraProjectIds: string[] = [],
     ): void {
       const membId = membIds[`${contactName}:${projectId}`];
-      stmts.insertLog.run(uuidv4(), membId, reporter.email, reporter.name, body, NOW - daysAgo * DAY);
+      const id = uuidv4();
+      stmts.insertLog.run(id, cid(contactName), reporter.email, reporter.name, body, NOW - daysAgo * DAY);
+      stmts.insertInteractionProject.run(id, membId);
+      for (const extraPid of extraProjectIds) {
+        const extraMembId = membIds[`${contactName}:${extraPid}`];
+        if (extraMembId) stmts.insertInteractionProject.run(id, extraMembId);
+      }
+    }
+
+    function addGlobalLog(
+      contactName: string,
+      reporter: { name: string; email: string },
+      body: string,
+      daysAgo: number,
+    ): void {
+      const id = uuidv4();
+      stmts.insertLog.run(id, cid(contactName), reporter.email, reporter.name, body, NOW - daysAgo * DAY);
+      // No interaction_projects row — this is a contact-level log not tied to any project
     }
 
     function addReminder(
@@ -339,6 +360,7 @@ export function seedDevData(db: Database.Database, email: string, name: string):
     });
 
     // ── Interaction logs ─────────────────────────────────────────────────────
+    // Distribution: many global (no project), most with one project, a handful with two
     addLog('Darnell Okafor', millgateId, me(),
       'Made initial contact through intermediary. Confirmed willingness to speak. Agreed to Signal only — no email.',
       21);
@@ -375,7 +397,6 @@ export function seedDevData(db: Database.Database, email: string, name: string):
       35);
     addLog('Eunice Addo-Yeboah', pensionId, me(),
       'Second call — she described the contents in detail. Enough to corroborate the securities commission filing.',
-
       19);
     addLog('Eunice Addo-Yeboah', pensionId, me(),
       "Her lawyer has asked us to pause direct contact for two weeks. Respect the ask.",
@@ -431,9 +452,45 @@ export function seedDevData(db: Database.Database, email: string, name: string):
       'He provided the grievance data in a spreadsheet. Three hospital regions, 2021–2024.',
       38);
 
+    // Cross-project entry: Dr. Jean-Paul Hébert appears in both Millgate and Health
     addLog('Dr. Jean-Paul Hébert', healthId, MARCUS,
       'On-record interview. Agreed to be quoted on governance failures and the pension fund overlap.',
-      50);
+      50, [millgateId]);
+    addLog('Dr. Jean-Paul Hébert', healthId, MARCUS,
+      'Follow-up call to clarify the governance section. Confirmed his quotes stand.',
+      22);
+
+    // Global logs (no project) — contact-level notes not tied to any investigation
+    addGlobalLog('Priya Subramaniam', me(),
+      'Met at a press conference. Exchanged cards. Might be useful background on the waterfront development story.',
+      60);
+    addGlobalLog('Gordon Whitfield', me(),
+      'Brief phone call — he reached out to clarify comments in a previous piece. Good relationship to maintain.',
+      55);
+    addGlobalLog('Zach Pendergast', me(),
+      'Coffee meeting. Caught up on the media landscape, nothing on the record.',
+      48);
+    addGlobalLog('Emil Rosenqvist', me(),
+      'Email exchange about the European regulatory situation. Sent him background materials.',
+      43);
+    addGlobalLog('Callum Forsythe', me(),
+      'Initial outreach — recommended by a mutual contact. Wants to meet in person before committing to anything.',
+      37);
+    addGlobalLog('Philip Gauthier-Lessard', me(),
+      'Spoke at a conference panel. Introduced myself afterward — agreed to follow up.',
+      32);
+    addGlobalLog('Tyler Deschênes', me(),
+      'Ran into him at a court filing. Exchanged numbers. Keeping him warm.',
+      29);
+    addGlobalLog('Chantal Beaubien', me(),
+      'Left a voicemail. No reply yet. Trying again next week.',
+      25);
+    addGlobalLog('Antoine Durocher', SARAH,
+      'He flagged a document in a public registry that we had missed. Worth following up independently.',
+      18);
+    addGlobalLog('Kevin Stelmach', me(),
+      'Initial contact via union newsletter. He expressed interest in speaking but wants anonymity.',
+      14);
 
     // ── Manual reminders ─────────────────────────────────────────────────────
     addReminder('Catherine Mwangi', millgateId, 5,

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -163,12 +163,18 @@ export const LOCAL_SCHEMA_SQL = `
 
   CREATE TABLE IF NOT EXISTS interaction_log_entries (
     id             TEXT    PRIMARY KEY,
-    membership_id  TEXT    NOT NULL REFERENCES project_memberships(id) ON DELETE CASCADE,
+    contact_id     TEXT    NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
     reporter_email TEXT    NOT NULL,
     reporter_name  TEXT    NOT NULL,
     body           TEXT    NOT NULL,
     created_at     INTEGER NOT NULL,
     synced_at      INTEGER
+  );
+
+  CREATE TABLE IF NOT EXISTS interaction_projects (
+    interaction_id TEXT NOT NULL REFERENCES interaction_log_entries(id) ON DELETE CASCADE,
+    membership_id  TEXT NOT NULL REFERENCES project_memberships(id) ON DELETE CASCADE,
+    PRIMARY KEY (interaction_id, membership_id)
   );
 
   CREATE TABLE IF NOT EXISTS message_scratchpad_drafts (
@@ -227,7 +233,8 @@ export const LOCAL_SCHEMA_SQL = `
   CREATE UNIQUE INDEX IF NOT EXISTS idx_contact_handles_contact_type_handle ON contact_handles(contact_id, type, handle);
   CREATE UNIQUE INDEX IF NOT EXISTS idx_contact_links_contact_url      ON contact_links(contact_id, url);
   CREATE INDEX IF NOT EXISTS idx_contact_screenshots_contact_id   ON contact_screenshots(contact_id);
-  CREATE INDEX IF NOT EXISTS idx_interaction_log_membership_created ON interaction_log_entries(membership_id, created_at);
+  CREATE INDEX IF NOT EXISTS idx_interaction_log_contact_created ON interaction_log_entries(contact_id, created_at);
+  CREATE INDEX IF NOT EXISTS idx_interaction_projects_membership ON interaction_projects(membership_id);
   CREATE INDEX IF NOT EXISTS idx_project_memberships_contact_id   ON project_memberships(contact_id);
   CREATE INDEX IF NOT EXISTS idx_project_memberships_project_id      ON project_memberships(project_id);
   CREATE INDEX IF NOT EXISTS idx_project_memberships_reporter_email ON project_memberships(reporter_email);

--- a/src/main/database/shared-schema.ts
+++ b/src/main/database/shared-schema.ts
@@ -91,11 +91,17 @@ export const SHARED_SCHEMA_SQL = `
 
   CREATE TABLE IF NOT EXISTS interaction_log_entries (
     id             TEXT    PRIMARY KEY,
-    membership_id  TEXT    NOT NULL REFERENCES project_memberships(id) ON DELETE CASCADE,
+    contact_id     TEXT    NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
     reporter_email TEXT    NOT NULL,
     reporter_name  TEXT    NOT NULL,
     body           TEXT    NOT NULL,
     created_at     INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS interaction_projects (
+    interaction_id TEXT NOT NULL REFERENCES interaction_log_entries(id) ON DELETE CASCADE,
+    membership_id  TEXT NOT NULL REFERENCES project_memberships(id) ON DELETE CASCADE,
+    PRIMARY KEY (interaction_id, membership_id)
   );
 
   CREATE TABLE IF NOT EXISTS shared_meta (
@@ -112,6 +118,7 @@ export const SHARED_SCHEMA_SQL = `
   CREATE UNIQUE INDEX IF NOT EXISTS idx_shared_contact_handles_contact_type_handle ON contact_handles(contact_id, type, handle);
   CREATE INDEX IF NOT EXISTS idx_shared_alert_mentions_contact_id     ON contact_alert_mentions(contact_id);
   CREATE UNIQUE INDEX IF NOT EXISTS idx_shared_alert_mentions_contact_guid ON contact_alert_mentions(contact_id, guid);
-  CREATE INDEX IF NOT EXISTS idx_shared_interaction_log_membership_created ON interaction_log_entries(membership_id, created_at);
+  CREATE INDEX IF NOT EXISTS idx_shared_interaction_log_contact_created ON interaction_log_entries(contact_id, created_at);
+  CREATE INDEX IF NOT EXISTS idx_shared_interaction_projects_membership ON interaction_projects(membership_id);
   CREATE INDEX IF NOT EXISTS idx_shared_project_memberships_contact_id ON project_memberships(contact_id);
 `;

--- a/src/main/dedup.ts
+++ b/src/main/dedup.ts
@@ -355,7 +355,7 @@ export function mergeContacts(
 
       if (winnerMembership) {
         db.prepare(
-          'UPDATE interaction_log_entries SET membership_id = ? WHERE membership_id = ?',
+          'UPDATE OR IGNORE interaction_projects SET membership_id = ? WHERE membership_id = ?',
         ).run(winnerMembership.id, membership.id);
         db.prepare('DELETE FROM project_memberships WHERE id = ?').run(membership.id);
       } else {

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -604,6 +604,7 @@ export function registerContactHandlers(): void {
       const ts = createdAt ?? Math.floor(Date.now() / 1000);
       if (!Number.isFinite(ts) || ts <= 0) throw new Error('invalid created_at');
       const reporterName = `${user.first_name} ${user.last_name}`;
+      const validMid = db.prepare('SELECT 1 FROM project_memberships WHERE id = ? AND contact_id = ?');
       const insertProject = db.prepare('INSERT OR IGNORE INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)');
       db.transaction(() => {
         db.prepare(
@@ -611,13 +612,14 @@ export function registerContactHandlers(): void {
         ).run(id, membership.contact_id, user.email, reporterName, body.trim(), ts);
         insertProject.run(id, membershipId);
         for (const mid of extraMembershipIds ?? []) {
-          if (mid !== membershipId) insertProject.run(id, mid);
+          if (mid !== membershipId && validMid.get(mid, membership.contact_id)) insertProject.run(id, mid);
         }
       })();
       // Clear auto-outreach reminders for all associated memberships.
       const allMids = [membershipId, ...(extraMembershipIds ?? [])];
       const clearReminder = db.prepare('DELETE FROM reminders WHERE membership_id = ? AND is_auto_outreach = 1');
       for (const mid of allMids) clearReminder.run(mid);
+      broadcastRemindersChanged();
       broadcastContactsChanged();
       return {
         id,
@@ -637,7 +639,7 @@ export function registerContactHandlers(): void {
                 (SELECT p.name FROM interaction_projects ip
                  JOIN project_memberships pm ON pm.id = ip.membership_id
                  JOIN projects p ON p.id = pm.project_id
-                 WHERE ip.interaction_id = ile.id LIMIT 1) AS project_name
+                 WHERE ip.interaction_id = ile.id ORDER BY p.name LIMIT 1) AS project_name
          FROM interaction_log_entries ile
          WHERE ile.contact_id = ?
          ORDER BY ile.created_at ASC`,
@@ -660,18 +662,20 @@ export function registerContactHandlers(): void {
       const insertProject = db.prepare(
         'INSERT OR IGNORE INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)',
       );
+      const validMidGlobal = db.prepare('SELECT 1 FROM project_memberships WHERE id = ? AND contact_id = ?');
       db.transaction(() => {
         insertEntry.run(id, contactId, user.email, reporterName, body.trim(), ts);
         for (const mid of membershipIds ?? []) {
-          insertProject.run(id, mid);
+          if (validMidGlobal.get(mid, contactId)) insertProject.run(id, mid);
         }
       })();
       const firstProject = (membershipIds ?? []).length > 0
-        ? (db.prepare('SELECT p.name FROM project_memberships pm JOIN projects p ON p.id = pm.project_id WHERE pm.id = ?').get(membershipIds![0]) as { name: string } | undefined)?.name ?? null
+        ? (db.prepare('SELECT p.name FROM project_memberships pm JOIN projects p ON p.id = pm.project_id WHERE pm.id = ? AND pm.contact_id = ?').get(membershipIds![0], contactId) as { name: string } | undefined)?.name ?? null
         : null;
       // Clear auto-outreach reminders for all associated memberships.
       const clearReminder = db.prepare('DELETE FROM reminders WHERE membership_id = ? AND is_auto_outreach = 1');
       for (const mid of membershipIds ?? []) clearReminder.run(mid);
+      broadcastRemindersChanged();
       broadcastContactsChanged();
       return {
         id,

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -18,6 +18,7 @@ import type {
   ContactHandleInput,
   ProjectContactRow,
   InteractionLogEntry,
+  ContactLogEntry,
   ScratchpadDraft,
   StatusOption,
   PriorityOption,
@@ -620,6 +621,46 @@ export function registerContactHandlers(): void {
         reporter_name: reporterName,
         body: body.trim(),
         created_at: ts,
+      };
+    },
+  );
+
+  ipcMain.handle('interaction-log:list-for-contact', (_, contactId: string): ContactLogEntry[] => {
+    return getDatabase()
+      .prepare(
+        `SELECT ile.id, ile.contact_id, ile.reporter_email, ile.reporter_name, ile.body, ile.created_at,
+                (SELECT p.name FROM interaction_projects ip
+                 JOIN project_memberships pm ON pm.id = ip.membership_id
+                 JOIN projects p ON p.id = pm.project_id
+                 WHERE ip.interaction_id = ile.id LIMIT 1) AS project_name
+         FROM interaction_log_entries ile
+         WHERE ile.contact_id = ?
+         ORDER BY ile.created_at ASC`,
+      )
+      .all(contactId) as ContactLogEntry[];
+  });
+
+  ipcMain.handle(
+    'interaction-log:add-global',
+    (_, { contactId, body, createdAt }: { contactId: string; body: string; createdAt?: number }): ContactLogEntry => {
+      const db = getDatabase();
+      const user = db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
+      const id = uuidv4();
+      const ts = createdAt ?? Math.floor(Date.now() / 1000);
+      if (!Number.isFinite(ts) || ts <= 0) throw new Error('invalid created_at');
+      const reporterName = `${user.first_name} ${user.last_name}`;
+      db.prepare(
+        'INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+      ).run(id, contactId, user.email, reporterName, body.trim(), ts);
+      broadcastContactsChanged();
+      return {
+        id,
+        contact_id: contactId,
+        reporter_email: user.email,
+        reporter_name: reporterName,
+        body: body.trim(),
+        created_at: ts,
+        project_name: null,
       };
     },
   );

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -153,12 +153,10 @@ export function registerContactHandlers(): void {
                 (SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contact_id = c.id) AS phones_raw,
                 (SELECT MIN(ile.created_at)
                  FROM interaction_log_entries ile
-                 JOIN project_memberships pm2 ON pm2.id = ile.membership_id
-                 WHERE pm2.contact_id = c.id) AS date_first_contacted,
+                 WHERE ile.contact_id = c.id) AS date_first_contacted,
                 (SELECT MAX(ile.created_at)
                  FROM interaction_log_entries ile
-                 JOIN project_memberships pm2 ON pm2.id = ile.membership_id
-                 WHERE pm2.contact_id = c.id) AS date_last_contacted
+                 WHERE ile.contact_id = c.id) AS date_last_contacted
          FROM contacts c
          LEFT JOIN project_memberships pm ON pm.contact_id = c.id
          LEFT JOIN projects p ON p.id = pm.project_id
@@ -238,9 +236,11 @@ export function registerContactHandlers(): void {
                 pm.theme, pm.first_outreach_at, pm.reporter_name, pm.reporter_email,
                 pm.outreach_reminders_enabled, pm.reporter_conflict,
                 (SELECT MIN(ile.created_at) FROM interaction_log_entries ile
-                 WHERE ile.membership_id = pm.id) AS first_log_at,
+                 JOIN interaction_projects ip ON ip.interaction_id = ile.id
+                 WHERE ip.membership_id = pm.id) AS first_log_at,
                 (SELECT MAX(ile.created_at) FROM interaction_log_entries ile
-                 WHERE ile.membership_id = pm.id) AS date_last_contacted
+                 JOIN interaction_projects ip ON ip.interaction_id = ile.id
+                 WHERE ip.membership_id = pm.id) AS date_last_contacted
          FROM project_memberships pm
          JOIN projects p ON p.id = pm.project_id
          WHERE pm.contact_id = ?
@@ -580,7 +580,11 @@ export function registerContactHandlers(): void {
   ipcMain.handle('interaction-log:list', (_, membershipId: string): InteractionLogEntry[] => {
     return getDatabase()
       .prepare(
-        'SELECT * FROM interaction_log_entries WHERE membership_id = ? ORDER BY created_at ASC',
+        `SELECT ile.id, ile.contact_id, ile.reporter_email, ile.reporter_name, ile.body, ile.created_at
+         FROM interaction_log_entries ile
+         JOIN interaction_projects ip ON ip.interaction_id = ile.id
+         WHERE ip.membership_id = ?
+         ORDER BY ile.created_at ASC`,
       )
       .all(membershipId) as InteractionLogEntry[];
   });
@@ -590,19 +594,28 @@ export function registerContactHandlers(): void {
     (_, { membershipId, body, createdAt }: { membershipId: string; body: string; createdAt?: number }): InteractionLogEntry => {
       const db = getDatabase();
       const user = db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
+      const membership = db
+        .prepare('SELECT contact_id FROM project_memberships WHERE id = ?')
+        .get(membershipId) as { contact_id: string } | undefined;
+      if (!membership) throw new Error('Membership not found');
       const id = uuidv4();
       const ts = createdAt ?? Math.floor(Date.now() / 1000);
       if (!Number.isFinite(ts) || ts <= 0) throw new Error('invalid created_at');
       const reporterName = `${user.first_name} ${user.last_name}`;
-      db.prepare(
-        'INSERT INTO interaction_log_entries (id, membership_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)',
-      ).run(id, membershipId, user.email, reporterName, body.trim(), ts);
+      db.transaction(() => {
+        db.prepare(
+          'INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+        ).run(id, membership.contact_id, user.email, reporterName, body.trim(), ts);
+        db.prepare(
+          'INSERT INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)',
+        ).run(id, membershipId);
+      })();
       // Clear any auto-outreach calendar reminder — source is no longer overdue.
       db.prepare('DELETE FROM reminders WHERE membership_id = ? AND is_auto_outreach = 1').run(membershipId);
       broadcastContactsChanged();
       return {
         id,
-        membership_id: membershipId,
+        contact_id: membership.contact_id,
         reporter_email: user.email,
         reporter_name: reporterName,
         body: body.trim(),
@@ -618,9 +631,7 @@ export function registerContactHandlers(): void {
 
   ipcMain.handle('contacts:interaction-count', (_, contactId: string): number => {
     const row = getDatabase().prepare(
-      `SELECT COUNT(*) as n FROM interaction_log_entries ile
-       JOIN project_memberships pm ON pm.id = ile.membership_id
-       WHERE pm.contact_id = ?`,
+      'SELECT COUNT(*) as n FROM interaction_log_entries WHERE contact_id = ?',
     ).get(contactId) as { n: number };
     return row.n;
   });

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -392,8 +392,8 @@ export function registerContactHandlers(): void {
                 EXISTS(SELECT 1 FROM contact_phones WHERE contact_id = c.id) AS has_phone,
                 (SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contact_id = c.id) AS emails_raw,
                 (SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contact_id = c.id) AS phones_raw,
-                (SELECT MIN(created_at) FROM interaction_log_entries WHERE membership_id = pm.id) AS date_first_contacted,
-                (SELECT MAX(created_at) FROM interaction_log_entries WHERE membership_id = pm.id) AS date_last_contacted
+                (SELECT MIN(ile.created_at) FROM interaction_log_entries ile JOIN interaction_projects ip ON ip.interaction_id = ile.id WHERE ip.membership_id = pm.id) AS date_first_contacted,
+                (SELECT MAX(ile.created_at) FROM interaction_log_entries ile JOIN interaction_projects ip ON ip.interaction_id = ile.id WHERE ip.membership_id = pm.id) AS date_last_contacted
          FROM project_memberships pm
          JOIN contacts c ON c.id = pm.contact_id
          WHERE pm.project_id = ?

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { getDatabase, isDatabaseOpen } from '../database';
 import { normalizeEmail, normalizePhone, validateEmail, validateUrl } from '../sanitize';
 import { broadcastRemindersChanged } from './reminders';
+import { checkOutreachReminders } from '../sync/outreach-checker';
 import type {
   ContactListItem,
   ContactDetail,
@@ -613,8 +614,10 @@ export function registerContactHandlers(): void {
           if (mid !== membershipId) insertProject.run(id, mid);
         }
       })();
-      // Clear any auto-outreach calendar reminder — source is no longer overdue.
-      db.prepare('DELETE FROM reminders WHERE membership_id = ? AND is_auto_outreach = 1').run(membershipId);
+      // Clear auto-outreach reminders for all associated memberships.
+      const allMids = [membershipId, ...(extraMembershipIds ?? [])];
+      const clearReminder = db.prepare('DELETE FROM reminders WHERE membership_id = ? AND is_auto_outreach = 1');
+      for (const mid of allMids) clearReminder.run(mid);
       broadcastContactsChanged();
       return {
         id,
@@ -666,6 +669,9 @@ export function registerContactHandlers(): void {
       const firstProject = (membershipIds ?? []).length > 0
         ? (db.prepare('SELECT p.name FROM project_memberships pm JOIN projects p ON p.id = pm.project_id WHERE pm.id = ?').get(membershipIds![0]) as { name: string } | undefined)?.name ?? null
         : null;
+      // Clear auto-outreach reminders for all associated memberships.
+      const clearReminder = db.prepare('DELETE FROM reminders WHERE membership_id = ? AND is_auto_outreach = 1');
+      for (const mid of membershipIds ?? []) clearReminder.run(mid);
       broadcastContactsChanged();
       return {
         id,
@@ -678,6 +684,19 @@ export function registerContactHandlers(): void {
       };
     },
   );
+
+  ipcMain.handle('interaction-log:delete', (_, interactionId: string): void => {
+    const db = getDatabase();
+    // Collect affected memberships before deleting so we can re-evaluate reminders.
+    const membershipIds = (
+      db.prepare('SELECT membership_id FROM interaction_projects WHERE interaction_id = ?').all(interactionId) as Array<{ membership_id: string }>
+    ).map((r) => r.membership_id);
+    db.prepare('DELETE FROM interaction_log_entries WHERE id = ?').run(interactionId);
+    // Re-run outreach checker so reminders are recreated if this was the last log.
+    checkOutreachReminders();
+    broadcastContactsChanged();
+    if (membershipIds.length > 0) broadcastRemindersChanged();
+  });
 
   ipcMain.handle('contacts:count', (): number => {
     const row = getDatabase().prepare('SELECT COUNT(*) as n FROM contacts').get() as { n: number };

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -642,16 +642,28 @@ export function registerContactHandlers(): void {
 
   ipcMain.handle(
     'interaction-log:add-global',
-    (_, { contactId, body, createdAt }: { contactId: string; body: string; createdAt?: number }): ContactLogEntry => {
+    (_, { contactId, body, createdAt, membershipIds }: { contactId: string; body: string; createdAt?: number; membershipIds?: string[] }): ContactLogEntry => {
       const db = getDatabase();
       const user = db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
       const id = uuidv4();
       const ts = createdAt ?? Math.floor(Date.now() / 1000);
       if (!Number.isFinite(ts) || ts <= 0) throw new Error('invalid created_at');
       const reporterName = `${user.first_name} ${user.last_name}`;
-      db.prepare(
+      const insertEntry = db.prepare(
         'INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)',
-      ).run(id, contactId, user.email, reporterName, body.trim(), ts);
+      );
+      const insertProject = db.prepare(
+        'INSERT OR IGNORE INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)',
+      );
+      db.transaction(() => {
+        insertEntry.run(id, contactId, user.email, reporterName, body.trim(), ts);
+        for (const mid of membershipIds ?? []) {
+          insertProject.run(id, mid);
+        }
+      })();
+      const firstProject = (membershipIds ?? []).length > 0
+        ? (db.prepare('SELECT p.name FROM project_memberships pm JOIN projects p ON p.id = pm.project_id WHERE pm.id = ?').get(membershipIds![0]) as { name: string } | undefined)?.name ?? null
+        : null;
       broadcastContactsChanged();
       return {
         id,
@@ -660,7 +672,7 @@ export function registerContactHandlers(): void {
         reporter_name: reporterName,
         body: body.trim(),
         created_at: ts,
-        project_name: null,
+        project_name: firstProject,
       };
     },
   );

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -592,7 +592,7 @@ export function registerContactHandlers(): void {
 
   ipcMain.handle(
     'interaction-log:add',
-    (_, { membershipId, body, createdAt }: { membershipId: string; body: string; createdAt?: number }): InteractionLogEntry => {
+    (_, { membershipId, body, createdAt, extraMembershipIds }: { membershipId: string; body: string; createdAt?: number; extraMembershipIds?: string[] }): InteractionLogEntry => {
       const db = getDatabase();
       const user = db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
       const membership = db
@@ -603,13 +603,15 @@ export function registerContactHandlers(): void {
       const ts = createdAt ?? Math.floor(Date.now() / 1000);
       if (!Number.isFinite(ts) || ts <= 0) throw new Error('invalid created_at');
       const reporterName = `${user.first_name} ${user.last_name}`;
+      const insertProject = db.prepare('INSERT OR IGNORE INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)');
       db.transaction(() => {
         db.prepare(
           'INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)',
         ).run(id, membership.contact_id, user.email, reporterName, body.trim(), ts);
-        db.prepare(
-          'INSERT INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)',
-        ).run(id, membershipId);
+        insertProject.run(id, membershipId);
+        for (const mid of extraMembershipIds ?? []) {
+          if (mid !== membershipId) insertProject.run(id, mid);
+        }
       })();
       // Clear any auto-outreach calendar reminder — source is no longer overdue.
       db.prepare('DELETE FROM reminders WHERE membership_id = ? AND is_auto_outreach = 1').run(membershipId);

--- a/src/main/ipc/export.ts
+++ b/src/main/ipc/export.ts
@@ -65,7 +65,8 @@ export function registerExportHandlers(): void {
         .prepare(
           `SELECT pm.id AS membership_id, pm.reporter_name, pm.theme, pm.priority, pm.status,
                   (SELECT MIN(ile.created_at) FROM interaction_log_entries ile
-                   WHERE ile.membership_id = pm.id) AS first_log_at,
+                   JOIN interaction_projects ip ON ip.interaction_id = ile.id
+                   WHERE ip.membership_id = pm.id) AS first_log_at,
                   c.id AS contact_id, c.name, c.organization, c.title, c.dob, c.notes
            FROM project_memberships pm
            JOIN contacts c ON c.id = pm.contact_id
@@ -117,7 +118,7 @@ export function registerExportHandlers(): void {
 
       const bulkLogs: { membership_id: string; reporter_name: string; body: string; created_at: number }[] =
         mode === 'full' && membershipIds.length
-          ? (db.prepare(`SELECT membership_id, reporter_name, body, created_at FROM interaction_log_entries WHERE membership_id IN (${ph(membershipIds)}) ORDER BY created_at ASC`).all(...membershipIds) as { membership_id: string; reporter_name: string; body: string; created_at: number }[])
+          ? (db.prepare(`SELECT ip.membership_id, ile.reporter_name, ile.body, ile.created_at FROM interaction_log_entries ile JOIN interaction_projects ip ON ip.interaction_id = ile.id WHERE ip.membership_id IN (${ph(membershipIds)}) ORDER BY ile.created_at ASC`).all(...membershipIds) as { membership_id: string; reporter_name: string; body: string; created_at: number }[])
           : [];
       const logsByMembership = new Map<string, { reporter_name: string; body: string; created_at: number }[]>();
       for (const r of bulkLogs) { const a = logsByMembership.get(r.membership_id) ?? []; a.push(r); logsByMembership.set(r.membership_id, a); }

--- a/src/main/ipc/export.ts
+++ b/src/main/ipc/export.ts
@@ -27,6 +27,56 @@ interface ExportRow {
   'Interaction log': string;
 }
 
+interface AllContactsRow {
+  Name: string;
+  Organization: string;
+  Title: string;
+  DOB: string;
+  Emails: string;
+  Phones: string;
+  Handles: string;
+  LinkedIn: string;
+  Facebook: string;
+  Instagram: string;
+  X: string;
+  Website: string;
+  'Other links': string;
+  Notes: string;
+  'Interaction log': string;
+}
+
+function fetchProjectsByInteraction(
+  db: import('better-sqlite3-multiple-ciphers').Database,
+  interactionIds: string[],
+): Map<string, string[]> {
+  if (!interactionIds.length) return new Map();
+  const ph = interactionIds.map(() => '?').join(',');
+  const rows = db.prepare(
+    `SELECT ip.interaction_id, p.name AS project_name
+     FROM interaction_projects ip
+     JOIN project_memberships pm ON pm.id = ip.membership_id
+     JOIN projects p ON p.id = pm.project_id
+     WHERE ip.interaction_id IN (${ph})
+     ORDER BY p.name ASC`,
+  ).all(...interactionIds) as { interaction_id: string; project_name: string }[];
+  const map = new Map<string, string[]>();
+  for (const r of rows) {
+    const a = map.get(r.interaction_id) ?? [];
+    a.push(r.project_name);
+    map.set(r.interaction_id, a);
+  }
+  return map;
+}
+
+function formatLogEntry(e: { id: string; created_at: number; reporter_name: string; body: string }, projectsByInteraction: Map<string, string[]>): string {
+  const date = new Date(e.created_at * 1000).toLocaleDateString();
+  const projects = projectsByInteraction.get(e.id) ?? [];
+  const header = projects.length
+    ? `${date} — ${e.reporter_name} — ${projects.join(', ')}`
+    : `${date} — ${e.reporter_name}`;
+  return `[${header}] ${e.body}`;
+}
+
 type ExportMode = 'full' | 'sanitized';
 
 
@@ -116,11 +166,12 @@ export function registerExportHandlers(): void {
       const handlesByContact = new Map<string, { type: string; handle: string }[]>();
       for (const r of bulkHandles) { const a = handlesByContact.get(r.contact_id) ?? []; a.push({ type: r.type, handle: r.handle }); handlesByContact.set(r.contact_id, a); }
 
-      const bulkLogs: { membership_id: string; reporter_name: string; body: string; created_at: number }[] =
+      const bulkLogs: { id: string; membership_id: string; reporter_name: string; body: string; created_at: number }[] =
         mode === 'full' && membershipIds.length
-          ? (db.prepare(`SELECT ip.membership_id, ile.reporter_name, ile.body, ile.created_at FROM interaction_log_entries ile JOIN interaction_projects ip ON ip.interaction_id = ile.id WHERE ip.membership_id IN (${ph(membershipIds)}) ORDER BY ile.created_at ASC`).all(...membershipIds) as { membership_id: string; reporter_name: string; body: string; created_at: number }[])
+          ? (db.prepare(`SELECT ile.id, ip.membership_id, ile.reporter_name, ile.body, ile.created_at FROM interaction_log_entries ile JOIN interaction_projects ip ON ip.interaction_id = ile.id WHERE ip.membership_id IN (${ph(membershipIds)}) ORDER BY ile.created_at ASC`).all(...membershipIds) as { id: string; membership_id: string; reporter_name: string; body: string; created_at: number }[])
           : [];
-      const logsByMembership = new Map<string, { reporter_name: string; body: string; created_at: number }[]>();
+      const projectsByInteraction = fetchProjectsByInteraction(db, bulkLogs.map((e) => e.id));
+      const logsByMembership = new Map<string, { id: string; reporter_name: string; body: string; created_at: number }[]>();
       for (const r of bulkLogs) { const a = logsByMembership.get(r.membership_id) ?? []; a.push(r); logsByMembership.set(r.membership_id, a); }
 
       const rows: ExportRow[] = [];
@@ -133,7 +184,7 @@ export function registerExportHandlers(): void {
         const byType = (type: string) => links.filter((l) => l.type === type).map((l) => l.url).join('; ');
         const interactionLog = mode === 'full'
           ? (logsByMembership.get(m.membership_id) ?? [])
-              .map((e) => `[${new Date(e.created_at * 1000).toLocaleDateString()} — ${e.reporter_name}] ${e.body}`)
+              .map((e) => formatLogEntry(e, projectsByInteraction))
               .join('\n')
           : '';
 
@@ -235,7 +286,14 @@ export function registerExportHandlers(): void {
       const handlesById = new Map<string, { type: string; handle: string }[]>();
       for (const r of allHandles2) { const a = handlesById.get(r.contact_id) ?? []; a.push({ type: r.type, handle: r.handle }); handlesById.set(r.contact_id, a); }
 
-      const rows: { Name: string; Organization: string; Title: string; DOB: string; Emails: string; Phones: string; Handles: string; LinkedIn: string; Facebook: string; Instagram: string; X: string; Website: string; 'Other links': string; Notes: string }[] = contacts.map((c) => {
+      const allLogs = allContactIds.length
+        ? (db.prepare(`SELECT id, contact_id, reporter_name, body, created_at FROM interaction_log_entries WHERE contact_id IN (${ph2(allContactIds)}) ORDER BY created_at ASC`).all(...allContactIds) as { id: string; contact_id: string; reporter_name: string; body: string; created_at: number }[])
+        : [];
+      const logsByContactId = new Map<string, { id: string; reporter_name: string; body: string; created_at: number }[]>();
+      for (const r of allLogs) { const a = logsByContactId.get(r.contact_id) ?? []; a.push(r); logsByContactId.set(r.contact_id, a); }
+      const allLogProjects = fetchProjectsByInteraction(db, allLogs.map((e) => e.id));
+
+      const rows: AllContactsRow[] = contacts.map((c) => {
         const links = linksById.get(c.id) ?? [];
         const byType2 = (type: string) => links.filter((l) => l.type === type).map((l) => l.url).join('; ');
         return {
@@ -253,6 +311,9 @@ export function registerExportHandlers(): void {
           Website: byType2('website'),
           'Other links': byType2('other'),
           Notes: c.notes ?? '',
+          'Interaction log': (logsByContactId.get(c.id) ?? [])
+            .map((e) => formatLogEntry(e, allLogProjects))
+            .join('\n'),
         };
       });
 
@@ -260,7 +321,7 @@ export function registerExportHandlers(): void {
         const wb = new ExcelJS.Workbook();
         const ws = wb.addWorksheet('Contacts');
         if (rows.length > 0) {
-          ws.columns = Object.keys(rows[0]).map((k) => ({ header: k, key: k }));
+          ws.columns = (Object.keys(rows[0]) as (keyof AllContactsRow)[]).map((k) => ({ header: k, key: k }));
         }
         ws.addRows(rows);
         if (isXlsx) {

--- a/src/main/ipc/projects.ts
+++ b/src/main/ipc/projects.ts
@@ -439,7 +439,8 @@ function attachProjects(
      FROM interaction_projects ip
      JOIN project_memberships pm ON pm.id = ip.membership_id
      JOIN projects p ON p.id = pm.project_id
-     WHERE ip.interaction_id IN (${ph})`,
+     WHERE ip.interaction_id IN (${ph})
+     ORDER BY p.name ASC`,
   ).all(...ids) as Array<{ interaction_id: string } & TimelineEntryProject>;
 
   const projMap = new Map<string, TimelineEntryProject[]>();

--- a/src/main/ipc/projects.ts
+++ b/src/main/ipc/projects.ts
@@ -6,7 +6,7 @@ import { createSharedDb, openSharedDb, closeSharedDb, rekeySharedDb } from '../d
 import { encodePayload, decodePayload } from '../sync/payload';
 import { syncProject } from '../sync/engine';
 import { broadcastRemindersChanged } from './reminders';
-import type { Project, User } from '@shared/types';
+import type { Project, User, TimelineEntry, TimelineEntryProject } from '@shared/types';
 
 export function registerProjectHandlers(): void {
   ipcMain.handle('projects:list', (): Project[] => {
@@ -396,36 +396,57 @@ export function registerProjectHandlers(): void {
       .all(projectId) as Array<{ email: string; name: string }>;
   });
 
-  ipcMain.handle('projects:list-timeline', (_, projectId: string) => {
-    return getDatabase()
-      .prepare(
-        `SELECT ile.id, ile.body, ile.created_at, ile.reporter_name, ile.reporter_email,
-                c.id AS contact_id, c.name AS contact_name, c.organization AS contact_organization,
-                p.id AS project_id, p.name AS project_name,
-                pm.theme, pm.priority
-         FROM interaction_log_entries ile
-         JOIN project_memberships pm ON pm.id = ile.membership_id
-         JOIN contacts c ON c.id = pm.contact_id
-         JOIN projects p ON p.id = pm.project_id
-         WHERE pm.project_id = ?
-         ORDER BY ile.created_at DESC`,
-      )
-      .all(projectId);
+  ipcMain.handle('projects:list-timeline', (_, projectId: string): TimelineEntry[] => {
+    const db = getDatabase();
+    type BaseRow = Omit<TimelineEntry, 'projects'>;
+    const entries = db.prepare(
+      `SELECT ile.id, ile.body, ile.created_at, ile.reporter_name, ile.reporter_email,
+              c.id AS contact_id, c.name AS contact_name, c.organization AS contact_organization
+       FROM interaction_log_entries ile
+       JOIN contacts c ON c.id = ile.contact_id
+       JOIN interaction_projects ip ON ip.interaction_id = ile.id
+       JOIN project_memberships pm ON pm.id = ip.membership_id
+       WHERE pm.project_id = ?
+       ORDER BY ile.created_at DESC`,
+    ).all(projectId) as BaseRow[];
+    return attachProjects(db, entries);
   });
 
-  ipcMain.handle('contacts:list-timeline', () => {
-    return getDatabase()
-      .prepare(
-        `SELECT ile.id, ile.body, ile.created_at, ile.reporter_name, ile.reporter_email,
-                c.id AS contact_id, c.name AS contact_name, c.organization AS contact_organization,
-                p.id AS project_id, p.name AS project_name,
-                pm.theme, pm.priority
-         FROM interaction_log_entries ile
-         JOIN project_memberships pm ON pm.id = ile.membership_id
-         JOIN contacts c ON c.id = pm.contact_id
-         JOIN projects p ON p.id = pm.project_id
-         ORDER BY ile.created_at DESC`,
-      )
-      .all();
+  ipcMain.handle('contacts:list-timeline', (): TimelineEntry[] => {
+    const db = getDatabase();
+    type BaseRow = Omit<TimelineEntry, 'projects'>;
+    const entries = db.prepare(
+      `SELECT ile.id, ile.body, ile.created_at, ile.reporter_name, ile.reporter_email,
+              c.id AS contact_id, c.name AS contact_name, c.organization AS contact_organization
+       FROM interaction_log_entries ile
+       JOIN contacts c ON c.id = ile.contact_id
+       ORDER BY ile.created_at DESC`,
+    ).all() as BaseRow[];
+    return attachProjects(db, entries);
   });
+}
+
+function attachProjects(
+  db: ReturnType<typeof getDatabase>,
+  entries: Array<Omit<TimelineEntry, 'projects'>>,
+): TimelineEntry[] {
+  if (entries.length === 0) return [];
+  const ids = entries.map((e) => e.id);
+  const ph = ids.map(() => '?').join(',');
+  const rows = db.prepare(
+    `SELECT ip.interaction_id, p.id AS project_id, p.name AS project_name,
+            ip.membership_id, pm.theme, pm.priority
+     FROM interaction_projects ip
+     JOIN project_memberships pm ON pm.id = ip.membership_id
+     JOIN projects p ON p.id = pm.project_id
+     WHERE ip.interaction_id IN (${ph})`,
+  ).all(...ids) as Array<{ interaction_id: string } & TimelineEntryProject>;
+
+  const projMap = new Map<string, TimelineEntryProject[]>();
+  for (const r of rows) {
+    const arr = projMap.get(r.interaction_id) ?? [];
+    arr.push({ project_id: r.project_id, project_name: r.project_name, membership_id: r.membership_id, theme: r.theme, priority: r.priority });
+    projMap.set(r.interaction_id, arr);
+  }
+  return entries.map((e) => ({ ...e, projects: projMap.get(e.id) ?? [] }));
 }

--- a/src/main/ipc/search.ts
+++ b/src/main/ipc/search.ts
@@ -52,13 +52,15 @@ export function performSearch(query: string, db: Database.Database): SearchResul
     logResults = db
       .prepare(
         `SELECT e.id AS entry_id, c.id AS contact_id, c.name AS contact_name,
-                p.name AS project_name,
+                (SELECT p.name FROM interaction_projects ip
+                 JOIN project_memberships pm ON pm.id = ip.membership_id
+                 JOIN projects p ON p.id = pm.project_id
+                 WHERE ip.interaction_id = e.id
+                 LIMIT 1) AS project_name,
                 snippet(interaction_log_fts, 0, '[[', ']]', '...', 20) AS excerpt
          FROM interaction_log_fts fts
          JOIN interaction_log_entries e ON e.rowid = fts.rowid
-         JOIN project_memberships pm ON pm.id = e.membership_id
-         JOIN contacts c ON c.id = pm.contact_id
-         JOIN projects p ON p.id = pm.project_id
+         JOIN contacts c ON c.id = e.contact_id
          WHERE fts.body MATCH ?
          ORDER BY fts.rank, e.created_at DESC
          LIMIT 5`,

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -381,16 +381,16 @@ function pullMemberships(
         .prepare('SELECT id FROM project_memberships WHERE contact_id = ? AND project_id = ? AND id != ?')
         .get(sm.contact_id, projectId, sm.id) as { id: string } | undefined;
 
-      type LogEntry = { id: string; reporter_email: string; reporter_name: string; body: string; created_at: number; synced_at: number | null };
       type MemberReporter = { id: string; reporter_email: string; reporter_name: string };
       type SavedReminder = { id: string; contact_id: string; project_id: string; due_date: number; note: string | null; is_auto_outreach: number; created_at: number; completed_at: number | null; last_notified_at: number | null };
-      let savedLogEntries: LogEntry[] = [];
+      let savedLogEntryIds: string[] = [];
       let savedReporters: MemberReporter[] = [];
       let savedReminders: SavedReminder[] = [];
 
       if (conflicting) {
-        // Read children before the CASCADE delete removes them
-        savedLogEntries = local.prepare('SELECT id, reporter_email, reporter_name, body, created_at, synced_at FROM interaction_log_entries WHERE membership_id = ?').all(conflicting.id) as LogEntry[];
+        // Read children before the CASCADE delete removes them.
+        // Log entries themselves survive (contact_id FK); only interaction_projects rows are cascade-deleted.
+        savedLogEntryIds = (local.prepare('SELECT interaction_id FROM interaction_projects WHERE membership_id = ?').all(conflicting.id) as { interaction_id: string }[]).map((r) => r.interaction_id);
         savedReporters = local.prepare('SELECT id, reporter_email, reporter_name FROM membership_reporters WHERE membership_id = ?').all(conflicting.id) as MemberReporter[];
         savedReminders = local.prepare('SELECT id, contact_id, project_id, due_date, note, is_auto_outreach, created_at, completed_at, last_notified_at FROM reminders WHERE membership_id = ?').all(conflicting.id) as SavedReminder[];
         local.prepare('DELETE FROM project_memberships WHERE id = ?').run(conflicting.id);
@@ -431,8 +431,8 @@ function pullMemberships(
 
       // Re-attach children that were cascade-deleted with conflicting membership
       if (conflicting) {
-        for (const e of savedLogEntries) {
-          local.prepare('INSERT OR IGNORE INTO interaction_log_entries (id, membership_id, reporter_email, reporter_name, body, created_at, synced_at) VALUES (?, ?, ?, ?, ?, ?, ?)').run(e.id, sm.id, e.reporter_email, e.reporter_name, e.body, e.created_at, e.synced_at);
+        for (const entryId of savedLogEntryIds) {
+          local.prepare('INSERT OR IGNORE INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)').run(entryId, sm.id);
         }
         for (const mr of savedReporters) {
           local.prepare('INSERT OR IGNORE INTO membership_reporters (id, membership_id, reporter_email, reporter_name) VALUES (?, ?, ?, ?)').run(mr.id, sm.id, mr.reporter_email, mr.reporter_name);
@@ -488,7 +488,7 @@ function pullAppendOnly(
 
   for (const se of shared.prepare('SELECT * FROM interaction_log_entries').all() as {
     id: string;
-    membership_id: string;
+    contact_id: string;
     reporter_email: string;
     reporter_name: string;
     body: string;
@@ -497,10 +497,19 @@ function pullAppendOnly(
     local
       .prepare(
         `INSERT OR IGNORE INTO interaction_log_entries
-           (id, membership_id, reporter_email, reporter_name, body, created_at)
+           (id, contact_id, reporter_email, reporter_name, body, created_at)
          VALUES (?, ?, ?, ?, ?, ?)`,
       )
-      .run(se.id, se.membership_id, se.reporter_email, se.reporter_name, se.body, se.created_at);
+      .run(se.id, se.contact_id, se.reporter_email, se.reporter_name, se.body, se.created_at);
+  }
+
+  for (const sip of shared.prepare('SELECT * FROM interaction_projects').all() as {
+    interaction_id: string;
+    membership_id: string;
+  }[]) {
+    local
+      .prepare('INSERT OR IGNORE INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)')
+      .run(sip.interaction_id, sip.membership_id);
   }
 }
 
@@ -720,14 +729,17 @@ function pushAppendOnly(
   if (membershipIds.length > 0) {
     const mPlaceholders = membershipIds.map(() => '?').join(',');
 
-    // Interaction log entries
+    // Interaction log entries (push entries not yet synced that are linked to these memberships)
     for (const e of local
       .prepare(
-        `SELECT * FROM interaction_log_entries WHERE membership_id IN (${mPlaceholders}) AND synced_at IS NULL`,
+        `SELECT DISTINCT ile.id, ile.contact_id, ile.reporter_email, ile.reporter_name, ile.body, ile.created_at
+         FROM interaction_log_entries ile
+         JOIN interaction_projects ip ON ip.interaction_id = ile.id
+         WHERE ip.membership_id IN (${mPlaceholders}) AND ile.synced_at IS NULL`,
       )
       .all(...membershipIds) as {
       id: string;
-      membership_id: string;
+      contact_id: string;
       reporter_email: string;
       reporter_name: string;
       body: string;
@@ -736,10 +748,18 @@ function pushAppendOnly(
       shared
         .prepare(
           `INSERT OR IGNORE INTO interaction_log_entries
-             (id, membership_id, reporter_email, reporter_name, body, created_at)
+             (id, contact_id, reporter_email, reporter_name, body, created_at)
            VALUES (?, ?, ?, ?, ?, ?)`,
         )
-        .run(e.id, e.membership_id, e.reporter_email, e.reporter_name, e.body, e.created_at);
+        .run(e.id, e.contact_id, e.reporter_email, e.reporter_name, e.body, e.created_at);
+      // Push all interaction_projects rows for this entry
+      for (const ip of local
+        .prepare('SELECT interaction_id, membership_id FROM interaction_projects WHERE interaction_id = ?')
+        .all(e.id) as { interaction_id: string; membership_id: string }[]) {
+        shared
+          .prepare('INSERT OR IGNORE INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)')
+          .run(ip.interaction_id, ip.membership_id);
+      }
       local
         .prepare('UPDATE interaction_log_entries SET synced_at = ? WHERE id = ?')
         .run(now, e.id);

--- a/src/main/sync/outreach-checker.ts
+++ b/src/main/sync/outreach-checker.ts
@@ -50,7 +50,8 @@ export function checkOutreachReminders(): void {
        JOIN contacts c  ON c.id = pm.contact_id
        JOIN projects p  ON p.id = pm.project_id
        LEFT JOIN priority_options po ON po.label = pm.priority
-       LEFT JOIN interaction_log_entries ile ON ile.membership_id = pm.id
+       LEFT JOIN interaction_projects ip ON ip.membership_id = pm.id
+       LEFT JOIN interaction_log_entries ile ON ile.id = ip.interaction_id
        WHERE pm.outreach_reminders_enabled = 1
          AND COALESCE(pm.outreach_interval_days, po.outreach_interval_days) IS NOT NULL
          AND pm.reporter_email = (SELECT email FROM users WHERE id = 1)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -144,6 +144,8 @@ const sourcererApi = {
     ipcRenderer.invoke('interaction-log:add', { membershipId, body, createdAt, extraMembershipIds }),
   listContactLog: (contactId: string): Promise<ContactLogEntry[]> =>
     ipcRenderer.invoke('interaction-log:list-for-contact', contactId),
+  deleteInteractionLogEntry: (interactionId: string): Promise<void> =>
+    ipcRenderer.invoke('interaction-log:delete', interactionId),
   addGlobalLogEntry: (contactId: string, body: string, createdAt?: number, membershipIds?: string[]): Promise<ContactLogEntry> =>
     ipcRenderer.invoke('interaction-log:add-global', { contactId, body, createdAt, membershipIds }),
   getContactCount: (): Promise<number> => ipcRenderer.invoke('contacts:count'),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -13,6 +13,7 @@ import type {
   UpdateMembershipInput,
   ProjectContactRow,
   InteractionLogEntry,
+  ContactLogEntry,
   ScratchpadDraft,
   StatusOption,
   PriorityOption,
@@ -141,6 +142,10 @@ const sourcererApi = {
     ipcRenderer.invoke('interaction-log:list', membershipId),
   addInteractionLogEntry: (membershipId: string, body: string, createdAt?: number): Promise<InteractionLogEntry> =>
     ipcRenderer.invoke('interaction-log:add', { membershipId, body, createdAt }),
+  listContactLog: (contactId: string): Promise<ContactLogEntry[]> =>
+    ipcRenderer.invoke('interaction-log:list-for-contact', contactId),
+  addGlobalLogEntry: (contactId: string, body: string, createdAt?: number): Promise<ContactLogEntry> =>
+    ipcRenderer.invoke('interaction-log:add-global', { contactId, body, createdAt }),
   getContactCount: (): Promise<number> => ipcRenderer.invoke('contacts:count'),
   getContactInteractionCount: (contactId: string): Promise<number> =>
     ipcRenderer.invoke('contacts:interaction-count', contactId),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -140,8 +140,8 @@ const sourcererApi = {
   // Interaction log
   listInteractionLog: (membershipId: string): Promise<InteractionLogEntry[]> =>
     ipcRenderer.invoke('interaction-log:list', membershipId),
-  addInteractionLogEntry: (membershipId: string, body: string, createdAt?: number): Promise<InteractionLogEntry> =>
-    ipcRenderer.invoke('interaction-log:add', { membershipId, body, createdAt }),
+  addInteractionLogEntry: (membershipId: string, body: string, createdAt?: number, extraMembershipIds?: string[]): Promise<InteractionLogEntry> =>
+    ipcRenderer.invoke('interaction-log:add', { membershipId, body, createdAt, extraMembershipIds }),
   listContactLog: (contactId: string): Promise<ContactLogEntry[]> =>
     ipcRenderer.invoke('interaction-log:list-for-contact', contactId),
   addGlobalLogEntry: (contactId: string, body: string, createdAt?: number, membershipIds?: string[]): Promise<ContactLogEntry> =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -144,8 +144,8 @@ const sourcererApi = {
     ipcRenderer.invoke('interaction-log:add', { membershipId, body, createdAt }),
   listContactLog: (contactId: string): Promise<ContactLogEntry[]> =>
     ipcRenderer.invoke('interaction-log:list-for-contact', contactId),
-  addGlobalLogEntry: (contactId: string, body: string, createdAt?: number): Promise<ContactLogEntry> =>
-    ipcRenderer.invoke('interaction-log:add-global', { contactId, body, createdAt }),
+  addGlobalLogEntry: (contactId: string, body: string, createdAt?: number, membershipIds?: string[]): Promise<ContactLogEntry> =>
+    ipcRenderer.invoke('interaction-log:add-global', { contactId, body, createdAt, membershipIds }),
   getContactCount: (): Promise<number> => ipcRenderer.invoke('contacts:count'),
   getContactInteractionCount: (contactId: string): Promise<number> =>
     ipcRenderer.invoke('contacts:interaction-count', contactId),

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -749,7 +749,7 @@
 
 .pt-log-projects {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 10px;
 }
 

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -641,6 +641,15 @@
   flex-wrap: wrap;
 }
 
+.pt-log-row-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  flex-shrink: 0;
+  padding-top: 2px;
+}
+
 .pt-log-row-delete {
   background: none;
   border: none;
@@ -651,7 +660,6 @@
   cursor: pointer;
   opacity: 0;
   transition: opacity 0.1s;
-  margin-left: auto;
 }
 
 .pt-log-row:hover .pt-log-row-delete {
@@ -660,6 +668,40 @@
 
 .pt-log-row-delete:hover {
   color: var(--color-danger);
+}
+
+.pt-log-row-confirm-yes,
+.pt-log-row-confirm-no {
+  height: 20px;
+  padding: 0 7px;
+  border: 1px solid var(--color-border);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+  background: none;
+  white-space: nowrap;
+}
+
+.pt-log-row-confirm-yes {
+  border-color: var(--color-danger);
+  color: var(--color-danger);
+}
+
+.pt-log-row-confirm-yes:hover {
+  background: var(--color-danger);
+  color: var(--color-bg);
+}
+
+.pt-log-row-confirm-no {
+  color: var(--color-text-muted);
+}
+
+.pt-log-row-confirm-no:hover {
+  color: var(--color-text);
+  border-color: var(--color-text);
 }
 
 .pt-log-row-reporter {

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -1027,6 +1027,12 @@
   margin-bottom: 0;
 }
 
+.pt-log-header-actions {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
 .pt-reminders-label {
   font-family: var(--font-mono);
   font-size: 11px;

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -747,6 +747,64 @@
   border-bottom: 1px solid var(--color-border);
 }
 
+.pt-log-compose--global {
+  margin-bottom: 12px;
+}
+
+.pt-log-projects {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.pt-log-project-tags {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.pt-log-project-tag {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  background: var(--color-border);
+  border-radius: 3px;
+  padding: 1px 4px 1px 6px;
+}
+
+.pt-log-project-tag-remove {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--color-text-dim);
+  cursor: pointer;
+}
+
+.pt-log-project-tag-remove:hover {
+  color: var(--color-text);
+}
+
+.pt-log-project-select {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  padding: 2px 4px;
+  cursor: pointer;
+  outline: none;
+}
+
 .pt-log-date-row {
   display: flex;
   align-items: center;

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -634,12 +634,29 @@
   margin-bottom: 4px;
 }
 
+.pt-log-row-footer {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
 .pt-log-row-reporter {
   font-family: var(--font-mono);
   font-size: 10px;
   color: var(--color-text-muted);
   letter-spacing: 0.16em;
   text-transform: uppercase;
+}
+
+.pt-log-row-project-badge {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+  background: var(--color-border);
+  border-radius: 3px;
+  padding: 0px 4px;
 }
 
 /* ── Log modal ── */

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -650,13 +650,12 @@
 }
 
 .pt-log-row-project-badge {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-family: var(--font-serif);
+  font-size: 11px;
   color: var(--color-text-muted);
   background: var(--color-border);
   border-radius: 3px;
-  padding: 0px 4px;
+  padding: 0px 5px;
 }
 
 /* ── Log modal ── */

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -743,12 +743,8 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 12px 0 4px;
+  padding: 12px 0 12px;
   border-bottom: 1px solid var(--color-border);
-}
-
-.pt-log-compose--global {
-  margin-bottom: 12px;
 }
 
 .pt-log-projects {
@@ -757,53 +753,6 @@
   gap: 10px;
 }
 
-.pt-log-project-tags {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 6px;
-}
-
-.pt-log-project-tag {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
-  background: var(--color-border);
-  border-radius: 3px;
-  padding: 1px 4px 1px 6px;
-}
-
-.pt-log-project-tag-remove {
-  background: none;
-  border: none;
-  padding: 0;
-  font-size: 12px;
-  line-height: 1;
-  color: var(--color-text-dim);
-  cursor: pointer;
-}
-
-.pt-log-project-tag-remove:hover {
-  color: var(--color-text);
-}
-
-.pt-log-project-select {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  padding: 2px 4px;
-  cursor: pointer;
-  outline: none;
-}
 
 .pt-log-date-row {
   display: flex;

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -650,12 +650,14 @@
 }
 
 .pt-log-row-project-badge {
-  font-family: var(--font-serif);
-  font-size: 11px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--color-text-muted);
   background: var(--color-border);
   border-radius: 3px;
-  padding: 0px 5px;
+  padding: 0px 4px;
 }
 
 /* ── Log modal ── */

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -641,6 +641,27 @@
   flex-wrap: wrap;
 }
 
+.pt-log-row-delete {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.1s;
+  margin-left: auto;
+}
+
+.pt-log-row:hover .pt-log-row-delete {
+  opacity: 1;
+}
+
+.pt-log-row-delete:hover {
+  color: var(--color-danger);
+}
+
 .pt-log-row-reporter {
   font-family: var(--font-mono);
   font-size: 10px;

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -867,7 +867,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
       <div className="pt-section">
         <div className="pt-reminders-header">
           <span className="pt-reminders-label">Interaction Log</span>
-          <div style={{ display: 'flex', alignItems: 'baseline', gap: 12 }}>
+          <div className="pt-log-header-actions">
             {logEntries.length > 0 && (
               <Button variant="ghost" onClick={() => setLogShowAll(true)}>
                 View all ({logEntries.length})

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -69,6 +69,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
   const [logDate, setLogDate] = useState('');
   const [logSubmitting, setLogSubmitting] = useState(false);
   const [logShowAll, setLogShowAll] = useState(false);
+  const [logSelectedMembershipIds, setLogSelectedMembershipIds] = useState<string[]>([]);
   const LOG_PREVIEW = 3;
 
   useEffect(() => {
@@ -151,6 +152,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
     setLogAdding(false);
     setLogText('');
     setLogDate('');
+    setLogSelectedMembershipIds([]);
     window.sourcerer.listContactLog(contact.id).then(setLogEntries);
   }, [contact.id]);
 
@@ -298,6 +300,13 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
     setAlertRssList((prev) => prev.filter((f) => f.id !== id));
   }
 
+  function cancelLog() {
+    setLogAdding(false);
+    setLogText('');
+    setLogDate('');
+    setLogSelectedMembershipIds([]);
+  }
+
   async function handleLogSubmit() {
     const body = logText.trim();
     if (!body || !logDate) return;
@@ -305,10 +314,11 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
     try {
       const [y, m, d] = logDate.split('-').map(Number);
       const createdAt = Math.floor(new Date(y, m - 1, d, 12, 0, 0).getTime() / 1000);
-      const entry = await window.sourcerer.addGlobalLogEntry(contact.id, body, createdAt);
+      const entry = await window.sourcerer.addGlobalLogEntry(contact.id, body, createdAt, logSelectedMembershipIds);
       setLogEntries((prev) => [...prev, entry].sort((a, b) => a.created_at - b.created_at));
       setLogText('');
       setLogDate('');
+      setLogSelectedMembershipIds([]);
       setLogAdding(false);
     } finally {
       setLogSubmitting(false);
@@ -857,12 +867,14 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                 View all ({logEntries.length})
               </Button>
             )}
-            <Button variant="ghost" onClick={() => {
-              if (!logAdding) setLogDate(new Date().toISOString().slice(0, 10));
-              setLogAdding((v) => !v);
-            }}>
-              {logAdding ? '× Cancel' : '+ Add'}
-            </Button>
+            {!logAdding && (
+              <Button variant="ghost" onClick={() => {
+                setLogDate(new Date().toISOString().slice(0, 10));
+                setLogAdding(true);
+              }}>
+                + Add
+              </Button>
+            )}
           </div>
         </div>
 
@@ -875,7 +887,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         ))}
 
         {logAdding && (
-          <div className="pt-log-compose">
+          <div className="pt-log-compose pt-log-compose--global">
             <div className="pt-log-date-row">
               <label className="pt-log-date-label">Date</label>
               <CalendarPicker
@@ -897,6 +909,42 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                 if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleLogSubmit();
               }}
             />
+            {contact.projects.length > 0 && (
+              <div className="pt-log-projects">
+                <label className="pt-log-date-label">Projects</label>
+                <div className="pt-log-project-tags">
+                  {logSelectedMembershipIds.map((mid) => {
+                    const proj = contact.projects.find((p) => p.membership_id === mid);
+                    return proj ? (
+                      <span key={mid} className="pt-log-project-tag">
+                        {proj.name}
+                        <button
+                          type="button"
+                          className="pt-log-project-tag-remove"
+                          onClick={() => setLogSelectedMembershipIds((prev) => prev.filter((id) => id !== mid))}
+                        >×</button>
+                      </span>
+                    ) : null;
+                  })}
+                  {contact.projects.filter((p) => !logSelectedMembershipIds.includes(p.membership_id)).length > 0 && (
+                    <select
+                      className="pt-log-project-select"
+                      value=""
+                      onChange={(e) => {
+                        if (e.target.value) setLogSelectedMembershipIds((prev) => [...prev, e.target.value]);
+                      }}
+                    >
+                      <option value="">Add project…</option>
+                      {contact.projects
+                        .filter((p) => !logSelectedMembershipIds.includes(p.membership_id))
+                        .map((p) => (
+                          <option key={p.membership_id} value={p.membership_id}>{p.name}</option>
+                        ))}
+                    </select>
+                  )}
+                </div>
+              </div>
+            )}
             <div className="pt-reminder-form-actions">
               <button
                 className="pt-log-submit"
@@ -904,6 +952,9 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                 disabled={!logText.trim() || !logDate || logSubmitting}
               >
                 {logSubmitting ? 'Saving…' : 'Save'}
+              </button>
+              <button type="button" className="pt-reminder-cancel" onClick={cancelLog}>
+                Cancel
               </button>
             </div>
           </div>

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -890,7 +890,6 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         {logAdding && (
           <div className="pt-log-compose pt-log-compose--global">
             <div className="pt-log-date-row">
-              <label className="pt-log-date-label">Date</label>
               <CalendarPicker
                 label="Select date"
                 value={logDate}

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -301,6 +301,11 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
     setAlertRssList((prev) => prev.filter((f) => f.id !== id));
   }
 
+  async function handleLogDelete(id: string) {
+    await window.sourcerer.deleteInteractionLogEntry(id);
+    setLogEntries((prev) => prev.filter((e) => e.id !== id));
+  }
+
   function cancelLog() {
     setLogAdding(false);
     setLogText('');
@@ -884,7 +889,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         )}
 
         {[...logEntries].reverse().slice(0, LOG_PREVIEW).map((e) => (
-          <LogRow key={e.id} entry={e} subtitle={e.project_name} />
+          <LogRow key={e.id} entry={e} subtitle={e.project_name} onDelete={handleLogDelete} />
         ))}
 
         {logAdding && (
@@ -938,6 +943,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
             title="Interaction Log"
             entries={logEntries}
             getSubtitle={(e) => (e as ContactLogEntry).project_name}
+            onDelete={handleLogDelete}
             onClose={() => setLogShowAll(false)}
           />
         )}

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ContactDetail as ContactDetailType, ContactAlertRss, ContactLogEntry, Project, User } from '@shared/types';
 import Button from '../shell/Button';
 import { LogRow, LogAllModal } from './logShared';
+import LogProjectPicker from './LogProjectPicker';
 import DynamicList, { useDragReorder } from './DynamicList';
 import {
   isValidEmail,
@@ -912,37 +913,11 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
             {contact.projects.length > 0 && (
               <div className="pt-log-projects">
                 <label className="pt-log-date-label">Projects</label>
-                <div className="pt-log-project-tags">
-                  {logSelectedMembershipIds.map((mid) => {
-                    const proj = contact.projects.find((p) => p.membership_id === mid);
-                    return proj ? (
-                      <span key={mid} className="pt-log-project-tag">
-                        {proj.name}
-                        <button
-                          type="button"
-                          className="pt-log-project-tag-remove"
-                          onClick={() => setLogSelectedMembershipIds((prev) => prev.filter((id) => id !== mid))}
-                        >×</button>
-                      </span>
-                    ) : null;
-                  })}
-                  {contact.projects.filter((p) => !logSelectedMembershipIds.includes(p.membership_id)).length > 0 && (
-                    <select
-                      className="pt-log-project-select"
-                      value=""
-                      onChange={(e) => {
-                        if (e.target.value) setLogSelectedMembershipIds((prev) => [...prev, e.target.value]);
-                      }}
-                    >
-                      <option value="">Add project…</option>
-                      {contact.projects
-                        .filter((p) => !logSelectedMembershipIds.includes(p.membership_id))
-                        .map((p) => (
-                          <option key={p.membership_id} value={p.membership_id}>{p.name}</option>
-                        ))}
-                    </select>
-                  )}
-                </div>
+                <LogProjectPicker
+                  projects={contact.projects}
+                  selectedIds={logSelectedMembershipIds}
+                  onChange={setLogSelectedMembershipIds}
+                />
               </div>
             )}
             <div className="pt-reminder-form-actions">

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { ContactDetail as ContactDetailType, ContactAlertRss, Project, User } from '@shared/types';
+import type { ContactDetail as ContactDetailType, ContactAlertRss, ContactLogEntry, Project, User } from '@shared/types';
 import Button from '../shell/Button';
+import { LogRow, LogAllModal } from './logShared';
 import DynamicList, { useDragReorder } from './DynamicList';
 import {
   isValidEmail,
@@ -61,6 +62,14 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
   const [alertRssList, setAlertRssList] = useState<ContactAlertRss[]>([]);
   const [waybackStatus, setWaybackStatus] = useState<Map<string, 'pending' | 'failed'>>(new Map());
   const formRef = useRef<HTMLDivElement>(null);
+
+  const [logEntries, setLogEntries] = useState<ContactLogEntry[]>([]);
+  const [logAdding, setLogAdding] = useState(false);
+  const [logText, setLogText] = useState('');
+  const [logDate, setLogDate] = useState('');
+  const [logSubmitting, setLogSubmitting] = useState(false);
+  const [logShowAll, setLogShowAll] = useState(false);
+  const LOG_PREVIEW = 3;
 
   useEffect(() => {
     return window.sourcerer.onWaybackStatus(({ contactId, url, status }) => {
@@ -135,6 +144,14 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
 
   useEffect(() => {
     window.sourcerer.listAlertRss(contact.id).then(setAlertRssList);
+  }, [contact.id]);
+
+  useEffect(() => {
+    setLogEntries([]);
+    setLogAdding(false);
+    setLogText('');
+    setLogDate('');
+    window.sourcerer.listContactLog(contact.id).then(setLogEntries);
   }, [contact.id]);
 
   async function checkEmailBlur(value: string) {
@@ -279,6 +296,23 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
   async function handleRemoveRss(id: string) {
     await window.sourcerer.removeAlertRss(id);
     setAlertRssList((prev) => prev.filter((f) => f.id !== id));
+  }
+
+  async function handleLogSubmit() {
+    const body = logText.trim();
+    if (!body || !logDate) return;
+    setLogSubmitting(true);
+    try {
+      const [y, m, d] = logDate.split('-').map(Number);
+      const createdAt = Math.floor(new Date(y, m - 1, d, 12, 0, 0).getTime() / 1000);
+      const entry = await window.sourcerer.addGlobalLogEntry(contact.id, body, createdAt);
+      setLogEntries((prev) => [...prev, entry].sort((a, b) => a.created_at - b.created_at));
+      setLogText('');
+      setLogDate('');
+      setLogAdding(false);
+    } finally {
+      setLogSubmitting(false);
+    }
   }
 
   // View mode: group links by type
@@ -813,6 +847,77 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         onAddRss={handleAddRss}
         onRemoveRss={handleRemoveRss}
       />
+
+      <div className="pt-section">
+        <div className="pt-reminders-header">
+          <span className="pt-reminders-label">Interaction Log</span>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 12 }}>
+            {logEntries.length > 0 && (
+              <Button variant="ghost" onClick={() => setLogShowAll(true)}>
+                View all ({logEntries.length})
+              </Button>
+            )}
+            <Button variant="ghost" onClick={() => {
+              if (!logAdding) setLogDate(new Date().toISOString().slice(0, 10));
+              setLogAdding((v) => !v);
+            }}>
+              {logAdding ? '× Cancel' : '+ Add'}
+            </Button>
+          </div>
+        </div>
+
+        {logEntries.length === 0 && !logAdding && (
+          <p className="pt-reminders-empty">No entries yet.</p>
+        )}
+
+        {[...logEntries].reverse().slice(0, LOG_PREVIEW).map((e) => (
+          <LogRow key={e.id} entry={e} subtitle={e.project_name} />
+        ))}
+
+        {logAdding && (
+          <div className="pt-log-compose">
+            <div className="pt-log-date-row">
+              <label className="pt-log-date-label">Date</label>
+              <CalendarPicker
+                label="Select date"
+                value={logDate}
+                onChange={setLogDate}
+                showYear
+                maxDate={new Date().toISOString().slice(0, 10)}
+              />
+            </div>
+            <textarea
+              className="pt-log-input"
+              placeholder="Log an interaction…"
+              value={logText}
+              onChange={(e) => setLogText(e.target.value)}
+              rows={3}
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleLogSubmit();
+              }}
+            />
+            <div className="pt-reminder-form-actions">
+              <button
+                className="pt-log-submit"
+                onClick={handleLogSubmit}
+                disabled={!logText.trim() || !logDate || logSubmitting}
+              >
+                {logSubmitting ? 'Saving…' : 'Save'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {logShowAll && (
+          <LogAllModal
+            title="Interaction Log"
+            entries={logEntries}
+            getSubtitle={(e) => (e as ContactLogEntry).project_name}
+            onClose={() => setLogShowAll(false)}
+          />
+        )}
+      </div>
 
       <div className="detail-section">
         <div className="detail-section-label">Projects</div>

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -912,7 +912,6 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
             />
             {contact.projects.length > 0 && (
               <div className="pt-log-projects">
-                <label className="pt-log-date-label">Projects</label>
                 <LogProjectPicker
                   projects={contact.projects}
                   selectedIds={logSelectedMembershipIds}

--- a/src/renderer/src/contacts/LogProjectPicker.css
+++ b/src/renderer/src/contacts/LogProjectPicker.css
@@ -1,0 +1,88 @@
+.lpp-root {
+  position: relative;
+  flex: 1;
+}
+
+.lpp-field {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+  min-height: 28px;
+  padding: 3px 6px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  cursor: text;
+}
+
+.lpp-field:focus-within {
+  border-color: var(--color-primary);
+}
+
+.lpp-tag {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  background: var(--color-surface-2);
+  padding: 1px 4px 1px 6px;
+}
+
+.lpp-tag-remove {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 13px;
+  line-height: 1;
+  color: var(--color-text-dim);
+  cursor: pointer;
+}
+
+.lpp-tag-remove:hover {
+  color: var(--color-text);
+}
+
+.lpp-input {
+  flex: 1;
+  min-width: 80px;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: var(--font-serif);
+  font-size: 13px;
+  color: var(--color-text);
+  padding: 0;
+}
+
+.lpp-input::placeholder {
+  color: var(--color-text-dim);
+}
+
+.lpp-dropdown {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 100;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.lpp-option {
+  padding: 7px 10px;
+  font-family: var(--font-serif);
+  font-size: 13px;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.lpp-option:hover {
+  background: var(--color-surface);
+}

--- a/src/renderer/src/contacts/LogProjectPicker.tsx
+++ b/src/renderer/src/contacts/LogProjectPicker.tsx
@@ -7,9 +7,10 @@ interface Props {
   projects: ContactProject[];
   selectedIds: string[];
   onChange: (ids: string[]) => void;
+  lockedIds?: string[];
 }
 
-export default function LogProjectPicker({ projects, selectedIds, onChange }: Props) {
+export default function LogProjectPicker({ projects, selectedIds, onChange, lockedIds = [] }: Props) {
   const [query, setQuery] = useState('');
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -37,11 +38,13 @@ export default function LogProjectPicker({ projects, selectedIds, onChange }: Pr
         {selected.map((p) => (
           <span key={p.membership_id} className="lpp-tag">
             {p.name}
-            <button
-              type="button"
-              className="lpp-tag-remove"
-              onMouseDown={(e) => { e.stopPropagation(); remove(p.membership_id); }}
-            >×</button>
+            {!lockedIds.includes(p.membership_id) && (
+              <button
+                type="button"
+                className="lpp-tag-remove"
+                onMouseDown={(e) => { e.stopPropagation(); remove(p.membership_id); }}
+              >×</button>
+            )}
           </span>
         ))}
         <input

--- a/src/renderer/src/contacts/LogProjectPicker.tsx
+++ b/src/renderer/src/contacts/LogProjectPicker.tsx
@@ -1,0 +1,70 @@
+import { useRef, useState } from 'react';
+import type { ContactProject } from '@shared/types';
+import { useClickOutside } from '../hooks/useClickOutside';
+import './LogProjectPicker.css';
+
+interface Props {
+  projects: ContactProject[];
+  selectedIds: string[];
+  onChange: (ids: string[]) => void;
+}
+
+export default function LogProjectPicker({ projects, selectedIds, onChange }: Props) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useClickOutside(containerRef, () => { setOpen(false); setQuery(''); }, { isOpen: open, escapeKey: false });
+
+  const selected = projects.filter((p) => selectedIds.includes(p.membership_id));
+  const available = projects.filter(
+    (p) => !selectedIds.includes(p.membership_id) &&
+      p.name.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  function add(mid: string) {
+    onChange([...selectedIds, mid]);
+    setQuery('');
+  }
+
+  function remove(mid: string) {
+    onChange(selectedIds.filter((id) => id !== mid));
+  }
+
+  return (
+    <div className="lpp-root" ref={containerRef}>
+      <div className="lpp-field" onClick={() => setOpen(true)}>
+        {selected.map((p) => (
+          <span key={p.membership_id} className="lpp-tag">
+            {p.name}
+            <button
+              type="button"
+              className="lpp-tag-remove"
+              onMouseDown={(e) => { e.stopPropagation(); remove(p.membership_id); }}
+            >×</button>
+          </span>
+        ))}
+        <input
+          className="lpp-input"
+          placeholder={selected.length === 0 ? 'Add projects…' : ''}
+          value={query}
+          onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
+          onFocus={() => setOpen(true)}
+        />
+      </div>
+      {open && available.length > 0 && (
+        <div className="lpp-dropdown">
+          {available.map((p) => (
+            <div
+              key={p.membership_id}
+              className="lpp-option"
+              onMouseDown={(e) => { e.preventDefault(); add(p.membership_id); }}
+            >
+              {p.name}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -197,6 +197,7 @@ function LogSection({
               projects={allProjects}
               selectedIds={selectedMembershipIds}
               onChange={setSelectedMembershipIds}
+              lockedIds={[membership.membership_id]}
             />
           </div>
           <div className="pt-reminder-form-actions">

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -3,7 +3,7 @@ import { fmtDateFull } from '../utils/fmtDate';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { CalendarPicker } from '../views/CalendarPicker';
 import Button from '../shell/Button';
-import { fmtLogDate, LogRow, LogAllModal } from './logShared';
+import { LogRow, LogAllModal } from './logShared';
 import LogProjectPicker from './LogProjectPicker';
 import './ContactDetail.css';
 import type {

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -69,6 +69,12 @@ function LogSection({
     window.sourcerer.listInteractionLog(membership.membership_id).then(setEntries);
   }, [membership.membership_id]);
 
+  async function handleDelete(id: string) {
+    await window.sourcerer.deleteInteractionLogEntry(id);
+    setEntries((prev) => prev.filter((e) => e.id !== id));
+    onEntryAdded?.();
+  }
+
   async function handleSubmit() {
     const body = text.trim();
     if (!body || !logDate) return;
@@ -135,7 +141,7 @@ function LogSection({
         <p className="pt-reminders-empty">No entries yet.</p>
       )}
 
-      {preview.map((e) => <LogRow key={e.id} entry={e} />)}
+      {preview.map((e) => <LogRow key={e.id} entry={e} onDelete={handleDelete} />)}
 
       {showStatusPrompt && (
         <div className="pt-status-prompt">
@@ -206,7 +212,7 @@ function LogSection({
         </div>
       )}
 
-      {showAll && <LogAllModal title="Interaction Log" entries={entries} onClose={() => setShowAll(false)} />}
+      {showAll && <LogAllModal title="Interaction Log" entries={entries} onDelete={handleDelete} onClose={() => setShowAll(false)} />}
     </div>
   );
 }

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { fmtDateFull } from '../utils/fmtDate';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { CalendarPicker } from '../views/CalendarPicker';
 import Button from '../shell/Button';
+import { fmtLogDate, LogRow, LogAllModal } from './logShared';
 import './ContactDetail.css';
 import type {
   ContactDetail as ContactDetailType,
@@ -24,90 +24,6 @@ interface Props {
 }
 
 
-function fmtLogDate(ts: number): string {
-  const now = Math.floor(Date.now() / 1000);
-  const diff = now - ts;
-  if (diff < 86400) return 'today';
-  if (diff < 2 * 86400) return 'yesterday';
-  if (diff < 7 * 86400) return `${Math.floor(diff / 86400)} days ago`;
-  const d = new Date(ts * 1000);
-  const mm = String(d.getMonth() + 1).padStart(2, '0');
-  const dd = String(d.getDate()).padStart(2, '0');
-  const thisYear = new Date().getFullYear();
-  if (d.getFullYear() !== thisYear) return `${mm}.${dd}.${String(d.getFullYear()).slice(2)}`;
-  return `${mm}.${dd}`;
-}
-
-function LogRow({ entry }: { entry: InteractionLogEntry }) {
-  return (
-    <div className="pt-log-row">
-      <div className="pt-log-row-date">{fmtLogDate(entry.created_at)}</div>
-      <div className="pt-log-row-content">
-        <p className="pt-log-row-body">{entry.body}</p>
-        <span className="pt-log-row-reporter">{entry.reporter_name}</span>
-      </div>
-    </div>
-  );
-}
-
-function LogAllModal({ entries, onClose }: { entries: InteractionLogEntry[]; onClose: () => void }) {
-  const [query, setQuery] = useState('');
-
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') {
-        e.preventDefault(); // prevent ContactDetail's window handler from also closing the drawer
-        onClose();
-      }
-    }
-    document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-  }, [onClose]);
-
-  const reversed = [...entries].reverse();
-  const visible = query
-    ? reversed.filter((e) => e.body.toLowerCase().includes(query.toLowerCase()))
-    : reversed;
-
-  return createPortal(
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="pt-log-modal-card" onClick={(e) => e.stopPropagation()}>
-        <div className="pt-log-modal-header">
-          <span className="pt-reminders-label">Interaction Log</span>
-          <button className="detail-close" onClick={onClose}>×</button>
-        </div>
-        {entries.length > 0 && (
-          <div className="pt-log-modal-search">
-            <input
-              className="pt-log-search-input"
-              type="text"
-              placeholder="Search entries…"
-              aria-label="Search log entries"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              autoFocus
-            />
-            {query && (
-              <button className="pt-log-search-clear" aria-label="Clear search" onClick={() => setQuery('')}>×</button>
-            )}
-          </div>
-        )}
-        <div className="pt-log-modal-body">
-          {visible.length === 0
-            ? <p className="pt-reminders-empty">{query ? 'No entries match.' : 'No entries yet.'}</p>
-            : visible.map((e) => <LogRow key={e.id} entry={e} />)
-          }
-        </div>
-        {query && entries.length > 0 && (
-          <div className="pt-log-modal-footer">
-            {visible.length} of {entries.length} {entries.length === 1 ? 'entry' : 'entries'}
-          </div>
-        )}
-      </div>
-    </div>,
-    document.body,
-  );
-}
 
 const LOG_PREVIEW = 3;
 
@@ -276,7 +192,7 @@ function LogSection({
         </div>
       )}
 
-      {showAll && <LogAllModal entries={entries} onClose={() => setShowAll(false)} />}
+      {showAll && <LogAllModal title="Interaction Log" entries={entries} onClose={() => setShowAll(false)} />}
     </div>
   );
 }

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -192,15 +192,13 @@ function LogSection({
               if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleSubmit();
             }}
           />
-          {allProjects.length > 1 && (
-            <div className="pt-log-projects">
-              <LogProjectPicker
-                projects={allProjects}
-                selectedIds={selectedMembershipIds}
-                onChange={setSelectedMembershipIds}
-              />
-            </div>
-          )}
+          <div className="pt-log-projects">
+            <LogProjectPicker
+              projects={allProjects}
+              selectedIds={selectedMembershipIds}
+              onChange={setSelectedMembershipIds}
+            />
+          </div>
           <div className="pt-reminder-form-actions">
             <button className="pt-log-submit" onClick={handleSubmit} disabled={!text.trim() || !logDate || submitting}>
               {submitting ? 'Saving…' : 'Log'}

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -4,6 +4,7 @@ import { useClickOutside } from '../hooks/useClickOutside';
 import { CalendarPicker } from '../views/CalendarPicker';
 import Button from '../shell/Button';
 import { fmtLogDate, LogRow, LogAllModal } from './logShared';
+import LogProjectPicker from './LogProjectPicker';
 import './ContactDetail.css';
 import type {
   ContactDetail as ContactDetailType,
@@ -34,12 +35,14 @@ const TRIGGER_STATUSES = ['Not yet contacted', 'Contacted, no reply'];
 
 function LogSection({
   membership,
+  allProjects,
   membershipStatus,
   statusOptions,
   onStatusChange,
   onEntryAdded,
 }: {
   membership: ContactProject;
+  allProjects: ContactProject[];
   membershipStatus: string;
   statusOptions: StatusOption[];
   onStatusChange: (value: string) => Promise<void>;
@@ -50,6 +53,7 @@ function LogSection({
   const [logDate, setLogDate] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [adding, setAdding] = useState(false);
+  const [selectedMembershipIds, setSelectedMembershipIds] = useState<string[]>([]);
   const [showAll, setShowAll] = useState(false);
   const [showStatusPrompt, setShowStatusPrompt] = useState(false);
   const [promptStatus, setPromptStatus] = useState('');
@@ -61,6 +65,7 @@ function LogSection({
     setLogDate('');
     setAdding(false);
     setShowStatusPrompt(false);
+    setSelectedMembershipIds([membership.membership_id]);
     window.sourcerer.listInteractionLog(membership.membership_id).then(setEntries);
   }, [membership.membership_id]);
 
@@ -71,10 +76,12 @@ function LogSection({
     try {
       const [y, m, d] = logDate.split('-').map(Number);
       const createdAt = Math.floor(new Date(y, m - 1, d, 12, 0, 0).getTime() / 1000);
-      const entry = await window.sourcerer.addInteractionLogEntry(membership.membership_id, body, createdAt);
+      const extras = selectedMembershipIds.filter((id) => id !== membership.membership_id);
+      const entry = await window.sourcerer.addInteractionLogEntry(membership.membership_id, body, createdAt, extras);
       setEntries((prev) => [...prev, entry].sort((a, b) => a.created_at - b.created_at));
       setText('');
       setLogDate('');
+      setSelectedMembershipIds([membership.membership_id]);
       setAdding(false);
       onEntryAdded?.();
       if (TRIGGER_STATUSES.includes(membershipStatus)) {
@@ -116,12 +123,11 @@ function LogSection({
               View all ({entries.length})
             </Button>
           )}
-          <Button variant="ghost" onClick={() => {
-            if (!adding) setLogDate(today);
-            setAdding((v) => !v);
-          }}>
-            {adding ? '× Cancel' : '+ Add'}
-          </Button>
+          {!adding && (
+            <Button variant="ghost" onClick={() => { setLogDate(today); setAdding(true); }}>
+              + Add
+            </Button>
+          )}
         </div>
       </div>
 
@@ -159,9 +165,8 @@ function LogSection({
       )}
 
       {adding && (
-        <div className="pt-log-compose">
+        <div className="pt-log-compose pt-log-compose--global">
           <div className="pt-log-date-row">
-            <label className="pt-log-date-label">Date</label>
             <CalendarPicker
               label="Select date"
               value={logDate}
@@ -181,11 +186,20 @@ function LogSection({
               if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleSubmit();
             }}
           />
+          {allProjects.length > 1 && (
+            <div className="pt-log-projects">
+              <LogProjectPicker
+                projects={allProjects}
+                selectedIds={selectedMembershipIds}
+                onChange={setSelectedMembershipIds}
+              />
+            </div>
+          )}
           <div className="pt-reminder-form-actions">
             <button className="pt-log-submit" onClick={handleSubmit} disabled={!text.trim() || !logDate || submitting}>
               {submitting ? 'Saving…' : 'Log'}
             </button>
-            <button className="pt-reminder-cancel" onClick={() => { setAdding(false); setText(''); setLogDate(''); }}>
+            <button className="pt-reminder-cancel" onClick={() => { setAdding(false); setText(''); setLogDate(''); setSelectedMembershipIds([membership.membership_id]); }}>
               Cancel
             </button>
           </div>
@@ -836,6 +850,7 @@ export default function ProjectTab({ contact, statusOptions, priorityOptions, on
       />
       <LogSection
         membership={membership}
+        allProjects={contact.projects}
         membershipStatus={localStatus}
         statusOptions={statusOptions}
         onStatusChange={handleStatusChange}

--- a/src/renderer/src/contacts/logShared.tsx
+++ b/src/renderer/src/contacts/logShared.tsx
@@ -23,10 +23,10 @@ export function LogRow({ entry, subtitle }: { entry: InteractionLogEntry; subtit
       <div className="pt-log-row-date">{fmtLogDate(entry.created_at)}</div>
       <div className="pt-log-row-content">
         <p className="pt-log-row-body">{entry.body}</p>
-        <span className="pt-log-row-reporter">
-          {entry.reporter_name}
-          {subtitle && <span className="pt-log-row-subtitle"> · {subtitle}</span>}
-        </span>
+        <div className="pt-log-row-footer">
+          <span className="pt-log-row-reporter">{entry.reporter_name}</span>
+          {subtitle && <span className="pt-log-row-project-badge">{subtitle}</span>}
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/src/contacts/logShared.tsx
+++ b/src/renderer/src/contacts/logShared.tsx
@@ -18,6 +18,8 @@ export function fmtLogDate(ts: number): string {
 }
 
 export function LogRow({ entry, subtitle, onDelete }: { entry: InteractionLogEntry; subtitle?: string | null; onDelete?: (id: string) => void }) {
+  const [confirming, setConfirming] = useState(false);
+
   return (
     <div className="pt-log-row">
       <div className="pt-log-row-date">{fmtLogDate(entry.created_at)}</div>
@@ -26,11 +28,20 @@ export function LogRow({ entry, subtitle, onDelete }: { entry: InteractionLogEnt
         <div className="pt-log-row-footer">
           <span className="pt-log-row-reporter">{entry.reporter_name}</span>
           {subtitle && <span className="pt-log-row-project-badge">{subtitle}</span>}
-          {onDelete && (
-            <button className="pt-log-row-delete" onClick={() => onDelete(entry.id)} title="Delete entry">×</button>
-          )}
         </div>
       </div>
+      {onDelete && (
+        <div className="pt-log-row-actions">
+          {confirming ? (
+            <>
+              <button className="pt-log-row-confirm-yes" onClick={() => onDelete(entry.id)}>Delete</button>
+              <button className="pt-log-row-confirm-no" onClick={() => setConfirming(false)}>Cancel</button>
+            </>
+          ) : (
+            <button className="pt-log-row-delete" onClick={() => setConfirming(true)} title="Delete entry">×</button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/renderer/src/contacts/logShared.tsx
+++ b/src/renderer/src/contacts/logShared.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import type { InteractionLogEntry } from '@shared/types';
+import './ContactDetail.css';
+
+export function fmtLogDate(ts: number): string {
+  const now = Math.floor(Date.now() / 1000);
+  const diff = now - ts;
+  if (diff < 86400) return 'today';
+  if (diff < 2 * 86400) return 'yesterday';
+  if (diff < 7 * 86400) return `${Math.floor(diff / 86400)} days ago`;
+  const d = new Date(ts * 1000);
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  const thisYear = new Date().getFullYear();
+  if (d.getFullYear() !== thisYear) return `${mm}.${dd}.${String(d.getFullYear()).slice(2)}`;
+  return `${mm}.${dd}`;
+}
+
+export function LogRow({ entry, subtitle }: { entry: InteractionLogEntry; subtitle?: string | null }) {
+  return (
+    <div className="pt-log-row">
+      <div className="pt-log-row-date">{fmtLogDate(entry.created_at)}</div>
+      <div className="pt-log-row-content">
+        <p className="pt-log-row-body">{entry.body}</p>
+        <span className="pt-log-row-reporter">
+          {entry.reporter_name}
+          {subtitle && <span className="pt-log-row-subtitle"> · {subtitle}</span>}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function LogAllModal({
+  title,
+  entries,
+  getSubtitle,
+  onClose,
+}: {
+  title: string;
+  entries: InteractionLogEntry[];
+  getSubtitle?: (entry: InteractionLogEntry) => string | null | undefined;
+  onClose: () => void;
+}) {
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const reversed = [...entries].reverse();
+  const visible = query
+    ? reversed.filter((e) => e.body.toLowerCase().includes(query.toLowerCase()))
+    : reversed;
+
+  return createPortal(
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="pt-log-modal-card" onClick={(e) => e.stopPropagation()}>
+        <div className="pt-log-modal-header">
+          <span className="pt-reminders-label">{title}</span>
+          <button className="detail-close" onClick={onClose}>×</button>
+        </div>
+        {entries.length > 0 && (
+          <div className="pt-log-modal-search">
+            <input
+              className="pt-log-search-input"
+              type="text"
+              placeholder="Search entries…"
+              aria-label="Search log entries"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              autoFocus
+            />
+            {query && (
+              <button className="pt-log-search-clear" aria-label="Clear search" onClick={() => setQuery('')}>×</button>
+            )}
+          </div>
+        )}
+        <div className="pt-log-modal-body">
+          {visible.length === 0
+            ? <p className="pt-reminders-empty">{query ? 'No entries match.' : 'No entries yet.'}</p>
+            : visible.map((e) => <LogRow key={e.id} entry={e} subtitle={getSubtitle?.(e)} />)
+          }
+        </div>
+        {query && entries.length > 0 && (
+          <div className="pt-log-modal-footer">
+            {visible.length} of {entries.length} {entries.length === 1 ? 'entry' : 'entries'}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/renderer/src/contacts/logShared.tsx
+++ b/src/renderer/src/contacts/logShared.tsx
@@ -17,7 +17,7 @@ export function fmtLogDate(ts: number): string {
   return `${mm}.${dd}`;
 }
 
-export function LogRow({ entry, subtitle }: { entry: InteractionLogEntry; subtitle?: string | null }) {
+export function LogRow({ entry, subtitle, onDelete }: { entry: InteractionLogEntry; subtitle?: string | null; onDelete?: (id: string) => void }) {
   return (
     <div className="pt-log-row">
       <div className="pt-log-row-date">{fmtLogDate(entry.created_at)}</div>
@@ -26,6 +26,9 @@ export function LogRow({ entry, subtitle }: { entry: InteractionLogEntry; subtit
         <div className="pt-log-row-footer">
           <span className="pt-log-row-reporter">{entry.reporter_name}</span>
           {subtitle && <span className="pt-log-row-project-badge">{subtitle}</span>}
+          {onDelete && (
+            <button className="pt-log-row-delete" onClick={() => onDelete(entry.id)} title="Delete entry">×</button>
+          )}
         </div>
       </div>
     </div>
@@ -36,11 +39,13 @@ export function LogAllModal({
   title,
   entries,
   getSubtitle,
+  onDelete,
   onClose,
 }: {
   title: string;
   entries: InteractionLogEntry[];
   getSubtitle?: (entry: InteractionLogEntry) => string | null | undefined;
+  onDelete?: (id: string) => void;
   onClose: () => void;
 }) {
   const [query, setQuery] = useState('');
@@ -87,7 +92,7 @@ export function LogAllModal({
         <div className="pt-log-modal-body">
           {visible.length === 0
             ? <p className="pt-reminders-empty">{query ? 'No entries match.' : 'No entries yet.'}</p>
-            : visible.map((e) => <LogRow key={e.id} entry={e} subtitle={getSubtitle?.(e)} />)
+            : visible.map((e) => <LogRow key={e.id} entry={e} subtitle={getSubtitle?.(e)} onDelete={onDelete} />)
           }
         </div>
         {query && entries.length > 0 && (

--- a/src/renderer/src/contacts/logShared.tsx
+++ b/src/renderer/src/contacts/logShared.tsx
@@ -38,7 +38,7 @@ export function LogRow({ entry, subtitle, onDelete }: { entry: InteractionLogEnt
               <button className="pt-log-row-confirm-no" onClick={() => setConfirming(false)}>Cancel</button>
             </>
           ) : (
-            <button className="pt-log-row-delete" onClick={() => setConfirming(true)} title="Delete entry">×</button>
+            <button className="pt-log-row-delete" onClick={() => setConfirming(true)} title="Delete entry" aria-label="Delete entry">×</button>
           )}
         </div>
       )}

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -10,6 +10,7 @@ import type {
   UpdateMembershipInput,
   ProjectContactRow,
   InteractionLogEntry,
+  ContactLogEntry,
   ScratchpadDraft,
   StatusOption,
   PriorityOption,
@@ -98,6 +99,8 @@ declare global {
       // Interaction log
       listInteractionLog: (membershipId: string) => Promise<InteractionLogEntry[]>;
       addInteractionLogEntry: (membershipId: string, body: string, createdAt?: number) => Promise<InteractionLogEntry>;
+      listContactLog: (contactId: string) => Promise<ContactLogEntry[]>;
+      addGlobalLogEntry: (contactId: string, body: string, createdAt?: number) => Promise<ContactLogEntry>;
       getContactCount: () => Promise<number>;
       getContactInteractionCount: (contactId: string) => Promise<number>;
       validatePhone: (raw: string) => Promise<boolean>;

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -100,6 +100,7 @@ declare global {
       listInteractionLog: (membershipId: string) => Promise<InteractionLogEntry[]>;
       addInteractionLogEntry: (membershipId: string, body: string, createdAt?: number, extraMembershipIds?: string[]) => Promise<InteractionLogEntry>;
       listContactLog: (contactId: string) => Promise<ContactLogEntry[]>;
+      deleteInteractionLogEntry: (interactionId: string) => Promise<void>;
       addGlobalLogEntry: (contactId: string, body: string, createdAt?: number, membershipIds?: string[]) => Promise<ContactLogEntry>;
       getContactCount: () => Promise<number>;
       getContactInteractionCount: (contactId: string) => Promise<number>;

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -98,7 +98,7 @@ declare global {
 
       // Interaction log
       listInteractionLog: (membershipId: string) => Promise<InteractionLogEntry[]>;
-      addInteractionLogEntry: (membershipId: string, body: string, createdAt?: number) => Promise<InteractionLogEntry>;
+      addInteractionLogEntry: (membershipId: string, body: string, createdAt?: number, extraMembershipIds?: string[]) => Promise<InteractionLogEntry>;
       listContactLog: (contactId: string) => Promise<ContactLogEntry[]>;
       addGlobalLogEntry: (contactId: string, body: string, createdAt?: number, membershipIds?: string[]) => Promise<ContactLogEntry>;
       getContactCount: () => Promise<number>;

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -100,7 +100,7 @@ declare global {
       listInteractionLog: (membershipId: string) => Promise<InteractionLogEntry[]>;
       addInteractionLogEntry: (membershipId: string, body: string, createdAt?: number) => Promise<InteractionLogEntry>;
       listContactLog: (contactId: string) => Promise<ContactLogEntry[]>;
-      addGlobalLogEntry: (contactId: string, body: string, createdAt?: number) => Promise<ContactLogEntry>;
+      addGlobalLogEntry: (contactId: string, body: string, createdAt?: number, membershipIds?: string[]) => Promise<ContactLogEntry>;
       getContactCount: () => Promise<number>;
       getContactInteractionCount: (contactId: string) => Promise<number>;
       validatePhone: (raw: string) => Promise<boolean>;

--- a/src/renderer/src/views/ProjectTimeline.css
+++ b/src/renderer/src/views/ProjectTimeline.css
@@ -417,8 +417,16 @@
   font-size: 11px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--color-text-muted);
-  background: var(--color-border);
   border-radius: 3px;
   padding: 1px 5px;
+}
+
+.ptl-project-badge {
+  color: var(--color-text-muted);
+  background: var(--color-border);
+}
+
+.ptl-priority-badge {
+  color: var(--color-primary);
+  background: rgba(200, 122, 26, 0.1);
 }

--- a/src/renderer/src/views/ProjectTimeline.css
+++ b/src/renderer/src/views/ProjectTimeline.css
@@ -333,10 +333,16 @@
 
 .ptl-entry-meta {
   display: flex;
-  align-items: baseline;
+  align-items: flex-start;
   gap: 8px;
   margin-bottom: 6px;
   flex-wrap: wrap;
+}
+
+.ptl-contact-header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .ptl-contact-name {

--- a/src/renderer/src/views/ProjectTimeline.css
+++ b/src/renderer/src/views/ProjectTimeline.css
@@ -332,17 +332,20 @@
 }
 
 .ptl-entry-meta {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
   margin-bottom: 6px;
-  flex-wrap: wrap;
 }
 
 .ptl-contact-header {
   display: flex;
   flex-direction: column;
   gap: 2px;
+}
+
+.ptl-contact-name-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .ptl-contact-name {

--- a/src/renderer/src/views/ProjectTimeline.tsx
+++ b/src/renderer/src/views/ProjectTimeline.tsx
@@ -79,12 +79,12 @@ function TimelinePrintSheet({
                   {entry.contact_organization && (
                     <span className="ptl-ps-badge">{entry.contact_organization}</span>
                   )}
-                  {isGlobal && entry.project_name && (
-                    <span className="ptl-ps-badge">{entry.project_name}</span>
-                  )}
-                  {entry.priority && (
-                    <span className="ptl-ps-badge">{entry.priority}</span>
-                  )}
+                  {isGlobal && entry.projects.map((p) => (
+                    <span key={p.project_id} className="ptl-ps-badge">{p.project_name}</span>
+                  ))}
+                  {entry.projects.map((p) => p.priority).filter(Boolean).slice(0, 1).map((priority) => (
+                    <span key={priority} className="ptl-ps-badge">{priority}</span>
+                  ))}
                 </div>
                 <p className="ptl-ps-body-text">{entry.body}</p>
                 <div className="ptl-ps-footer">
@@ -234,20 +234,20 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
     [entries],
   );
   const projectOptions = useMemo(
-    () => [...new Set(entries.map((e) => e.project_name).filter(Boolean) as string[])].sort(),
+    () => [...new Set(entries.flatMap((e) => e.projects.map((p) => p.project_name)))].sort(),
     [entries],
   );
   const priorityOptions = useMemo(
-    () => [...new Set(entries.map((e) => e.priority).filter(Boolean) as string[])].sort(),
+    () => [...new Set(entries.flatMap((e) => e.projects.map((p) => p.priority).filter(Boolean) as string[]))].sort(),
     [entries],
   );
 
   const filtered = useMemo(() => {
     return entries.filter((e) => {
       if (selectedReporters.length > 0 && !selectedReporters.includes(e.reporter_name)) return false;
-      if (selectedProjects.length > 0 && (!e.project_name || !selectedProjects.includes(e.project_name))) return false;
-      if (selectedPriorities.length > 0 && (!e.priority || !selectedPriorities.includes(e.priority))) return false;
-      if (themeFilter && !(e.theme ?? '').toLowerCase().includes(themeFilter.toLowerCase())) return false;
+      if (selectedProjects.length > 0 && !e.projects.some((p) => selectedProjects.includes(p.project_name))) return false;
+      if (selectedPriorities.length > 0 && !e.projects.some((p) => p.priority && selectedPriorities.includes(p.priority))) return false;
+      if (themeFilter && !e.projects.some((p) => (p.theme ?? '').toLowerCase().includes(themeFilter.toLowerCase()))) return false;
       if (orgFilter && !(e.contact_organization ?? '').toLowerCase().includes(orgFilter.toLowerCase())) return false;
       if (notesFilter && !e.body.toLowerCase().includes(notesFilter.toLowerCase())) return false;
       if (dateFrom) {
@@ -504,12 +504,12 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
                       {entry.contact_organization && (
                         <span className="ptl-contact-org">{entry.contact_organization}</span>
                       )}
-                      {isGlobal && entry.project_name && (
-                        <span className="ptl-project-badge">{entry.project_name}</span>
-                      )}
-                      {entry.priority && (
-                        <span className="ptl-priority-badge">{entry.priority}</span>
-                      )}
+                      {isGlobal && entry.projects.map((p) => (
+                        <span key={p.project_id} className="ptl-project-badge">{p.project_name}</span>
+                      ))}
+                      {entry.projects.map((p) => p.priority).filter(Boolean).slice(0, 1).map((priority) => (
+                        <span key={priority} className="ptl-priority-badge">{priority}</span>
+                      ))}
                     </div>
                     <p className="ptl-entry-body">{entry.body}</p>
                     <div className="ptl-entry-footer">

--- a/src/renderer/src/views/ProjectTimeline.tsx
+++ b/src/renderer/src/views/ProjectTimeline.tsx
@@ -495,15 +495,17 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
                 {group.entries.map((entry) => (
                   <div key={entry.id} className="ptl-entry">
                     <div className="ptl-entry-meta">
-                      <button
-                        className="ptl-contact-name"
-                        onClick={() => onSelectContact(entry.contact_id)}
-                      >
-                        {entry.contact_name}
-                      </button>
-                      {entry.contact_organization && (
-                        <span className="ptl-contact-org">{entry.contact_organization}</span>
-                      )}
+                      <div className="ptl-contact-header">
+                        <button
+                          className="ptl-contact-name"
+                          onClick={() => onSelectContact(entry.contact_id)}
+                        >
+                          {entry.contact_name}
+                        </button>
+                        {entry.contact_organization && (
+                          <span className="ptl-contact-org">{entry.contact_organization}</span>
+                        )}
+                      </div>
                       {isGlobal && entry.projects.map((p) => (
                         <span key={p.project_id} className="ptl-project-badge">{p.project_name}</span>
                       ))}

--- a/src/renderer/src/views/ProjectTimeline.tsx
+++ b/src/renderer/src/views/ProjectTimeline.tsx
@@ -496,22 +496,24 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
                   <div key={entry.id} className="ptl-entry">
                     <div className="ptl-entry-meta">
                       <div className="ptl-contact-header">
-                        <button
-                          className="ptl-contact-name"
-                          onClick={() => onSelectContact(entry.contact_id)}
-                        >
-                          {entry.contact_name}
-                        </button>
+                        <div className="ptl-contact-name-row">
+                          <button
+                            className="ptl-contact-name"
+                            onClick={() => onSelectContact(entry.contact_id)}
+                          >
+                            {entry.contact_name}
+                          </button>
+                          {isGlobal && entry.projects.map((p) => (
+                            <span key={p.project_id} className="ptl-project-badge">{p.project_name}</span>
+                          ))}
+                          {entry.projects.map((p) => p.priority).filter(Boolean).slice(0, 1).map((priority) => (
+                            <span key={priority} className="ptl-priority-badge">{priority}</span>
+                          ))}
+                        </div>
                         {entry.contact_organization && (
                           <span className="ptl-contact-org">{entry.contact_organization}</span>
                         )}
                       </div>
-                      {isGlobal && entry.projects.map((p) => (
-                        <span key={p.project_id} className="ptl-project-badge">{p.project_name}</span>
-                      ))}
-                      {entry.projects.map((p) => p.priority).filter(Boolean).slice(0, 1).map((priority) => (
-                        <span key={priority} className="ptl-priority-badge">{priority}</span>
-                      ))}
                     </div>
                     <p className="ptl-entry-body">{entry.body}</p>
                     <div className="ptl-entry-footer">

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -184,11 +184,19 @@ export interface UpdateMembershipInput {
 
 export interface InteractionLogEntry {
   id: string;
-  membership_id: string;
+  contact_id: string;
   reporter_name: string;
   reporter_email: string;
   body: string;
   created_at: number;
+}
+
+export interface TimelineEntryProject {
+  project_id: string;
+  project_name: string;
+  membership_id: string;
+  theme: string | null;
+  priority: string | null;
 }
 
 export interface TimelineEntry {
@@ -200,10 +208,7 @@ export interface TimelineEntry {
   contact_id: string;
   contact_name: string;
   contact_organization: string | null;
-  project_id: string | null;
-  project_name: string | null;
-  theme: string | null;
-  priority: string | null;
+  projects: TimelineEntryProject[];
 }
 
 export interface ScratchpadDraft {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -191,6 +191,10 @@ export interface InteractionLogEntry {
   created_at: number;
 }
 
+export interface ContactLogEntry extends InteractionLogEntry {
+  project_name: string | null;
+}
+
 export interface TimelineEntryProject {
   project_id: string;
   project_name: string;

--- a/src/test/outreach-checker.test.ts
+++ b/src/test/outreach-checker.test.ts
@@ -94,11 +94,14 @@ function insertMembership(
 }
 
 function insertInteractionLog(membId: string, createdAt: number): void {
+  const entryId = uuidv4();
+  const { contact_id } = testDb.prepare('SELECT contact_id FROM project_memberships WHERE id = ?').get(membId) as { contact_id: string };
   testDb.prepare(
     `INSERT INTO interaction_log_entries
-       (id, membership_id, reporter_email, reporter_name, body, created_at)
+       (id, contact_id, reporter_email, reporter_name, body, created_at)
      VALUES (?, ?, ?, ?, 'note', ?)`,
-  ).run(uuidv4(), membId, TEST_REPORTER.email, TEST_REPORTER.name, createdAt);
+  ).run(entryId, contact_id, TEST_REPORTER.email, TEST_REPORTER.name, createdAt);
+  testDb.prepare('INSERT INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)').run(entryId, membId);
 }
 
 beforeEach(() => {

--- a/src/test/search.test.ts
+++ b/src/test/search.test.ts
@@ -23,11 +23,13 @@ function insertMembership(contactId: string, projId: string): string {
 function insertLogEntry(membershipId: string, body: string): string {
   const id = uuidv4();
   const now = Math.floor(Date.now() / 1000);
+  const membership = testDb.prepare('SELECT contact_id FROM project_memberships WHERE id = ?').get(membershipId) as { contact_id: string };
   testDb.prepare(
     `INSERT INTO interaction_log_entries
-       (id, membership_id, reporter_email, reporter_name, body, created_at)
+       (id, contact_id, reporter_email, reporter_name, body, created_at)
      VALUES (?, ?, ?, ?, ?, ?)`,
-  ).run(id, membershipId, TEST_REPORTER.email, TEST_REPORTER.name, body, now);
+  ).run(id, membership.contact_id, TEST_REPORTER.email, TEST_REPORTER.name, body, now);
+  testDb.prepare('INSERT INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)').run(id, membershipId);
   return id;
 }
 

--- a/src/test/sync-engine.test.ts
+++ b/src/test/sync-engine.test.ts
@@ -221,11 +221,14 @@ describe('syncProject — membership conflict guard', () => {
     const localContactId = insertContact(localDb, 'Carol', { emails: ['carol@example.com'] });
     const localMembershipId = localInsertMembership(localDb, localContactId, projectId, { updatedAt: NOW - 100 });
 
-    // Local interaction log entry under the local membership
+    // Local interaction log entry associated with the local membership
     const logEntryId = uuidv4();
     localDb.prepare(
-      'INSERT INTO interaction_log_entries (id, membership_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)',
-    ).run(logEntryId, localMembershipId, 'r@r.com', 'Reporter', 'Called on Monday', NOW - 50);
+      'INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run(logEntryId, localContactId, 'r@r.com', 'Reporter', 'Called on Monday', NOW - 50);
+    localDb.prepare(
+      'INSERT INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)',
+    ).run(logEntryId, localMembershipId);
 
     // Shared DB: same contact (matched by email) under a different membership UUID
     const sharedContactId = uuidv4();
@@ -244,8 +247,10 @@ describe('syncProject — membership conflict guard', () => {
     expect(localDb.prepare('SELECT id FROM project_memberships WHERE id = ?').get(localMembershipId)).toBeUndefined();
     expect(localDb.prepare('SELECT id FROM project_memberships WHERE id = ?').get(sharedMembershipId)).toBeDefined();
 
-    // Interaction log entry re-attached to shared membership
-    const entry = localDb.prepare('SELECT membership_id FROM interaction_log_entries WHERE id = ?').get(logEntryId) as { membership_id: string } | undefined;
-    expect(entry?.membership_id).toBe(sharedMembershipId);
+    // Interaction log entry still exists (contact_id FK survives) and is re-linked to shared membership
+    const entry = localDb.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(logEntryId) as { id: string } | undefined;
+    expect(entry?.id).toBe(logEntryId);
+    const ip = localDb.prepare('SELECT membership_id FROM interaction_projects WHERE interaction_id = ?').get(logEntryId) as { membership_id: string } | undefined;
+    expect(ip?.membership_id).toBe(sharedMembershipId);
   });
 });


### PR DESCRIPTION
Closes #97.

## Summary

- **Schema**: \`interaction_log_entries\` now has a direct \`contact_id\` FK instead of \`membership_id\`. Project associations live in a new \`interaction_projects(interaction_id, membership_id)\` junction table.
- **Zero projects**: an interaction with no rows in \`interaction_projects\` is a contact-level note not tied to any project.
- **Multiple projects**: an interaction can be linked to several project memberships at once.
- **No migration**: schema fully replaced. Drop and re-create the database (dev only — delete \`sourcerer.db\` and \`sourcerer.salt\`, then relaunch to re-seed).

## What changed

- \`interaction_log_entries\`: \`membership_id\` → \`contact_id\`
- New \`interaction_projects\` junction table
- All IPC handlers updated: \`interaction-log:list\`, \`interaction-log:add\`, \`contacts:interaction-count\`, \`contacts:list\`, \`contacts:get\`, both timeline handlers
- Export, search (FTS), outreach checker, sync engine pull/push, and dedup merge all updated
- \`ProjectTimeline.tsx\`: \`TimelineEntry.projects\` is now an array; filters and badges updated accordingly
- All 244 tests pass

**Interaction log UI:**
- Log is now present in both the **Global tab** (all interactions across every project) and the **Project tab** (membership-scoped view)
- Each form includes a project multi-select (tag-input selectize) — Global tab defaults to empty, Project tab pre-selects the current project
- Log entries are deletable with inline confirmation; deleting clears outreach reminders for all associated projects
- Log entries show a project badge (mono uppercase) matching the style used in the timeline
- \`LogRow\`, \`LogAllModal\`, \`fmtLogDate\` extracted to \`logShared.tsx\` and shared between both tabs

**Timeline view tweaks:**
- Org now sits on its own line below the contact name
- Project and priority badges are flush with the contact name
- Priority badge is visually distinct (amber tint) from project badges (neutral grey)

**Export:**
- Project export: log entries now include project associations in the header — \`[date — reporter — Project A, Project B] body\`
- All Contacts export: new \`Interaction log\` column with the same format

## Test plan

- [x] Log an interaction from a contact's Project tab — still works as before
- [x] Log an interaction from the Global tab with zero, one, or multiple projects
- [x] Delete a log entry — confirmation appears; reminders recalculated
- [x] Timeline view: org on second line, badges flush with name, priority badge visually distinct
- [x] Export project contacts — interaction log column includes project names
- [x] Export all contacts — interaction log column present and populated
- [x] Search finds log entries
- [x] Outreach reminders still fire correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)