### PR TITLE
0.1.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sourcerer",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sourcerer",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcerer",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "description": "Encrypted source management for journalists",
   "author": "Tom Cardoso",

--- a/src/renderer/src/screens/Unlock.css
+++ b/src/renderer/src/screens/Unlock.css
@@ -14,7 +14,7 @@
   max-width: 380px;
   background: var(--color-surface);
   /* border: 1px solid var(--color-border); */
-  padding: 36px 32px 32px;
+  padding: 0 32px 32px;
   text-align: center;
 }
 


### PR DESCRIPTION
## What's new

**Portable vault** — You can now choose where your vault is stored when setting up the app for the first time, and move it to a different location at any time from Settings. This makes it easier to keep your vault on an encrypted drive, a folder excluded from cloud sync, or wherever makes sense for your setup.

**Backups now include screenshots** — Encrypted backups exported from Settings now include all screenshots captured through the browser extension. Restoring a backup brings them back too. The backup format has been redesigned to stream data in chunks, so large vaults with many screenshots no longer cause memory spikes during export or restore.

**Quick log and quick reminder buttons** — New buttons in the sidebar let you log an interaction or set a reminder for any contact without opening their full profile first.

**Default project per contact** — You can now mark one project as the default for each contact using the star icon in the Projects section. This pre-selects that project when logging interactions.

**Shift-click range selection** — In any contact table, hold Shift and click to select a range of contacts at once.

**Interaction log improvements** — Log entries can now be associated with a project, can be deleted, and are visible in a contact-level global tab independent of any project.

**Contact form clean-up** — Less-used fields (date of birth, notes, social handles) are now collapsed behind a "More details" toggle to keep the form focused.

**Security update** — Updated the UUID library to address CVE-2026-41907. All dependency versions are now pinned exactly for reproducible builds.

**Bug fixes**
- Deduplication badge no longer persists after all contacts are deleted; clicking Skip on a stale pair no longer throws a database error
- Dev seed data no longer re-appears after deleting contacts in development mode
- Opening a contact from the search bar or timeline no longer navigates away from your current view

<details>
<summary>All changes</summary>- #122 Fix dedup badge persisting after contact deletion + FK error on dismiss
- #121 Fix dev seed guard: use persistent flag instead of contact count
- #117 Upgrade uuid to 11.1.1 (CVE-2026-41907)
- #116 Overhaul backup format: streaming chunked encryption, screenshots included
- #113 Add portable vault: configurable storage location
- #111 Update app icons
- #110 Fix license badge
- #109 0.1.15
- #108 Preserve active view when opening contact from timeline
- #107 Shift-click range selection in contact tables
- #106 Add quick-log and quick-reminder sidebar shortcuts
- #105 Add default project per contact

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)