### PR TITLE
Preserve active view when opening contact from timeline

### DIFF
--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -274,12 +274,7 @@ export default function AppShell() {
         )}
         {nav.view === 'reminders' && <RemindersView onCountChange={setOverdueReminders} user={user} />}
         {nav.view === 'all-timeline' && (
-          <ProjectTimeline
-            onSelectContact={(id) => {
-              setNav({ view: 'all-contacts' });
-              setOpenContactId(id);
-            }}
-          />
+          <ProjectTimeline user={user} />
         )}
         {nav.view === 'project' && (
           <ProjectView
@@ -297,16 +292,10 @@ export default function AppShell() {
           <ProjectTimeline
             projectId={activeProject.id}
             projectName={activeProject.name}
-            onSelectContact={(id) => {
-              setNav({ view: 'project', projectId: activeProject.id });
-              setOpenContactId(id);
-            }}
+            user={user}
           />
         ) : (
-          // Project not yet loaded / no longer exists — fall back to global timeline
-          <ProjectTimeline
-            onSelectContact={(id) => setOpenContactId(id)}
-          />
+          <ProjectTimeline user={user} />
         ))}
         {nav.view === 'settings' && <SettingsView user={user} onUserUpdated={setUser} />}
       </main>

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -8,6 +8,7 @@ import ProjectView from '../views/ProjectView';
 import ImportCsvModal from '../views/ImportCsvModal';
 import ImportResultModal from '../views/ImportResultModal';
 import AddContactModal from '../contacts/AddContactModal';
+import ContactDetail from '../contacts/ContactDetail';
 import QuickLogModal from '../contacts/QuickLogModal';
 import QuickReminderModal from '../contacts/QuickReminderModal';
 import AlertMentions from '../views/AlertMentions';
@@ -38,6 +39,8 @@ export default function AppShell() {
   const [totalContacts, setTotalContacts] = useState(0);
   const [searchOpen, setSearchOpen] = useState(false);
   const [openContactId, setOpenContactId] = useState<string | null>(null);
+  const [globalContactId, setGlobalContactId] = useState<string | null>(null);
+  const [globalDrawerClosing, setGlobalDrawerClosing] = useState(false);
   const [showAddContact, setShowAddContact] = useState(false);
   const [showImportCsv, setShowImportCsv] = useState(false);
   const [showQuickLog, setShowQuickLog] = useState(false);
@@ -149,6 +152,16 @@ export default function AppShell() {
       offError();
     };
   }, []);
+
+  function openGlobalContact(id: string) {
+    if (globalContactId === id) { closeGlobalContact(); return; }
+    setGlobalContactId(id);
+  }
+
+  function closeGlobalContact() {
+    setGlobalDrawerClosing(true);
+    setTimeout(() => { setGlobalContactId(null); setGlobalDrawerClosing(false); }, 160);
+  }
 
   function handleProjectCreated(project: Project) {
     setProjects((prev) => [...prev, project]);
@@ -304,7 +317,7 @@ export default function AppShell() {
         <SearchModal
           onClose={() => setSearchOpen(false)}
           onNav={setNav}
-          onOpenContact={(id) => setOpenContactId(id)}
+          onOpenContact={openGlobalContact}
         />
       )}
 
@@ -364,6 +377,16 @@ export default function AppShell() {
             setShowQuickReminder(false);
             refreshOverdue();
           }}
+        />
+      )}
+      {globalContactId && (
+        <ContactDetail
+          contactId={globalContactId}
+          onClose={closeGlobalContact}
+          onDeleted={closeGlobalContact}
+          onUpdated={() => {}}
+          user={user}
+          closing={globalDrawerClosing}
         />
       )}
       </div>

--- a/src/renderer/src/shell/SearchModal.tsx
+++ b/src/renderer/src/shell/SearchModal.tsx
@@ -27,12 +27,10 @@ export default function SearchModal({ onClose, onNav, onOpenContact }: Props) {
 
   function pick(result: SearchResult) {
     if (result.type === 'contact') {
-      onNav({ view: 'all-contacts' });
       onOpenContact(result.id);
     } else if (result.type === 'project') {
       onNav({ view: 'project', projectId: result.id });
     } else {
-      onNav({ view: 'all-contacts' });
       onOpenContact(result.contactId);
     }
     onClose();

--- a/src/renderer/src/views/ProjectTimeline.tsx
+++ b/src/renderer/src/views/ProjectTimeline.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import type { TimelineEntry } from '@shared/types';
+import type { TimelineEntry, User } from '@shared/types';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { CalendarPicker } from './CalendarPicker';
 import Button from '../shell/Button';
+import ContactDetail from '../contacts/ContactDetail';
 import './View.css';
 import './ColumnHeader.css';
 import './ProjectTimeline.css';
@@ -11,7 +12,7 @@ import './ProjectTimeline.css';
 interface Props {
   projectId?: string;
   projectName?: string;
-  onSelectContact: (id: string) => void;
+  user?: User | null;
 }
 
 function dayKey(ts: number): string {
@@ -175,7 +176,7 @@ function MultiSelect({
   );
 }
 
-export default function ProjectTimeline({ projectId, projectName, onSelectContact }: Props) {
+export default function ProjectTimeline({ projectId, projectName, user }: Props) {
   const [entries, setEntries] = useState<TimelineEntry[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -193,6 +194,18 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
   const [notesFilter, setNotesFilter] = useState('');
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
+  const [selectedContactId, setSelectedContactId] = useState<string | null>(null);
+  const [drawerClosing, setDrawerClosing] = useState(false);
+
+  function openContact(id: string) {
+    if (selectedContactId === id) { closeContact(); return; }
+    setSelectedContactId(id);
+  }
+
+  function closeContact() {
+    setDrawerClosing(true);
+    setTimeout(() => { setSelectedContactId(null); setDrawerClosing(false); }, 160);
+  }
 
   useEffect(() => {
     setEntries([]);
@@ -499,7 +512,7 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
                         <div className="ptl-contact-name-row">
                           <button
                             className="ptl-contact-name"
-                            onClick={() => onSelectContact(entry.contact_id)}
+                            onClick={() => openContact(entry.contact_id)}
                           >
                             {entry.contact_name}
                           </button>
@@ -528,6 +541,16 @@ export default function ProjectTimeline({ projectId, projectName, onSelectContac
         </div>
       )}
       </div>
+      {selectedContactId && (
+        <ContactDetail
+          contactId={selectedContactId}
+          onClose={closeContact}
+          onDeleted={closeContact}
+          onUpdated={() => {}}
+          user={user ?? null}
+          closing={drawerClosing}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## What's new

Opening a contact no longer switches the middle column away from the current view. Two entry points were affected:

**Timeline views** — clicking a contact name in the All Contacts timeline or a per-project timeline now slides the contact drawer in over the timeline itself. \`ProjectTimeline\` manages its own \`ContactDetail\` drawer internally (same pattern as \`RemindersView\`).

**Search (⌘K)** — clicking a contact or interaction result in the search modal now opens a drawer at the app shell level without navigating to All Contacts. A project result still navigates to that project as before.

Closes #103.

## Test plan

- [x] **All Contacts timeline** — navigate to the global timeline; click a contact name; drawer opens over the timeline, middle column stays put
- [x] **Project timeline** — click a contact name in a per-project timeline; drawer opens without switching back to the table
- [x] **Search — contact result** — open search (⌘K) from any view; click a contact result; drawer opens over the current view without navigating to All Contacts
- [x] **Search — log result** — click an interaction result; same — drawer opens in place
- [x] **Search — project result** — clicking a project result still navigates to that project
- [x] **Close drawer** — Escape or ✕ closes the drawer; active view is unchanged
- [x] **Toggle** — clicking the same contact a second time closes the drawer
- [x] **Other views unaffected** — contacts opened from All Contacts table, project table, and Reminders view all still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)