### PR TITLE
Add default project per contact

### DIFF
--- a/src/main/database/dev-seeds.ts
+++ b/src/main/database/dev-seeds.ts
@@ -121,6 +121,7 @@ export function seedDevData(db: Database.Database, email: string, name: string):
 
     // ── Membership helpers ────────────────────────────────────────────────────
     const membIds: Record<string, string> = {};
+    const firstMembByContact = new Map<string, string>();
 
     function addMembership(
       contactName: string,
@@ -130,6 +131,7 @@ export function seedDevData(db: Database.Database, email: string, name: string):
     ): string {
       const id = uuidv4();
       membIds[`${contactName}:${projectId}`] = id;
+      if (!firstMembByContact.has(contactName)) firstMembByContact.set(contactName, id);
       stmts.insertMembership.run(
         id,
         projectId,
@@ -505,6 +507,12 @@ export function seedDevData(db: Database.Database, email: string, name: string):
       'Check in — agency counsel may have issued guidance that affects what she can share.');
     addReminder('Theresa Ouellet-Gauvin', healthId, 10,
       'Complete cross-reference of falsified staffing records against her redacted report.');
+
+    // ── Default project per contact ───────────────────────────────────────────
+    const updateDefault = db.prepare('UPDATE contacts SET default_membership_id = ? WHERE id = ?');
+    for (const [contactName, membershipId] of firstMembByContact) {
+      updateDefault.run(membershipId, cid(contactName));
+    }
   });
 
   doSeed();

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -34,6 +34,7 @@ export const LOCAL_SCHEMA_SQL = `
     title        TEXT,
     dob          TEXT,
     notes        TEXT,
+    default_membership_id TEXT REFERENCES project_memberships(id) ON DELETE SET NULL,
     created_at   INTEGER NOT NULL,
     updated_at   INTEGER NOT NULL,
     synced_at    INTEGER

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -208,7 +208,7 @@ export function registerContactHandlers(): void {
   ipcMain.handle('contacts:get', (_, id: string): ContactDetail => {
     const db = getDatabase();
     const contact = db
-      .prepare('SELECT id, name, organization, title, dob, notes, created_at, updated_at FROM contacts WHERE id = ?')
+      .prepare('SELECT id, name, organization, title, dob, notes, default_membership_id, created_at, updated_at FROM contacts WHERE id = ?')
       .get(id) as {
       id: string;
       name: string;
@@ -216,6 +216,7 @@ export function registerContactHandlers(): void {
       title: string | null;
       dob: string | null;
       notes: string | null;
+      default_membership_id: string | null;
       created_at: number;
       updated_at: number;
     } | undefined;
@@ -265,7 +266,7 @@ export function registerContactHandlers(): void {
       reporters: allReporters.filter((r) => r.membership_id === p.membership_id),
     }));
 
-    return { ...contact, emails, phones, links, handles, projects: projectsWithReporters };
+    return { ...contact, emails, phones, links, handles, projects: projectsWithReporters } as ContactDetail;
   });
 
   ipcMain.handle('contacts:create', (_, data: CreateContactInput): ContactListItem => {
@@ -354,21 +355,16 @@ export function registerContactHandlers(): void {
       const defaultStatus = db
         .prepare('SELECT label FROM status_options ORDER BY sort_order LIMIT 1')
         .get() as { label: string } | undefined;
-
-      db.prepare(
+      const membershipId = uuidv4();
+      const now = Math.floor(Date.now() / 1000);
+      const result = db.prepare(
         `INSERT OR IGNORE INTO project_memberships
          (id, contact_id, project_id, reporter_email, reporter_name, status, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-      ).run(
-        uuidv4(),
-        contactId,
-        projectId,
-        user.email,
-        `${user.first_name} ${user.last_name}`,
-        defaultStatus?.label ?? null,
-        Math.floor(Date.now() / 1000),
-        Math.floor(Date.now() / 1000),
-      );
+      ).run(membershipId, contactId, projectId, user.email, `${user.first_name} ${user.last_name}`, defaultStatus?.label ?? null, now, now);
+      if (result.changes > 0) {
+        db.prepare('UPDATE contacts SET default_membership_id = ? WHERE id = ? AND default_membership_id IS NULL').run(membershipId, contactId);
+      }
       broadcastContactsChanged();
     },
   );
@@ -376,9 +372,31 @@ export function registerContactHandlers(): void {
   ipcMain.handle(
     'memberships:remove',
     (_, { contactId, projectId }: { contactId: string; projectId: string }): void => {
-      getDatabase()
-        .prepare('DELETE FROM project_memberships WHERE contact_id = ? AND project_id = ?')
-        .run(contactId, projectId);
+      const db = getDatabase();
+      const membership = db
+        .prepare('SELECT id FROM project_memberships WHERE contact_id = ? AND project_id = ?')
+        .get(contactId, projectId) as { id: string } | undefined;
+      db.prepare('DELETE FROM project_memberships WHERE contact_id = ? AND project_id = ?').run(contactId, projectId);
+      if (membership) {
+        db.prepare(
+          'UPDATE contacts SET default_membership_id = NULL WHERE id = ? AND default_membership_id = ?',
+        ).run(contactId, membership.id);
+      }
+      broadcastContactsChanged();
+    },
+  );
+
+  ipcMain.handle(
+    'contacts:set-default-project',
+    (_, { contactId, membershipId }: { contactId: string; membershipId: string | null }): void => {
+      const db = getDatabase();
+      if (membershipId !== null) {
+        const valid = db
+          .prepare('SELECT 1 FROM project_memberships WHERE id = ? AND contact_id = ?')
+          .get(membershipId, contactId);
+        if (!valid) return;
+      }
+      db.prepare('UPDATE contacts SET default_membership_id = ? WHERE id = ?').run(membershipId, contactId);
       broadcastContactsChanged();
     },
   );

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -148,6 +148,8 @@ const sourcererApi = {
     ipcRenderer.invoke('interaction-log:delete', interactionId),
   addGlobalLogEntry: (contactId: string, body: string, createdAt?: number, membershipIds?: string[]): Promise<ContactLogEntry> =>
     ipcRenderer.invoke('interaction-log:add-global', { contactId, body, createdAt, membershipIds }),
+  setContactDefaultProject: (contactId: string, membershipId: string | null): Promise<void> =>
+    ipcRenderer.invoke('contacts:set-default-project', { contactId, membershipId }),
   getContactCount: (): Promise<number> => ipcRenderer.invoke('contacts:count'),
   getContactInteractionCount: (contactId: string): Promise<number> =>
     ipcRenderer.invoke('contacts:interaction-count', contactId),

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -819,7 +819,6 @@
 .detail-project-default {
   flex-shrink: 0;
   font-size: 14px;
-  line-height: 1;
   color: var(--color-text-muted);
   opacity: 0;
   padding: 0 2px;

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -818,6 +818,9 @@
 
 .detail-project-default {
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   font-size: 14px;
   color: var(--color-text-muted);
   opacity: 0;

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -198,7 +198,7 @@
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--color-text-muted);
-  padding: 2px 6px;
+  padding: 0 6px;
   white-space: nowrap;
   flex-shrink: 0;
 }

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -816,41 +816,30 @@
   gap: 10px;
 }
 
-.pt-log-default-project {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 6px 0;
-  border-bottom: 1px solid var(--color-border);
-  margin-bottom: 2px;
-}
-
-.pt-log-default-label {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  color: var(--color-text-muted);
+.detail-project-default {
   flex-shrink: 0;
-}
-
-.pt-log-default-select {
-  font-family: var(--font-serif);
-  font-size: 13px;
-  color: var(--color-text);
-  background: transparent;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--color-text-muted);
+  opacity: 0;
+  padding: 0 2px;
   border: none;
-  border-bottom: 1px solid var(--color-border);
-  padding: 2px 4px;
+  background: none;
   cursor: pointer;
-  flex: 1;
-  min-width: 0;
+  transition: opacity 0.1s, color 0.1s;
 }
 
-.pt-log-default-select:focus {
-  outline: none;
-  border-bottom-color: var(--color-text-muted);
+.detail-project-item:hover .detail-project-default {
+  opacity: 1;
+}
+
+.detail-project-default--active {
+  opacity: 1 !important;
+  color: var(--color-amber);
+}
+
+.detail-project-default--active:hover {
+  color: var(--color-text-muted);
 }
 
 

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -184,6 +184,7 @@
 
 .detail-project-name {
   flex: 1;
+  align-self: center;
   font-size: 13px;
   color: var(--color-text);
   overflow: hidden;
@@ -201,6 +202,7 @@
   padding: 0 6px;
   white-space: nowrap;
   flex-shrink: 0;
+  align-self: center;
 }
 
 .detail-project-remove {

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -203,6 +203,7 @@
   white-space: nowrap;
   flex-shrink: 0;
   align-self: center;
+  margin-top: 1px;
 }
 
 .detail-project-remove {
@@ -831,6 +832,7 @@
   background: none;
   cursor: pointer;
   transition: opacity 0.1s, color 0.1s;
+  margin-top: -2px;
 }
 
 .detail-project-item:hover .detail-project-default {

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -816,6 +816,43 @@
   gap: 10px;
 }
 
+.pt-log-default-project {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 2px;
+}
+
+.pt-log-default-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.pt-log-default-select {
+  font-family: var(--font-serif);
+  font-size: 13px;
+  color: var(--color-text);
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--color-border);
+  padding: 2px 4px;
+  cursor: pointer;
+  flex: 1;
+  min-width: 0;
+}
+
+.pt-log-default-select:focus {
+  outline: none;
+  border-bottom-color: var(--color-text-muted);
+}
+
 
 .pt-log-date-row {
   display: flex;

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -888,25 +888,6 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
           </div>
         </div>
 
-        {contact.projects.length > 0 && (
-          <div className="pt-log-default-project">
-            <span className="pt-log-default-label">Default project</span>
-            <select
-              className="pt-log-default-select"
-              value={contact.default_membership_id ?? ''}
-              onChange={async (e) => {
-                await window.sourcerer.setContactDefaultProject(contact.id, e.target.value || null);
-                onRefresh();
-              }}
-            >
-              <option value="">None</option>
-              {contact.projects.map((p) => (
-                <option key={p.membership_id} value={p.membership_id}>{p.name}</option>
-              ))}
-            </select>
-          </div>
-        )}
-
         {logEntries.length === 0 && !logAdding && (
           <p className="pt-reminders-empty">No entries yet.</p>
         )}
@@ -978,30 +959,43 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
           <p className="detail-empty-projects">Not added to any projects yet.</p>
         ) : (
           <ul className="detail-project-list">
-            {contact.projects.map((p) => (
-              <li key={p.id} className="detail-project-item">
-                <span className="detail-project-name">{p.name}</span>
-                {p.status && <span className="detail-project-status">{p.status}</span>}
-                {confirmRemoveProjectId === p.id ? (
-                  <span className="detail-project-remove-confirm">
-                    <button
-                      className="detail-project-remove-yes"
-                      onClick={() => handleRemoveFromProject(p.id)}
-                    >Remove</button>
-                    <button
-                      className="detail-project-remove-no"
-                      onClick={() => setConfirmRemoveProjectId(null)}
-                    >Cancel</button>
-                  </span>
-                ) : (
-                  <button
-                    className="detail-project-remove"
-                    title="Remove from project"
-                    onClick={() => setConfirmRemoveProjectId(p.id)}
-                  >×</button>
-                )}
-              </li>
-            ))}
+            {contact.projects.map((p) => {
+              const isDefault = contact.default_membership_id === p.membership_id;
+              return (
+                <li key={p.id} className="detail-project-item">
+                  <span className="detail-project-name">{p.name}</span>
+                  {p.status && <span className="detail-project-status">{p.status}</span>}
+                  {confirmRemoveProjectId === p.id ? (
+                    <span className="detail-project-remove-confirm">
+                      <button
+                        className="detail-project-remove-yes"
+                        onClick={() => handleRemoveFromProject(p.id)}
+                      >Remove</button>
+                      <button
+                        className="detail-project-remove-no"
+                        onClick={() => setConfirmRemoveProjectId(null)}
+                      >Cancel</button>
+                    </span>
+                  ) : (
+                    <>
+                      <button
+                        className={`detail-project-default${isDefault ? ' detail-project-default--active' : ''}`}
+                        title={isDefault ? 'Clear default project' : 'Set as default project'}
+                        onClick={async () => {
+                          await window.sourcerer.setContactDefaultProject(contact.id, isDefault ? null : p.membership_id);
+                          onRefresh();
+                        }}
+                      >{isDefault ? '★' : '☆'}</button>
+                      <button
+                        className="detail-project-remove"
+                        title="Remove from project"
+                        onClick={() => setConfirmRemoveProjectId(p.id)}
+                      >×</button>
+                    </>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         )}
 

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -876,6 +876,10 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
             {!logAdding && (
               <Button variant="ghost" onClick={() => {
                 setLogDate(new Date().toISOString().slice(0, 10));
+                const effectiveDefault = contact.projects.find(
+                  (p) => p.membership_id === contact.default_membership_id,
+                );
+                setLogSelectedMembershipIds(effectiveDefault ? [effectiveDefault.membership_id] : []);
                 setLogAdding(true);
               }}>
                 + Add
@@ -883,6 +887,25 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
             )}
           </div>
         </div>
+
+        {contact.projects.length > 0 && (
+          <div className="pt-log-default-project">
+            <span className="pt-log-default-label">Default project</span>
+            <select
+              className="pt-log-default-select"
+              value={contact.default_membership_id ?? ''}
+              onChange={async (e) => {
+                await window.sourcerer.setContactDefaultProject(contact.id, e.target.value || null);
+                onRefresh();
+              }}
+            >
+              <option value="">None</option>
+              {contact.projects.map((p) => (
+                <option key={p.membership_id} value={p.membership_id}>{p.name}</option>
+              ))}
+            </select>
+          </div>
+        )}
 
         {logEntries.length === 0 && !logAdding && (
           <p className="pt-reminders-empty">No entries yet.</p>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -102,6 +102,7 @@ declare global {
       listContactLog: (contactId: string) => Promise<ContactLogEntry[]>;
       deleteInteractionLogEntry: (interactionId: string) => Promise<void>;
       addGlobalLogEntry: (contactId: string, body: string, createdAt?: number, membershipIds?: string[]) => Promise<ContactLogEntry>;
+      setContactDefaultProject: (contactId: string, membershipId: string | null) => Promise<void>;
       getContactCount: () => Promise<number>;
       getContactInteractionCount: (contactId: string) => Promise<number>;
       validatePhone: (raw: string) => Promise<boolean>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -131,6 +131,7 @@ export interface ContactDetail {
   title: string | null;
   dob: string | null;
   notes: string | null;
+  default_membership_id: string | null;
   created_at: number;
   updated_at: number;
   emails: ContactEmail[];


### PR DESCRIPTION
Closes #98.

## Summary

- New nullable `default_membership_id` column on `contacts` — no migration needed, recreate the database.
- When a contact is added to their **first** project (`memberships:add`), `default_membership_id` is automatically set to that membership.
- When a contact is removed from a project (`memberships:remove`), the default is cleared if it matched the removed membership.
- New `contacts:set-default-project` IPC handler for explicit changes from the UI.
- **Global tab**: a "Default project" selector appears in the interaction log section whenever the contact belongs to at least one project. Saved immediately on change (no extra Save step).
- Opening the log form pre-selects the default project in the picker (if one is set and still valid).
- Dev seeds: each seeded contact's `default_membership_id` is set to their first project membership.

## Test plan

- [x] Add a contact to their first project — default is auto-set, visible in the selector
- [x] Add a contact to a second project — default doesn't change
- [x] Change default via the selector — picker pre-selects the new default next time the form opens
- [x] Remove a contact from the project that was their default — selector resets to "None"
- [x] Set default to "None" explicitly — log form opens with nothing pre-selected
- [x] Dev seeds: open any contact in the Global tab — Default project selector shows their first project
- [x] All 244 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)