### PR TITLE
Fix dedup badge persisting after contact deletion + FK error on dismiss

### DIFF
--- a/src/main/dedup.ts
+++ b/src/main/dedup.ts
@@ -195,6 +195,9 @@ export function loadDismissedPairs(db: Database.Database): Set<string> {
 
 export function dismissPair(db: Database.Database, aId: string, bId: string): void {
   const [a, b] = aId < bId ? [aId, bId] : [bId, aId];
+  // Skip if either contact was deleted since the pair was cached.
+  if (!db.prepare('SELECT 1 FROM contacts WHERE id = ?').get(a)) return;
+  if (!db.prepare('SELECT 1 FROM contacts WHERE id = ?').get(b)) return;
   db.prepare(
     'INSERT OR IGNORE INTO dedup_dismissed_pairs (contact_a_id, contact_b_id, dismissed_at) VALUES (?, ?, ?)',
   ).run(a, b, Math.floor(Date.now() / 1000));

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -344,6 +344,7 @@ export function registerContactHandlers(): void {
 
   ipcMain.handle('contacts:delete', (_, id: string): void => {
     getDatabase().prepare('DELETE FROM contacts WHERE id = ?').run(id);
+    runDedupScan();
     broadcastContactsChanged();
   });
 

--- a/src/test/dedup.db.test.ts
+++ b/src/test/dedup.db.test.ts
@@ -94,6 +94,16 @@ describe('dismissPair', () => {
     const dismissed = loadDismissedPairs(db);
     expect(findDuplicatePairs(contacts, dismissed)).toHaveLength(0);
   });
+
+  it('silently no-ops when either contact has been deleted (no FK error)', () => {
+    const a = insertContact(db, 'Alice');
+    const b = insertContact(db, 'Bob');
+    db.prepare('DELETE FROM contacts WHERE id = ?').run(b);
+    expect(() => dismissPair(db, a, b)).not.toThrow();
+    expect(
+      (db.prepare('SELECT COUNT(*) AS n FROM dedup_dismissed_pairs').get() as { n: number }).n,
+    ).toBe(0);
+  });
 });
 
 describe('mergeContacts — keep strategy', () => {


### PR DESCRIPTION
## What this fixes

Closes #118.

Two related bugs with the same root cause — the dedup cache going stale when contacts are deleted:

**Bug 1: Badge persists after all contacts deleted**
`contacts:delete` called `broadcastContactsChanged()` but not `runDedupScan()`. The cached pairs were never invalidated on deletion, so the badge count stayed non-zero even with an empty contacts list. Fix: add `runDedupScan()` to the delete handler.

**Bug 2: FK constraint error when clicking Skip on a stale pair**
`dismissPair` uses `INSERT OR IGNORE`, which handles uniqueness conflicts but silently ignores them — it does NOT catch FK constraint violations. So clicking Skip on a pair whose contacts were already deleted threw `SQLITE_CONSTRAINT_FOREIGNKEY`. Fix: check both contact IDs exist before attempting the insert, and return early if either is gone.

## Testing

1. Create contacts with a pending dedupe suggestion
2. Delete all contacts — badge should immediately disappear (within ~500ms)
3. If you somehow open the dedup modal before the scan fires and click Skip, no error is thrown

🤖 Generated with [Claude Code](https://claude.com/claude-code)