### PR TITLE
0.1.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sourcerer",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sourcerer",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcerer",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "description": "Encrypted source management for journalists",
   "author": "Tom Cardoso",


### PR DESCRIPTION
## What's new

**Log interaction and Set reminder from anywhere** — two new buttons in the sidebar let you capture a note or create a reminder without navigating to a contact first. Both modals have a searchable contact picker and optional project association.

**Reminders no longer require a project** — reminders can now be created without a project attached. The Reminders view has been restyled accordingly: the project name appears as a small badge on its own line below the contact name, and rows without a project degrade cleanly. The contact global tab now also shows a dedicated Reminders section for manual reminders.

**Shift-click range selection** — in the All Contacts and project contact tables, holding Shift while clicking a checkbox selects (or deselects) all rows between the last-clicked row and the newly clicked one.

**Contact drawer no longer disrupts the active view** — clicking a contact name in a timeline view or from the search modal (⌘K) now opens the detail drawer in place, without switching the middle column back to the table view.

<details>
<summary>Full commit list</summary>

- Fix SearchModal: open contact drawer without navigating away
- Preserve active view when opening contact from timeline
- Shift-click range selection in contact tables
- Fix QuickReminderModal: allow save with no project selected
- Add quick-log and quick-reminder buttons to sidebar
- Allow project-less reminders; add reminders to GlobalTab
- Restyle RemindersView for project-less reminders; fix ICS feed
- Put project badge on its own line in GlobalTab reminder rows

</details>