### PR TITLE
Replace inline styles with CSS classes

### DIFF
--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -1,3 +1,12 @@
+.app-loading {
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  font-size: 14px;
+}
+
 .ext-approval-overlay {
   position: fixed;
   inset: 0;

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -64,16 +64,7 @@ export default function App() {
 
   if (screen === 'loading') {
     return (
-      <div
-        style={{
-          height: '100vh',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'var(--color-text-muted)',
-          fontSize: 14,
-        }}
-      >
+      <div className="app-loading">
         Loading…
       </div>
     );

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -123,7 +123,7 @@ function LogSection({
     <div className="pt-section">
       <div className="pt-reminders-header">
         <span className="pt-reminders-label">Interaction Log</span>
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: 12 }}>
+        <div className="pt-log-header-actions">
           {entries.length > 0 && (
             <Button variant="ghost" onClick={() => setShowAll(true)}>
               View all ({entries.length})

--- a/src/renderer/src/views/AllContacts.css
+++ b/src/renderer/src/views/AllContacts.css
@@ -210,6 +210,10 @@
   gap: 4px;
 }
 
+.bulk-bar-element--right {
+  margin-left: auto;
+}
+
 .bulk-bar-count {
   font-family: var(--font-mono);
   font-size: 10px;

--- a/src/renderer/src/views/DedupModal.css
+++ b/src/renderer/src/views/DedupModal.css
@@ -126,6 +126,10 @@
   word-break: break-word;
 }
 
+.dedup-field-value--empty {
+  color: var(--color-text-dim);
+}
+
 .dedup-field-value--unique {
   border-left: 2px solid var(--color-warning-border);
   padding-left: 6px;

--- a/src/renderer/src/views/DedupModal.tsx
+++ b/src/renderer/src/views/DedupModal.tsx
@@ -83,7 +83,7 @@ function ContactCard({ contact, other }: { contact: DedupContact; other: DedupCo
       <div className="dedup-field dedup-field--projects">
         <span className="dedup-field-label">Projects</span>
         {(contact.projects ?? []).length === 0 ? (
-          <span className="dedup-field-value" style={{ color: 'var(--color-text-dim)' }}>none</span>
+          <span className="dedup-field-value dedup-field-value--empty">none</span>
         ) : (
           <div>
             {(contact.projects ?? []).map((p) => (

--- a/src/renderer/src/views/ProjectView.tsx
+++ b/src/renderer/src/views/ProjectView.tsx
@@ -772,7 +772,7 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
                   </select>
                 </div>
               )}
-              <div className="bulk-bar-element bulk-actions-wrap" ref={bulkActionsRef} style={{ marginLeft: 'auto' }}>
+              <div className="bulk-bar-element bulk-bar-element--right bulk-actions-wrap" ref={bulkActionsRef}>
                 <button
                   className="bulk-actions-trigger"
                   onClick={() => setShowBulkActions((v) => !v)}


### PR DESCRIPTION
## What

Removes four instances of `style={{...}}` that contain only static values — converting them to properly named CSS classes.

| Location | Inline style | Fix |
|---|---|---|
| `App.tsx` loading screen | `height: 100vh; display: flex; …` | new `.app-loading` class in `App.css` |
| `ProjectTab.tsx` log header | `display: flex; alignItems: baseline; gap: 12` | reuses existing `.pt-log-header-actions` |
| `DedupModal.tsx` empty projects | `color: var(--color-text-dim)` | new `.dedup-field-value--empty` modifier |
| `ProjectView.tsx` bulk-bar right-align | `marginLeft: auto` | new `.bulk-bar-element--right` modifier in `AllContacts.css` |

Dynamic inline styles (virtualisation spacer heights, dropdown position coordinates, dot colours) are left as-is — those can't be expressed in static CSS.

## Test plan
- [x] Typecheck passes (`npm run typecheck`)
- [x] All 278 tests pass (`npm test`)
- [x] App loads correctly; loading screen, dedup modal, project tab log header, and project view bulk bar all look unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)