### PR TITLE
Fix stale updated_at timestamps after contact dedup merge

### DIFF
--- a/src/main/dedup.ts
+++ b/src/main/dedup.ts
@@ -242,11 +242,12 @@ export function mergeContacts(
             ? loser.notes
             : winner.notes;
 
-      db.prepare('UPDATE contacts SET name = ?, organization = ?, title = ?, notes = ? WHERE id = ?').run(
+      db.prepare('UPDATE contacts SET name = ?, organization = ?, title = ?, notes = ?, updated_at = ? WHERE id = ?').run(
         name,
         organization,
         title,
         notes,
+        now,
         winnerId,
       );
 
@@ -362,8 +363,9 @@ export function mergeContacts(
         ).run(winnerMembership.id, membership.id);
         db.prepare('DELETE FROM project_memberships WHERE id = ?').run(membership.id);
       } else {
-        db.prepare('UPDATE project_memberships SET contact_id = ? WHERE id = ?').run(
+        db.prepare('UPDATE project_memberships SET contact_id = ?, updated_at = ? WHERE id = ?').run(
           winnerId,
+          now,
           membership.id,
         );
       }

--- a/src/test/dedup.db.test.ts
+++ b/src/test/dedup.db.test.ts
@@ -142,6 +142,24 @@ describe('mergeContacts — keep strategy', () => {
     expect(projectIds).toContain(p2);
   });
 
+  it('advances updated_at on the reassigned loser membership', () => {
+    const p1 = insertProject(db, 'Project A');
+    const p2 = insertProject(db, 'Project B');
+    const winner = insertContact(db, 'Alice Smith');
+    const loser = insertContact(db, 'Alicia Smith');
+    insertMembership(winner, p1);
+    const loserMembId = insertMembership(loser, p2);
+    const staleTs = Math.floor(Date.now() / 1000) - 100;
+    db.prepare('UPDATE project_memberships SET updated_at = ? WHERE id = ?').run(staleTs, loserMembId);
+
+    mergeContacts(db, winner, loser, 'keep');
+
+    const row = db
+      .prepare('SELECT updated_at FROM project_memberships WHERE contact_id = ? AND project_id = ?')
+      .get(winner, p2) as { updated_at: number };
+    expect(row.updated_at).toBeGreaterThan(staleTs);
+  });
+
   it('does not duplicate membership when winner already belongs to same project', () => {
     const proj = insertProject(db, 'Shared Project');
     const winner = insertContact(db, 'Alice Smith');
@@ -238,5 +256,17 @@ describe('mergeContacts — merge strategy', () => {
     expect(handles).toHaveLength(2);
     expect(handles.some((h) => h.type === 'signal' && h.handle === '+1 202 111 0001')).toBe(true);
     expect(handles.some((h) => h.type === 'whatsapp' && h.handle === '+1 202 111 0002')).toBe(true);
+  });
+
+  it('advances contacts.updated_at when overwriting winner fields', () => {
+    const staleTs = Math.floor(Date.now() / 1000) - 100;
+    const winner = insertContact(db, 'Alice S');
+    const loser = insertContact(db, 'Alice Smith');
+    db.prepare('UPDATE contacts SET updated_at = ? WHERE id = ?').run(staleTs, winner);
+
+    mergeContacts(db, winner, loser, 'merge');
+
+    const row = db.prepare('SELECT updated_at FROM contacts WHERE id = ?').get(winner) as { updated_at: number };
+    expect(row.updated_at).toBeGreaterThan(staleTs);
   });
 });


### PR DESCRIPTION
## Bug

Two `UPDATE` statements in `dedup.ts`'s merge transaction omit `updated_at`, leaving the column holding the contact's (or membership's) pre-merge timestamp:

1. **`UPDATE contacts`** (merge strategy, line 245) — when the winner's name/org/title/notes are replaced by the merged values, `updated_at` is not advanced.
2. **`UPDATE project_memberships`** (both strategies, line 365) — when a loser membership is reassigned to the winner contact, `updated_at` is not advanced.

This means the stored `updated_at` no longer reflects when the row was last modified, which is incorrect on its own and could cause issues for any future sync or export logic that relies on the timestamp.

## Fix

Add `updated_at = ?` to both UPDATE statements, binding the `now` value already in scope at the top of the transaction.

## Test plan
- [x] Typecheck passes
- [x] All 280 tests pass (including two new tests asserting `updated_at` advances after a merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)