### PR TITLE
Add quick-log and quick-reminder sidebar shortcuts

### DIFF
--- a/src/main/database/dev-seeds.ts
+++ b/src/main/database/dev-seeds.ts
@@ -182,11 +182,11 @@ export function seedDevData(db: Database.Database, email: string, name: string):
 
     function addReminder(
       contactName: string,
-      projectId: string,
+      projectId: string | null,
       daysFromNow: number,
       note: string,
     ): void {
-      const membId = membIds[`${contactName}:${projectId}`];
+      const membId = projectId ? (membIds[`${contactName}:${projectId}`] ?? null) : null;
       stmts.insertReminder.run(uuidv4(), cid(contactName), projectId, membId, NOW + daysFromNow * DAY, note, NOW);
     }
 
@@ -499,11 +499,11 @@ export function seedDevData(db: Database.Database, email: string, name: string):
       'Follow up on secure-form submission — has she had a chance to upload the documents?');
     addReminder('Darnell Okafor', millgateId, 3,
       'Check in on legal review of handwritten notes — two-week window he mentioned is almost up.');
-    addReminder('Eunice Addo-Yeboah', pensionId, 14,
+    addReminder('Eunice Addo-Yeboah', null, 14,
       'Resume contact after lawyer-requested pause — confirm she is still willing to proceed.');
     addReminder('Sen. (ret.) Gérald Marquette', pensionId, 2,
       'Confirm he received the briefing notes and whether he stands by the key passage.');
-    addReminder('Dr. Ananya Krishnamurthy', healthId, 1,
+    addReminder('Dr. Ananya Krishnamurthy', null, 1,
       'Check in — agency counsel may have issued guidance that affects what she can share.');
     addReminder('Theresa Ouellet-Gauvin', healthId, 10,
       'Complete cross-reference of falsified staffing records against her redacted report.');

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -206,7 +206,7 @@ export const LOCAL_SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS reminders (
     id               TEXT    PRIMARY KEY,
     contact_id       TEXT    NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
-    project_id       TEXT    NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    project_id       TEXT    REFERENCES projects(id) ON DELETE SET NULL,
     membership_id    TEXT    REFERENCES project_memberships(id) ON DELETE CASCADE,
     due_date         INTEGER NOT NULL,
     note             TEXT,

--- a/src/main/http-server.ts
+++ b/src/main/http-server.ts
@@ -344,11 +344,11 @@ function generateIcal(db: ReturnType<typeof getDatabase>): string {
               c.name AS contact_name, p.name AS project_name
        FROM reminders r
        JOIN contacts c ON c.id = r.contact_id
-       JOIN projects p ON p.id = r.project_id
-       WHERE p.is_archived = 0
+       LEFT JOIN projects p ON p.id = r.project_id
+       WHERE (r.project_id IS NULL OR p.is_archived = 0)
        ORDER BY r.due_date ASC`,
     )
-    .all() as Array<{ id: string; due_date: number; note: string | null; is_auto_outreach: number; contact_name: string; project_name: string }>;
+    .all() as Array<{ id: string; due_date: number; note: string | null; is_auto_outreach: number; contact_name: string; project_name: string | null }>;
 
   const lines: string[] = [
     'BEGIN:VCALENDAR',
@@ -362,8 +362,8 @@ function generateIcal(db: ReturnType<typeof getDatabase>): string {
   for (const r of reminders) {
     const dateStr = toIcalDate(r.due_date);
     const summary = r.is_auto_outreach
-      ? `Outreach overdue: ${r.contact_name} — ${r.project_name}`
-      : `Follow up: ${r.contact_name} — ${r.project_name}`;
+      ? `Outreach overdue: ${r.contact_name}${r.project_name ? ` — ${r.project_name}` : ''}`
+      : `Follow up: ${r.contact_name}${r.project_name ? ` — ${r.project_name}` : ''}`;
     const event = [
       'BEGIN:VEVENT',
       `UID:${r.id}@sourcerer`,

--- a/src/main/ipc/reminders.ts
+++ b/src/main/ipc/reminders.ts
@@ -14,6 +14,11 @@ const SELECT_COLS = `
   c.name AS contact_name, p.name AS project_name,
   r.due_date, r.note, r.is_auto_outreach, r.created_at, r.completed_at`;
 
+const FROM_JOINS = `
+  FROM reminders r
+  JOIN contacts c ON c.id = r.contact_id
+  LEFT JOIN projects p ON p.id = r.project_id`;
+
 export function registerReminderHandlers(): void {
   ipcMain.handle(
     'reminders:list-for-contact-project',
@@ -21,9 +26,7 @@ export function registerReminderHandlers(): void {
       return getDatabase()
         .prepare(
           `SELECT ${SELECT_COLS}
-           FROM reminders r
-           JOIN contacts c ON c.id = r.contact_id
-           JOIN projects p ON p.id = r.project_id
+           ${FROM_JOINS}
            WHERE r.contact_id = ? AND r.project_id = ?
            ORDER BY r.is_auto_outreach DESC, r.due_date ASC`,
         )
@@ -31,14 +34,26 @@ export function registerReminderHandlers(): void {
     },
   );
 
+  ipcMain.handle(
+    'reminders:list-for-contact',
+    (_, contactId: string): Reminder[] => {
+      return getDatabase()
+        .prepare(
+          `SELECT ${SELECT_COLS}
+           ${FROM_JOINS}
+           WHERE r.contact_id = ?
+           ORDER BY r.is_auto_outreach DESC, r.due_date ASC`,
+        )
+        .all(contactId) as Reminder[];
+    },
+  );
+
   ipcMain.handle('reminders:list-all', (): Reminder[] => {
     return getDatabase()
       .prepare(
         `SELECT ${SELECT_COLS}
-         FROM reminders r
-         JOIN contacts c ON c.id = r.contact_id
-         JOIN projects p ON p.id = r.project_id
-         WHERE r.completed_at IS NULL AND p.is_archived = 0
+         ${FROM_JOINS}
+         WHERE r.completed_at IS NULL AND (r.project_id IS NULL OR p.is_archived = 0)
          ORDER BY r.due_date ASC`,
       )
       .all() as Reminder[];
@@ -53,7 +68,7 @@ export function registerReminderHandlers(): void {
         projectId,
         dueDate,
         note,
-      }: { contactId: string; projectId: string; dueDate: number; note?: string },
+      }: { contactId: string; projectId?: string; dueDate: number; note?: string },
     ): Reminder => {
       const db = getDatabase();
       if (!Number.isFinite(dueDate) || dueDate <= 0) throw new Error('invalid due_date');
@@ -62,13 +77,11 @@ export function registerReminderHandlers(): void {
       db.prepare(
         `INSERT INTO reminders (id, contact_id, project_id, due_date, note, created_at)
          VALUES (?, ?, ?, ?, ?, ?)`,
-      ).run(id, contactId, projectId, dueDate, note ?? null, now);
+      ).run(id, contactId, projectId ?? null, dueDate, note ?? null, now);
       const reminder = db
         .prepare(
           `SELECT ${SELECT_COLS}
-           FROM reminders r
-           JOIN contacts c ON c.id = r.contact_id
-           JOIN projects p ON p.id = r.project_id
+           ${FROM_JOINS}
            WHERE r.id = ?`,
         )
         .get(id) as Reminder;
@@ -106,9 +119,7 @@ export function registerReminderHandlers(): void {
       const reminder = db
         .prepare(
           `SELECT ${SELECT_COLS}
-           FROM reminders r
-           JOIN contacts c ON c.id = r.contact_id
-           JOIN projects p ON p.id = r.project_id
+           ${FROM_JOINS}
            WHERE r.id = ?`,
         )
         .get(id) as Reminder;

--- a/src/main/sync/reminder-checker.ts
+++ b/src/main/sync/reminder-checker.ts
@@ -8,7 +8,7 @@ const notifiedThisSession = new Set<string>();
 interface DueReminder {
   id: string;
   contact_name: string;
-  project_name: string;
+  project_name: string | null;
   note: string | null;
 }
 
@@ -29,9 +29,9 @@ export function checkReminders(): void {
       `SELECT r.id, c.name AS contact_name, p.name AS project_name, r.note
        FROM reminders r
        JOIN contacts c ON c.id = r.contact_id
-       JOIN projects p ON p.id = r.project_id
+       LEFT JOIN projects p ON p.id = r.project_id
        WHERE r.due_date <= ? AND r.is_auto_outreach = 0 AND r.completed_at IS NULL
-         AND p.is_archived = 0
+         AND (r.project_id IS NULL OR p.is_archived = 0)
          AND (r.last_notified_at IS NULL OR r.last_notified_at < ?)`,
     )
     .all(now, oneDayAgo) as DueReminder[];
@@ -46,8 +46,8 @@ export function checkReminders(): void {
     if (!notificationsEnabled) continue;
 
     const body = row.note
-      ? `${row.project_name} · ${row.note}`
-      : row.project_name;
+      ? (row.project_name ? `${row.project_name} · ${row.note}` : row.note)
+      : (row.project_name ?? 'Reminder');
 
     const notif = new Notification({
       title: `Reminder: ${row.contact_name}`,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -294,10 +294,12 @@ const sourcererApi = {
     projectId: string,
   ): Promise<Reminder[]> =>
     ipcRenderer.invoke('reminders:list-for-contact-project', { contactId, projectId }),
+  listRemindersForContact: (contactId: string): Promise<Reminder[]> =>
+    ipcRenderer.invoke('reminders:list-for-contact', contactId),
   listAllReminders: (): Promise<Reminder[]> => ipcRenderer.invoke('reminders:list-all'),
   createReminder: (data: {
     contactId: string;
-    projectId: string;
+    projectId?: string;
     dueDate: number;
     note?: string;
   }): Promise<Reminder> => ipcRenderer.invoke('reminders:create', data),

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -1130,6 +1130,17 @@
   color: var(--color-text);
 }
 
+.pt-reminder-row-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--color-text);
+}
+
 .pt-reminder-row-hint {
   color: var(--color-text-muted)
 }

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { ContactDetail as ContactDetailType, ContactAlertRss, ContactLogEntry, Project, User } from '@shared/types';
+import type { ContactDetail as ContactDetailType, ContactAlertRss, ContactLogEntry, Project, Reminder, User } from '@shared/types';
 import Button from '../shell/Button';
 import { LogRow, LogAllModal } from './logShared';
 import LogProjectPicker from './LogProjectPicker';
@@ -48,6 +48,184 @@ const SOCIAL_META: Record<SocialType, { label: string; placeholder: string }> = 
 };
 
 const KNOWN_LINK_TYPES = new Set<string>([...SOCIAL_TYPES, 'website']);
+
+function GlobalRemindersSection({ contact }: { contact: ContactDetailType }) {
+  const [reminders, setReminders] = useState<Reminder[]>([]);
+  const [completing, setCompleting] = useState<Set<string>>(new Set());
+  const [adding, setAdding] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [dueDate, setDueDate] = useState('');
+  const [note, setNote] = useState('');
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [editDueDate, setEditDueDate] = useState('');
+  const [editNote, setEditNote] = useState('');
+
+  useEffect(() => {
+    setReminders([]);
+    setCompleting(new Set());
+    setEditingId(null);
+    window.sourcerer.listRemindersForContact(contact.id).then((loaded) => {
+      setReminders(loaded);
+      setCompleting(new Set(loaded.filter((r) => r.completed_at !== null).map((r) => r.id)));
+    });
+  }, [contact.id]);
+
+  function sortReminders(a: Reminder, b: Reminder) {
+    return b.is_auto_outreach - a.is_auto_outreach || a.due_date - b.due_date;
+  }
+
+  function handleStartAdd() {
+    const defaultProject = contact.default_membership_id
+      ? contact.projects.find((p) => p.membership_id === contact.default_membership_id)
+      : null;
+    setSelectedProjectId(defaultProject?.id ?? null);
+    setDueDate('');
+    setNote('');
+    setAdding(true);
+    setEditingId(null);
+  }
+
+  async function handleAdd() {
+    if (!dueDate || !note.trim()) return;
+    const ts = Math.floor(new Date(`${dueDate}T09:00:00`).getTime() / 1000);
+    const r = await window.sourcerer.createReminder({
+      contactId: contact.id,
+      projectId: selectedProjectId ?? undefined,
+      dueDate: ts,
+      note: note.trim(),
+    });
+    setReminders((prev) => [...prev, r].sort(sortReminders));
+    setAdding(false);
+  }
+
+  function handleStartEdit(r: Reminder) {
+    const d = new Date(r.due_date * 1000);
+    setEditDueDate(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`);
+    setEditNote(r.note ?? '');
+    setEditingId(r.id);
+    setAdding(false);
+  }
+
+  async function handleSaveEdit(id: string) {
+    if (!editDueDate || !editNote.trim()) return;
+    const ts = Math.floor(new Date(`${editDueDate}T09:00:00`).getTime() / 1000);
+    try {
+      const updated = await window.sourcerer.updateReminder({ id, dueDate: ts, note: editNote.trim() });
+      setReminders((prev) => prev.map((r) => (r.id === id ? updated : r)).sort(sortReminders));
+      setEditingId(null);
+    } catch { /* leave edit form open */ }
+  }
+
+  async function handleComplete(id: string) {
+    setCompleting((prev) => new Set(prev).add(id));
+    try { await window.sourcerer.completeReminder(id); }
+    catch { setCompleting((prev) => { const n = new Set(prev); n.delete(id); return n; }); }
+  }
+
+  async function handleUncomplete(id: string) {
+    setCompleting((prev) => { const n = new Set(prev); n.delete(id); return n; });
+    try { await window.sourcerer.uncompleteReminder(id); }
+    catch { setCompleting((prev) => new Set(prev).add(id)); }
+  }
+
+  async function handleDelete(id: string) {
+    try { await window.sourcerer.deleteReminder(id); }
+    catch { return; }
+    setReminders((prev) => prev.filter((r) => r.id !== id));
+    setEditingId(null);
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  function fmtReminderDate(ts: number, overdue: boolean): string {
+    const d = new Date(ts * 1000);
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    const dateStr = `${mm}.${dd}`;
+    const days = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+    const dayName = days[d.getDay()];
+    const diffDays = Math.ceil((ts - now) / 86400);
+    if (overdue) return `WAS ${dayName} · ${dateStr}`;
+    if (diffDays <= 7) return `${dayName} · ${dateStr}`;
+    return dateStr;
+  }
+
+  const manualReminders = reminders.filter((r) => r.is_auto_outreach === 0);
+
+  return (
+    <div className="pt-section">
+      <div className="pt-reminders-header">
+        <span className="pt-reminders-label">Reminders</span>
+        <Button variant="ghost" onClick={() => { if (adding) { setAdding(false); } else { handleStartAdd(); } setEditingId(null); }}>
+          {adding ? '× CANCEL' : '+ ADD'}
+        </Button>
+      </div>
+      {manualReminders.length === 0 && !adding && (
+        <p className="pt-reminders-empty">No reminders set.</p>
+      )}
+      {manualReminders.map((r) => {
+        const overdue = r.completed_at === null && r.due_date < now;
+        const done = completing.has(r.id);
+        if (editingId === r.id) {
+          return (
+            <div key={r.id} className="pt-reminder-form">
+              <CalendarPicker label="Due date" value={editDueDate} onChange={setEditDueDate} showYear />
+              <input className="pt-input" value={editNote} onChange={(e) => setEditNote(e.target.value)} placeholder="Note" />
+              <div className="pt-reminder-form-actions">
+                <button className="pt-log-submit" onClick={() => handleSaveEdit(r.id)} disabled={!editDueDate || !editNote.trim()}>Save</button>
+                <button className="pt-reminder-cancel" onClick={() => setEditingId(null)}>Cancel</button>
+                <button className="pt-reminder-delete-btn" onClick={() => handleDelete(r.id)}>Delete</button>
+              </div>
+            </div>
+          );
+        }
+        return (
+          <div key={r.id} className={`pt-reminder-row${overdue ? ' pt-reminder-row--overdue' : ''}${done ? ' pt-reminder-row--completing' : ''}`}>
+            <div className={`pt-reminder-row-date${overdue && !done ? ' pt-reminder-row-date--overdue' : ''}`}>
+              {fmtReminderDate(r.due_date, overdue)}
+            </div>
+            <div className="pt-reminder-row-note">
+              {r.note || ''}
+              {r.project_name && <span className="pt-log-row-project-badge">{r.project_name}</span>}
+            </div>
+            {!done && (
+              <button className="pt-reminder-edit-btn" onClick={() => handleStartEdit(r)} title="Edit">Edit</button>
+            )}
+            <input
+              type="checkbox"
+              className="pt-reminder-check"
+              checked={done}
+              onChange={() => { if (done) handleUncomplete(r.id); else handleComplete(r.id); }}
+              title={done ? 'Mark incomplete' : 'Mark complete'}
+            />
+          </div>
+        );
+      })}
+      {adding && (
+        <div className="pt-reminder-form">
+          <CalendarPicker label="Due date" value={dueDate} onChange={setDueDate} showYear />
+          <input className="pt-input" value={note} onChange={(e) => setNote(e.target.value)} placeholder="Note" />
+          {contact.projects.length > 0 && (
+            <select
+              className="pt-select"
+              value={selectedProjectId ?? ''}
+              onChange={(e) => setSelectedProjectId(e.target.value || null)}
+            >
+              <option value="">No project</option>
+              {contact.projects.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          )}
+          <div className="pt-reminder-form-actions">
+            <button className="pt-log-submit" onClick={handleAdd} disabled={!dueDate || !note.trim()}>Add</button>
+            <button className="pt-reminder-cancel" onClick={() => setAdding(false)}>Cancel</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 
 export default function GlobalTab({ contact, allProjects, onRefresh, onMembershipChanged, onDeleted, onEditingChange, user }: Props) {
   const [editing, setEditing] = useState(false);
@@ -952,6 +1130,8 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
           />
         )}
       </div>
+
+      <GlobalRemindersSection contact={contact} />
 
       <div className="detail-section">
         <div className="detail-section-label">Projects</div>

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -184,8 +184,8 @@ function GlobalRemindersSection({ contact }: { contact: ContactDetailType }) {
             <div className={`pt-reminder-row-date${overdue && !done ? ' pt-reminder-row-date--overdue' : ''}`}>
               {fmtReminderDate(r.due_date, overdue)}
             </div>
-            <div className="pt-reminder-row-note">
-              {r.note || ''}
+            <div className="pt-reminder-row-body">
+              <span>{r.note || ''}</span>
               {r.project_name && <span className="pt-log-row-project-badge">{r.project_name}</span>}
             </div>
             {!done && (

--- a/src/renderer/src/contacts/QuickLogModal.css
+++ b/src/renderer/src/contacts/QuickLogModal.css
@@ -99,9 +99,9 @@
 
 .qlm-dropdown-option {
   display: flex;
-  align-items: baseline;
-  gap: 8px;
-  padding: 8px 10px;
+  flex-direction: column;
+  gap: 2px;
+  padding: 7px 10px;
   font-family: var(--font-serif);
   font-size: 13px;
   color: var(--color-text);

--- a/src/renderer/src/contacts/QuickLogModal.css
+++ b/src/renderer/src/contacts/QuickLogModal.css
@@ -1,0 +1,184 @@
+/* Shared styles for QuickLogModal and QuickReminderModal */
+
+.quick-log-modal,
+.quick-reminder-modal {
+  width: 460px;
+}
+
+.qlm-field {
+  margin-bottom: 14px;
+}
+
+.qlm-label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin-bottom: 5px;
+}
+
+.qlm-required {
+  color: var(--color-danger);
+}
+
+/* Selected contact chip */
+.qlm-selected {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+}
+
+.qlm-selected-name {
+  flex: 1;
+  font-family: var(--font-serif);
+  font-size: 14px;
+  color: var(--color-text);
+}
+
+.qlm-clear-btn {
+  background: none;
+  border: none;
+  font-size: 16px;
+  line-height: 1;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  padding: 0 2px;
+  flex-shrink: 0;
+}
+
+.qlm-clear-btn:hover {
+  color: var(--color-text);
+}
+
+/* Contact search picker */
+.qlm-picker-wrap {
+  position: relative;
+}
+
+.qlm-picker-input {
+  width: 100%;
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--color-border);
+  font-size: 14px;
+  font-family: var(--font-serif);
+  color: var(--color-text);
+  background: var(--color-bg);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.qlm-picker-input:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(200, 122, 26, 0.18);
+}
+
+.qlm-picker-input::placeholder {
+  color: var(--color-text-dim);
+}
+
+.qlm-dropdown {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 200;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.qlm-dropdown-option {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 8px 10px;
+  font-family: var(--font-serif);
+  font-size: 13px;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.qlm-dropdown-option:hover {
+  background: var(--color-surface);
+}
+
+.qlm-dropdown-org {
+  font-size: 11px;
+  color: var(--color-text-dim);
+}
+
+/* Date wrapper */
+.qlm-date-wrap {
+  display: flex;
+  align-items: center;
+}
+
+/* Note textarea */
+.qlm-textarea {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border);
+  font-size: 14px;
+  font-family: var(--font-serif);
+  color: var(--color-text);
+  background: var(--color-bg);
+  outline: none;
+  resize: vertical;
+  box-sizing: border-box;
+  line-height: 1.5;
+}
+
+.qlm-textarea:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(200, 122, 26, 0.18);
+}
+
+.qlm-textarea::placeholder {
+  color: var(--color-text-dim);
+}
+
+/* Project dropdown (reminder modal) */
+.qlm-select {
+  width: 100%;
+  height: 36px;
+  padding: 0 32px 0 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 0;
+  font-size: 14px;
+  font-family: var(--font-serif);
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%235b5750'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  appearance: none;
+  cursor: pointer;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.qlm-select:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(200, 122, 26, 0.18);
+}
+
+/* No-projects message */
+.qlm-no-projects {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  margin: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-2);
+  line-height: 1.45;
+}

--- a/src/renderer/src/contacts/QuickLogModal.tsx
+++ b/src/renderer/src/contacts/QuickLogModal.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ContactDetail, ContactListItem } from '@shared/types';
+import Modal from '../shell/Modal';
+import Button from '../shell/Button';
+import { CalendarPicker } from '../views/CalendarPicker';
+import LogProjectPicker from './LogProjectPicker';
+import './QuickLogModal.css';
+
+function todayISO(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+interface Props {
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export default function QuickLogModal({ onClose, onSaved }: Props) {
+  const [contacts, setContacts] = useState<ContactListItem[]>([]);
+  const [query, setQuery] = useState('');
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [selectedContactId, setSelectedContactId] = useState<string | null>(null);
+  const [selectedContactName, setSelectedContactName] = useState('');
+  const [detail, setDetail] = useState<ContactDetail | null>(null);
+  const [membershipIds, setMembershipIds] = useState<string[]>([]);
+  const [date, setDate] = useState(todayISO());
+  const [body, setBody] = useState('');
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    window.sourcerer.listContacts().then(setContacts);
+  }, []);
+
+  useEffect(() => {
+    if (!selectedContactId) {
+      setDetail(null);
+      setMembershipIds([]);
+      return;
+    }
+    window.sourcerer.getContact(selectedContactId).then((d) => {
+      setDetail(d);
+      const def = d.default_membership_id
+        ? d.projects.find((p) => p.membership_id === d.default_membership_id)
+        : null;
+      setMembershipIds(def ? [def.membership_id] : []);
+    });
+  }, [selectedContactId]);
+
+  const filtered = query
+    ? contacts.filter((c) =>
+        c.name.toLowerCase().includes(query.toLowerCase()),
+      )
+    : contacts;
+
+  function selectContact(c: ContactListItem) {
+    setSelectedContactId(c.id);
+    setSelectedContactName(c.name);
+    setQuery('');
+    setDropdownOpen(false);
+  }
+
+  function clearContact() {
+    setSelectedContactId(null);
+    setSelectedContactName('');
+    setDetail(null);
+    setMembershipIds([]);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }
+
+  async function handleSave() {
+    if (!selectedContactId || !body.trim() || !date) return;
+    setSaving(true);
+    try {
+      const [y, m, d] = date.split('-').map(Number);
+      const ts = Math.floor(new Date(y, m - 1, d, 12, 0, 0).getTime() / 1000);
+      await window.sourcerer.addGlobalLogEntry(
+        selectedContactId,
+        body.trim(),
+        ts,
+        membershipIds.length > 0 ? membershipIds : undefined,
+      );
+      onSaved();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const canSave = !!selectedContactId && body.trim().length > 0 && !!date && !saving;
+
+  return (
+    <Modal title="Log interaction" onDismiss={onClose} className="quick-log-modal">
+      <div className="qlm-field">
+        <label className="qlm-label">Contact <span className="qlm-required">*</span></label>
+        {selectedContactId ? (
+          <div className="qlm-selected">
+            <span className="qlm-selected-name">{selectedContactName}</span>
+            <button type="button" className="qlm-clear-btn" onClick={clearContact} aria-label="Clear contact">×</button>
+          </div>
+        ) : (
+          <div className="qlm-picker-wrap">
+            <input
+              ref={inputRef}
+              className="qlm-picker-input"
+              placeholder="Search contacts…"
+              value={query}
+              onChange={(e) => { setQuery(e.target.value); setDropdownOpen(true); }}
+              onFocus={() => setDropdownOpen(true)}
+              onBlur={() => setTimeout(() => setDropdownOpen(false), 150)}
+              autoFocus
+            />
+            {dropdownOpen && filtered.length > 0 && (
+              <div className="qlm-dropdown">
+                {filtered.slice(0, 10).map((c) => (
+                  <div
+                    key={c.id}
+                    className="qlm-dropdown-option"
+                    onMouseDown={(e) => { e.preventDefault(); selectContact(c); }}
+                  >
+                    {c.name}
+                    {c.organization && <span className="qlm-dropdown-org">{c.organization}</span>}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {detail && detail.projects.length > 0 && (
+        <div className="qlm-field">
+          <label className="qlm-label">Projects</label>
+          <LogProjectPicker
+            projects={detail.projects}
+            selectedIds={membershipIds}
+            onChange={setMembershipIds}
+          />
+        </div>
+      )}
+
+      <div className="qlm-field">
+        <label className="qlm-label">Date</label>
+        <div className="qlm-date-wrap">
+          <CalendarPicker
+            label="Pick date"
+            value={date}
+            onChange={setDate}
+            showYear
+            maxDate={todayISO()}
+          />
+        </div>
+      </div>
+
+      <div className="qlm-field">
+        <label className="qlm-label">Note <span className="qlm-required">*</span></label>
+        <textarea
+          className="qlm-textarea"
+          placeholder="What happened?"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={4}
+        />
+      </div>
+
+      <div className="modal-actions">
+        <Button variant="secondary" onClick={onClose} disabled={saving}>Cancel</Button>
+        <Button variant="primary" onClick={handleSave} disabled={!canSave}>
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/renderer/src/contacts/QuickReminderModal.tsx
+++ b/src/renderer/src/contacts/QuickReminderModal.tsx
@@ -68,7 +68,7 @@ export default function QuickReminderModal({ onClose, onSaved }: Props) {
   }
 
   async function handleSave() {
-    if (!selectedContactId || !selectedProjectId || !date) return;
+    if (!selectedContactId || !date) return;
     setSaving(true);
     try {
       const ts = Math.floor(new Date(`${date}T09:00:00`).getTime() / 1000);

--- a/src/renderer/src/contacts/QuickReminderModal.tsx
+++ b/src/renderer/src/contacts/QuickReminderModal.tsx
@@ -74,7 +74,7 @@ export default function QuickReminderModal({ onClose, onSaved }: Props) {
       const ts = Math.floor(new Date(`${date}T09:00:00`).getTime() / 1000);
       await window.sourcerer.createReminder({
         contactId: selectedContactId,
-        projectId: selectedProjectId,
+        projectId: selectedProjectId ?? undefined,
         dueDate: ts,
         note: note.trim() || undefined,
       });
@@ -84,7 +84,7 @@ export default function QuickReminderModal({ onClose, onSaved }: Props) {
     }
   }
 
-  const canSave = !!selectedContactId && !!selectedProjectId && !!date && note.trim().length > 0 && !saving;
+  const canSave = !!selectedContactId && !!date && note.trim().length > 0 && !saving;
 
   return (
     <Modal title="Set reminder" onDismiss={onClose} className="quick-reminder-modal">
@@ -127,12 +127,13 @@ export default function QuickReminderModal({ onClose, onSaved }: Props) {
 
       {detail && detail.projects.length > 0 && (
         <div className="qlm-field">
-          <label className="qlm-label">Project <span className="qlm-required">*</span></label>
+          <label className="qlm-label">Project</label>
           <select
             className="qlm-select"
             value={selectedProjectId ?? ''}
             onChange={(e) => setSelectedProjectId(e.target.value || null)}
           >
+            <option value="">No project</option>
             {detail.projects.map((p) => (
               <option key={p.id} value={p.id}>{p.name}</option>
             ))}

--- a/src/renderer/src/contacts/QuickReminderModal.tsx
+++ b/src/renderer/src/contacts/QuickReminderModal.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ContactDetail, ContactListItem } from '@shared/types';
+import Modal from '../shell/Modal';
+import Button from '../shell/Button';
+import { CalendarPicker } from '../views/CalendarPicker';
+import './QuickLogModal.css';
+
+interface Props {
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export default function QuickReminderModal({ onClose, onSaved }: Props) {
+  const [contacts, setContacts] = useState<ContactListItem[]>([]);
+  const [query, setQuery] = useState('');
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [selectedContactId, setSelectedContactId] = useState<string | null>(null);
+  const [selectedContactName, setSelectedContactName] = useState('');
+  const [detail, setDetail] = useState<ContactDetail | null>(null);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [date, setDate] = useState('');
+  const [note, setNote] = useState('');
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    window.sourcerer.listContacts().then(setContacts);
+  }, []);
+
+  useEffect(() => {
+    if (!selectedContactId) {
+      setDetail(null);
+      setSelectedProjectId(null);
+      return;
+    }
+    window.sourcerer.getContact(selectedContactId).then((d) => {
+      setDetail(d);
+      const defaultProject = d.default_membership_id
+        ? d.projects.find((p) => p.membership_id === d.default_membership_id)
+        : null;
+      setSelectedProjectId(defaultProject?.id ?? d.projects[0]?.id ?? null);
+    });
+  }, [selectedContactId]);
+
+  const filtered = query
+    ? contacts.filter((c) =>
+        c.name.toLowerCase().includes(query.toLowerCase()),
+      )
+    : contacts;
+
+  function selectContact(c: ContactListItem) {
+    setSelectedContactId(c.id);
+    setSelectedContactName(c.name);
+    setQuery('');
+    setDropdownOpen(false);
+  }
+
+  function clearContact() {
+    setSelectedContactId(null);
+    setSelectedContactName('');
+    setDetail(null);
+    setSelectedProjectId(null);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }
+
+  async function handleSave() {
+    if (!selectedContactId || !selectedProjectId || !date) return;
+    setSaving(true);
+    try {
+      const ts = Math.floor(new Date(`${date}T09:00:00`).getTime() / 1000);
+      await window.sourcerer.createReminder({
+        contactId: selectedContactId,
+        projectId: selectedProjectId,
+        dueDate: ts,
+        note: note.trim() || undefined,
+      });
+      onSaved();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const canSave = !!selectedContactId && !!selectedProjectId && !!date && !saving;
+
+  return (
+    <Modal title="Set reminder" onDismiss={onClose} className="quick-reminder-modal">
+      <div className="qlm-field">
+        <label className="qlm-label">Contact <span className="qlm-required">*</span></label>
+        {selectedContactId ? (
+          <div className="qlm-selected">
+            <span className="qlm-selected-name">{selectedContactName}</span>
+            <button type="button" className="qlm-clear-btn" onClick={clearContact} aria-label="Clear contact">×</button>
+          </div>
+        ) : (
+          <div className="qlm-picker-wrap">
+            <input
+              ref={inputRef}
+              className="qlm-picker-input"
+              placeholder="Search contacts…"
+              value={query}
+              onChange={(e) => { setQuery(e.target.value); setDropdownOpen(true); }}
+              onFocus={() => setDropdownOpen(true)}
+              onBlur={() => setTimeout(() => setDropdownOpen(false), 150)}
+              autoFocus
+            />
+            {dropdownOpen && filtered.length > 0 && (
+              <div className="qlm-dropdown">
+                {filtered.slice(0, 10).map((c) => (
+                  <div
+                    key={c.id}
+                    className="qlm-dropdown-option"
+                    onMouseDown={(e) => { e.preventDefault(); selectContact(c); }}
+                  >
+                    {c.name}
+                    {c.organization && <span className="qlm-dropdown-org">{c.organization}</span>}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {detail && (
+        <div className="qlm-field">
+          <label className="qlm-label">Project <span className="qlm-required">*</span></label>
+          {detail.projects.length === 0 ? (
+            <p className="qlm-no-projects">
+              This contact isn't in any projects. Add them to a project first.
+            </p>
+          ) : (
+            <select
+              className="qlm-select"
+              value={selectedProjectId ?? ''}
+              onChange={(e) => setSelectedProjectId(e.target.value || null)}
+            >
+              {detail.projects.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          )}
+        </div>
+      )}
+
+      <div className="qlm-field">
+        <label className="qlm-label">Due date <span className="qlm-required">*</span></label>
+        <div className="qlm-date-wrap">
+          <CalendarPicker
+            label="Pick date"
+            value={date}
+            onChange={setDate}
+            showYear
+          />
+        </div>
+      </div>
+
+      <div className="qlm-field">
+        <label className="qlm-label">Note</label>
+        <textarea
+          className="qlm-textarea"
+          placeholder="Optional note…"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          rows={3}
+        />
+      </div>
+
+      <div className="modal-actions">
+        <Button variant="secondary" onClick={onClose} disabled={saving}>Cancel</Button>
+        <Button
+          variant="primary"
+          onClick={handleSave}
+          disabled={!canSave || (!!detail && detail.projects.length === 0)}
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/renderer/src/contacts/QuickReminderModal.tsx
+++ b/src/renderer/src/contacts/QuickReminderModal.tsx
@@ -18,7 +18,11 @@ export default function QuickReminderModal({ onClose, onSaved }: Props) {
   const [selectedContactName, setSelectedContactName] = useState('');
   const [detail, setDetail] = useState<ContactDetail | null>(null);
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
-  const [date, setDate] = useState('');
+  const [date, setDate] = useState(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 7);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  });
   const [note, setNote] = useState('');
   const [saving, setSaving] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -80,7 +84,7 @@ export default function QuickReminderModal({ onClose, onSaved }: Props) {
     }
   }
 
-  const canSave = !!selectedContactId && !!selectedProjectId && !!date && !saving;
+  const canSave = !!selectedContactId && !!selectedProjectId && !!date && note.trim().length > 0 && !saving;
 
   return (
     <Modal title="Set reminder" onDismiss={onClose} className="quick-reminder-modal">
@@ -121,24 +125,18 @@ export default function QuickReminderModal({ onClose, onSaved }: Props) {
         )}
       </div>
 
-      {detail && (
+      {detail && detail.projects.length > 0 && (
         <div className="qlm-field">
           <label className="qlm-label">Project <span className="qlm-required">*</span></label>
-          {detail.projects.length === 0 ? (
-            <p className="qlm-no-projects">
-              This contact isn't in any projects. Add them to a project first.
-            </p>
-          ) : (
-            <select
-              className="qlm-select"
-              value={selectedProjectId ?? ''}
-              onChange={(e) => setSelectedProjectId(e.target.value || null)}
-            >
-              {detail.projects.map((p) => (
-                <option key={p.id} value={p.id}>{p.name}</option>
-              ))}
-            </select>
-          )}
+          <select
+            className="qlm-select"
+            value={selectedProjectId ?? ''}
+            onChange={(e) => setSelectedProjectId(e.target.value || null)}
+          >
+            {detail.projects.map((p) => (
+              <option key={p.id} value={p.id}>{p.name}</option>
+            ))}
+          </select>
         </div>
       )}
 
@@ -155,10 +153,10 @@ export default function QuickReminderModal({ onClose, onSaved }: Props) {
       </div>
 
       <div className="qlm-field">
-        <label className="qlm-label">Note</label>
+        <label className="qlm-label">Note <span className="qlm-required">*</span></label>
         <textarea
           className="qlm-textarea"
-          placeholder="Optional note…"
+          placeholder="What do you want to be reminded about?"
           value={note}
           onChange={(e) => setNote(e.target.value)}
           rows={3}
@@ -170,7 +168,7 @@ export default function QuickReminderModal({ onClose, onSaved }: Props) {
         <Button
           variant="primary"
           onClick={handleSave}
-          disabled={!canSave || (!!detail && detail.projects.length === 0)}
+          disabled={!canSave}
         >
           {saving ? 'Saving…' : 'Save'}
         </Button>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -169,10 +169,11 @@ declare global {
 
       // Reminders
       listRemindersForContactProject: (contactId: string, projectId: string) => Promise<Reminder[]>;
+      listRemindersForContact: (contactId: string) => Promise<Reminder[]>;
       listAllReminders: () => Promise<Reminder[]>;
       createReminder: (data: {
         contactId: string;
-        projectId: string;
+        projectId?: string;
         dueDate: number;
         note?: string;
       }) => Promise<Reminder>;

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -8,6 +8,8 @@ import ProjectView from '../views/ProjectView';
 import ImportCsvModal from '../views/ImportCsvModal';
 import ImportResultModal from '../views/ImportResultModal';
 import AddContactModal from '../contacts/AddContactModal';
+import QuickLogModal from '../contacts/QuickLogModal';
+import QuickReminderModal from '../contacts/QuickReminderModal';
 import AlertMentions from '../views/AlertMentions';
 import RemindersView from '../views/RemindersView';
 import SettingsView from '../views/SettingsView';
@@ -38,6 +40,8 @@ export default function AppShell() {
   const [openContactId, setOpenContactId] = useState<string | null>(null);
   const [showAddContact, setShowAddContact] = useState(false);
   const [showImportCsv, setShowImportCsv] = useState(false);
+  const [showQuickLog, setShowQuickLog] = useState(false);
+  const [showQuickReminder, setShowQuickReminder] = useState(false);
   const [importResult, setImportResult] = useState<ImportResult | null>(null);
   const [importRefreshTrigger, setImportRefreshTrigger] = useState(0);
   const [updateState, setUpdateState] = useState<'idle' | 'available' | 'downloading' | 'ready'>('idle');
@@ -252,6 +256,8 @@ export default function AppShell() {
         onProjectDeleted={handleProjectDeleted}
         onAddContact={() => setShowAddContact(true)}
         onImportCsv={() => setShowImportCsv(true)}
+        onQuickLog={() => setShowQuickLog(true)}
+        onQuickReminder={() => setShowQuickReminder(true)}
       />
       <main className="app-content">
         {nav.view === 'all-contacts' && (
@@ -349,6 +355,27 @@ export default function AppShell() {
 
       {importResult && (
         <ImportResultModal result={importResult} onClose={() => setImportResult(null)} />
+      )}
+
+      {showQuickLog && (
+        <QuickLogModal
+          onClose={() => setShowQuickLog(false)}
+          onSaved={() => {
+            setShowQuickLog(false);
+            setImportRefreshTrigger((n) => n + 1);
+            refreshOverdue();
+          }}
+        />
+      )}
+
+      {showQuickReminder && (
+        <QuickReminderModal
+          onClose={() => setShowQuickReminder(false)}
+          onSaved={() => {
+            setShowQuickReminder(false);
+            refreshOverdue();
+          }}
+        />
       )}
       </div>
     </div>

--- a/src/renderer/src/shell/Sidebar.tsx
+++ b/src/renderer/src/shell/Sidebar.tsx
@@ -27,6 +27,8 @@ interface Props {
   onProjectDeleted: (id: string) => void;
   onAddContact: () => void;
   onImportCsv: () => void;
+  onQuickLog: () => void;
+  onQuickReminder: () => void;
 }
 
 export default function Sidebar({
@@ -47,6 +49,8 @@ export default function Sidebar({
   onProjectDeleted,
   onAddContact,
   onImportCsv,
+  onQuickLog,
+  onQuickReminder,
 }: Props) {
   const [showNewProject, setShowNewProject] = useState(false);
   const [showJoinProject, setShowJoinProject] = useState(false);
@@ -122,6 +126,8 @@ export default function Sidebar({
           <div className="sidebar-action-btns">
             <Button variant="accent" size="sm" full onClick={onAddContact}>+ Add contact</Button>
             <Button variant="secondary" size="sm" full onClick={onImportCsv}>Import contacts</Button>
+            <Button variant="secondary" size="sm" full onClick={onQuickLog}>Log interaction</Button>
+            <Button variant="secondary" size="sm" full onClick={onQuickReminder}>Set reminder</Button>
           </div>
 
           <div className="sidebar-section-label">Workspace</div>

--- a/src/renderer/src/views/RemindersView.css
+++ b/src/renderer/src/views/RemindersView.css
@@ -241,6 +241,19 @@
   margin-top: 2px;
 }
 
+.reminders-item-project {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-radius: 3px;
+  padding: 1px 5px;
+  color: var(--color-text-muted);
+  background: var(--color-border);
+  align-self: flex-start;
+}
+
 .reminders-item-note {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/renderer/src/views/RemindersView.css
+++ b/src/renderer/src/views/RemindersView.css
@@ -244,11 +244,11 @@
 .reminders-item-project {
   display: inline-block;
   font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 0.08em;
+  font-size: 10px;
+  letter-spacing: 0.10em;
   text-transform: uppercase;
   border-radius: 3px;
-  padding: 1px 5px;
+  padding: 1px 4px;
   color: var(--color-text-muted);
   background: var(--color-border);
   align-self: flex-start;

--- a/src/renderer/src/views/RemindersView.css
+++ b/src/renderer/src/views/RemindersView.css
@@ -175,7 +175,7 @@
 }
 
 .reminders-item-contact {
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--color-text);
   overflow: hidden;
@@ -191,7 +191,7 @@
   border: none;
   padding: 0;
   font-family: inherit;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--color-text);
   text-transform: none;
@@ -255,6 +255,7 @@
 }
 
 .reminders-item-note {
+  font-size: 13px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/renderer/src/views/RemindersView.css
+++ b/src/renderer/src/views/RemindersView.css
@@ -250,7 +250,7 @@
   border-radius: 3px;
   padding: 1px 4px;
   color: var(--color-text-muted);
-  background: var(--color-border);
+  background: var(--color-surface-2);
   align-self: flex-start;
 }
 

--- a/src/renderer/src/views/RemindersView.css
+++ b/src/renderer/src/views/RemindersView.css
@@ -234,15 +234,11 @@
 
 .reminders-item-meta {
   display: flex;
-  align-items: center;
-  gap: 5px;
+  flex-direction: column;
+  gap: 2px;
   font-size: 11px;
   color: var(--color-text-muted);
   margin-top: 2px;
-}
-
-.reminders-item-sep {
-  opacity: 0.5;
 }
 
 .reminders-item-note {

--- a/src/renderer/src/views/RemindersView.tsx
+++ b/src/renderer/src/views/RemindersView.tsx
@@ -163,7 +163,7 @@ export default function RemindersView({ onCountChange, user }: Props) {
           </p>
         )}
         <h1 className="view-headline">Reminders</h1>
-        <p className="view-subtitle">Scheduled follow-ups and outreach nudges across all your projects.</p>
+        <p className="view-subtitle">Scheduled follow-ups and outreach nudges across all your contacts.</p>
         <div className="view-rule-thick" />
         <div className="view-rule-thin" />
         <div className="project-meta-bar">
@@ -302,18 +302,14 @@ function ReminderRow({
           {!isAuto && <span className="reminders-item-badge reminders-item-badge-manual">Reminder</span>}
         </div>
         <div className="reminders-item-meta">
-          <span className="reminders-item-project">{reminder.project_name}</span>
+          {reminder.project_name && (
+            <span className="reminders-item-project">{reminder.project_name}</span>
+          )}
           {!isAuto && reminder.note && (
-            <>
-              <span className="reminders-item-sep">·</span>
-              <span className="reminders-item-note">{reminder.note}</span>
-            </>
+            <span className="reminders-item-note">{reminder.note}</span>
           )}
           {isAuto && (
-            <>
-              <span className="reminders-item-sep">·</span>
-              <span className="reminders-item-auto-hint">Log an interaction to clear</span>
-            </>
+            <span className="reminders-item-auto-hint">Log an interaction to clear</span>
           )}
         </div>
       </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -294,10 +294,10 @@ export interface ProjectReporter {
 export interface Reminder {
   id: string;
   contact_id: string;
-  project_id: string;
+  project_id: string | null;
   membership_id: string | null;
   contact_name: string;
-  project_name: string;
+  project_name: string | null;
   due_date: number;
   note: string | null;
   is_auto_outreach: 0 | 1;


### PR DESCRIPTION
## What's new

Two new buttons in the sidebar — **Log interaction** and **Set reminder** — let you capture notes and reminders from anywhere in the app without navigating to a contact first.

**Log interaction modal:**
- Searchable contact picker (required)
- Project multi-select (optional; pre-fills from the contact's default project if set)
- Date picker (defaults to today, capped at today)
- Note (required)

**Set reminder modal:**
- Searchable contact picker (required)
- Project selector (optional; pre-fills from the contact's default project if set)
- Due date (required, defaults to 7 days from now)
- Note (required)

Reminders can now be created without a project association — `project_id` is nullable throughout the stack. A new **Reminders section** in the contact global tab shows all reminders for a contact in one place, with optional project badge and add/edit/complete/delete support.

The Reminders view has been restyled: contact name and note text are larger, project name appears as a badge on its own line (using the same pill style as the timeline view), and the layout degrades cleanly when no project is set. The ICS calendar feed has also been fixed to include project-less reminders.

Closes #99.

## Test plan

- [ ] **Log interaction modal** — click "Log interaction" in sidebar; contact picker shows all contacts; selecting one pre-fills their default project; date defaults to today and rejects future dates; note field required (Save disabled if empty); saving with a project creates an interaction in that project; saving with no project selected still saves the entry
- [ ] **Set reminder modal** — click "Set reminder" in sidebar; contact picker works; project field hidden when contact belongs to no projects; project shows "No project" option when contact is in at least one project; date defaults to 7 days from now; note field required (Save disabled if empty); saving creates reminder visible in Reminders view
- [ ] **Project-less reminders** — create a reminder with no project via sidebar modal and via GlobalTab; reminder appears in Reminders view with no badge; no crash in reminder-checker notification; reminder appears in ICS calendar feed (subscribe and check Apple Calendar / Thunderbird)
- [ ] **GlobalTab Reminders section** — open a contact's global tab; manual reminders appear listed with note and optional project badge on its own line; add a new reminder (with and without project); complete a reminder; delete a reminder; outreach reminders do not appear in this section
- [ ] **Reminders view styling** — confirm contact name is legible (14px), project badge appears on its own line below the name, note text on the next line; rows without a project show only the note; overdue and upcoming sections still collapse/expand
- [ ] **Dev seeds** — recreate the DB (delete sourcerer.db) and unlock; verify Eunice Addo-Yeboah and Dr. Ananya Krishnamurthy have reminders with no project badge in the Reminders view

## Details

<details>
<summary>Commits</summary>

- Add quick-log and quick-reminder buttons to sidebar
- Show organization below contact name in quick-modal dropdown
- Fix quick-reminder modal: default date, required note, hide no-project field
- Allow project-less reminders; add reminders to GlobalTab
- Remove project association from two dev-seed reminders
- Restyle RemindersView for project-less reminders; fix ICS feed
- Match project badge style in RemindersView to timeline view
- Increase type size on reminder contact name and note text
- Reduce project badge size in RemindersView
- Lighten project badge background in RemindersView
- Put project badge on its own line in GlobalTab reminder rows

</details>