### PR TITLE
Fix license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Source and contact management for journalists and researchers — local-first, e
 
 [![Latest release](https://img.shields.io/github/v/release/tomcardoso/sourcerer?label=version&color=4b5563)](https://github.com/tomcardoso/sourcerer/releases/latest)
 [![Build](https://img.shields.io/github/actions/workflow/status/tomcardoso/sourcerer/ci.yml?label=build)](https://github.com/tomcardoso/sourcerer/actions/workflows/ci.yml)
-[![License: AGPL-3.0](https://img.shields.io/github/license/tomcardoso/sourcerer?color=4b5563)](LICENSE)
+[![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-4b5563)](LICENSE)
 [![Sponsor](https://img.shields.io/github/sponsors/tomcardoso?label=sponsor&logo=github&color=ea4aaa)](https://github.com/sponsors/tomcardoso)
 
 ![screenshot](docs/img/contact-details-2.png)


### PR DESCRIPTION
The `github/license` shield queries GitHub's API which returns SPDX ID `AGPL-3.0`. SPDX deprecated that identifier in favour of `AGPL-3.0-only`, and shields.io now shows "invalid" for it. Swap to a static badge — same appearance, no API lookup required.