### PR TITLE
Fix dev seed guard: use persistent flag instead of contact count

### DIFF
--- a/src/main/database/dev-seeds.ts
+++ b/src/main/database/dev-seeds.ts
@@ -30,9 +30,6 @@ const NOW = Math.floor(Date.now() / 1000);
 const DAY = 86400;
 
 export function seedDevData(db: Database.Database, email: string, name: string): void {
-  const existing = (db.prepare('SELECT COUNT(*) AS n FROM contacts').get() as { n: number }).n;
-  if (existing > 0) return;
-
   const doSeed = db.transaction(() => {
     const stmts = {
       insertContact: db.prepare(
@@ -513,6 +510,8 @@ export function seedDevData(db: Database.Database, email: string, name: string):
     for (const [contactName, membershipId] of firstMembByContact) {
       updateDefault.run(membershipId, cid(contactName));
     }
+
+    db.prepare('UPDATE users SET dev_seeded = 1 WHERE id = 1').run();
   });
 
   doSeed();

--- a/src/main/database/index.ts
+++ b/src/main/database/index.ts
@@ -49,10 +49,10 @@ export function initDatabase(dbPath: string, keyHex: string): Database.Database 
 /** Called once per unlock after the user row is guaranteed to exist. */
 export function maybeRunDevSeeds(db: Database.Database): void {
   if (!is.dev) return;
-  const u = db.prepare('SELECT first_name, last_name, email FROM users WHERE id = 1').get() as
-    | { first_name: string; last_name: string; email: string }
+  const u = db.prepare('SELECT first_name, last_name, email, dev_seeded FROM users WHERE id = 1').get() as
+    | { first_name: string; last_name: string; email: string; dev_seeded: number }
     | undefined;
-  if (!u) return;
+  if (!u || u.dev_seeded) return;
   seedDevData(db, u.email, `${u.first_name} ${u.last_name}`.trim());
 }
 

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -24,7 +24,8 @@ export const LOCAL_SCHEMA_SQL = `
     last_rss_fetched_at            INTEGER,
     auto_backup_enabled            INTEGER NOT NULL DEFAULT 0,
     auto_backup_dest_path          TEXT,
-    auto_backup_max_count          INTEGER NOT NULL DEFAULT 10
+    auto_backup_max_count          INTEGER NOT NULL DEFAULT 10,
+    dev_seeded                     INTEGER NOT NULL DEFAULT 0
   );
 
   CREATE TABLE IF NOT EXISTS contacts (


### PR DESCRIPTION
## What this fixes

Closes #119 and #120.

**Root cause:** `seedDevData` was guarding against re-seeding by checking `SELECT COUNT(*) FROM contacts`. If you deleted all contacts, the count dropped to zero and the seeds re-ran on the next unlock — restoring all 100 contacts. Projects were re-inserted unconditionally so they doubled on top of any that still existed.

## Fix

Added a `dev_seeded INTEGER NOT NULL DEFAULT 0` column to the `users` table. The column is stamped to `1` inside the seed transaction, and `maybeRunDevSeeds` bails immediately if it's already set. Deleting contacts no longer triggers a re-seed.

No migration needed — dev databases should be recreated anyway since the schema changed.

## Testing

- Delete all contacts → quit and relaunch → contacts stay gone
- Delete all contacts but keep projects → quit and relaunch → projects not doubled
- Fresh vault → seeds run once and never again

🤖 Generated with [Claude Code](https://claude.com/claude-code)