### PR TITLE
Remove border-radius from interactive elements and modal cards

### DIFF
--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -11,7 +11,7 @@
 .ext-approval-card {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: 10px;
+  border-radius: 0;
   padding: 28px 24px 20px;
   width: 340px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -1437,7 +1437,7 @@
 .sv-zoom-toggle {
   display: flex;
   background: rgba(255, 255, 255, 0.06);
-  border-radius: 5px;
+  border-radius: 0;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.1);
 }
@@ -1464,7 +1464,7 @@
   background: rgba(255, 255, 255, 0.07);
   border: 1px solid rgba(255, 255, 255, 0.1);
   color: rgba(255, 255, 255, 0.75);
-  border-radius: 4px;
+  border-radius: 0;
   padding: 4px 10px;
   cursor: pointer;
   font-size: 10px;

--- a/src/renderer/src/contacts/ScreenshotPickerModal.css
+++ b/src/renderer/src/contacts/ScreenshotPickerModal.css
@@ -11,7 +11,7 @@
 .spm-card {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: 10px;
+  border-radius: 0;
   padding: 24px 20px 16px;
   width: 360px;
   max-height: 480px;
@@ -57,7 +57,7 @@
   text-align: left;
   background: none;
   border: none;
-  border-radius: 6px;
+  border-radius: 0;
   padding: 5px 3px;
   cursor: pointer;
   font-size: 13px;

--- a/src/renderer/src/shell/AppShell.css
+++ b/src/renderer/src/shell/AppShell.css
@@ -66,7 +66,7 @@
   letter-spacing: 0.16em;
   text-transform: uppercase;
   padding: 2px 7px;
-  border-radius: 3px;
+  border-radius: 0;
   border: 1px solid var(--color-primary);
   cursor: pointer;
   background: none;


### PR DESCRIPTION
## What

Fixes `border-radius` violations across four files. The design rule is: **all interactive elements use `border-radius: 0`; no exceptions.** Modal cards are also squared up to match the rest of the UI.

| File | Element | Before | After |
|---|---|---|---|
| `AppShell.css` | `.app-update-btn` | 3px | 0 |
| `ScreenshotPickerModal.css` | `.spm-card` (modal card) | 10px | 0 |
| `ScreenshotPickerModal.css` | `.spm-contact-btn` | 6px | 0 |
| `ContactDetail.css` | `.sv-zoom-toggle` (button group) | 5px | 0 |
| `ContactDetail.css` | `.sv-action-btn` | 4px | 0 |
| `App.css` | `.ext-approval-card` (modal card) | 10px | 0 |

Untouched: `border-radius: 50%` on decorative elements (avatar dots, status indicators, scrollbar thumb) — those are intentional circular shapes, not interactive controls.

## Test plan
- [x] Typecheck passes
- [x] All 278 tests pass
- [x] Update notification button in titlebar is square
- [x] Screenshot picker modal and contact list buttons are square
- [x] Screenshot viewer zoom-toggle and action buttons are square
- [x] Extension approval dialog (trigger from Chrome extension) is square

🤖 Generated with [Claude Code](https://claude.com/claude-code)