### PR TITLE
Guard reminder Add button against double-submit

### DIFF
--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -53,6 +53,7 @@ function GlobalRemindersSection({ contact }: { contact: ContactDetailType }) {
   const [reminders, setReminders] = useState<Reminder[]>([]);
   const [completing, setCompleting] = useState<Set<string>>(new Set());
   const [adding, setAdding] = useState(false);
+  const [addingSaving, setAddingSaving] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [dueDate, setDueDate] = useState('');
   const [note, setNote] = useState('');
@@ -86,16 +87,21 @@ function GlobalRemindersSection({ contact }: { contact: ContactDetailType }) {
   }
 
   async function handleAdd() {
-    if (!dueDate || !note.trim()) return;
-    const ts = Math.floor(new Date(`${dueDate}T09:00:00`).getTime() / 1000);
-    const r = await window.sourcerer.createReminder({
-      contactId: contact.id,
-      projectId: selectedProjectId ?? undefined,
-      dueDate: ts,
-      note: note.trim(),
-    });
-    setReminders((prev) => [...prev, r].sort(sortReminders));
-    setAdding(false);
+    if (!dueDate || !note.trim() || addingSaving) return;
+    setAddingSaving(true);
+    try {
+      const ts = Math.floor(new Date(`${dueDate}T09:00:00`).getTime() / 1000);
+      const r = await window.sourcerer.createReminder({
+        contactId: contact.id,
+        projectId: selectedProjectId ?? undefined,
+        dueDate: ts,
+        note: note.trim(),
+      });
+      setReminders((prev) => [...prev, r].sort(sortReminders));
+      setAdding(false);
+    } finally {
+      setAddingSaving(false);
+    }
   }
 
   function handleStartEdit(r: Reminder) {
@@ -218,7 +224,7 @@ function GlobalRemindersSection({ contact }: { contact: ContactDetailType }) {
             </select>
           )}
           <div className="pt-reminder-form-actions">
-            <button className="pt-log-submit" onClick={handleAdd} disabled={!dueDate || !note.trim()}>Add</button>
+            <button className="pt-log-submit" onClick={handleAdd} disabled={!dueDate || !note.trim() || addingSaving}>Add</button>
             <button className="pt-reminder-cancel" onClick={() => setAdding(false)}>Cancel</button>
           </div>
         </div>

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -338,6 +338,7 @@ function RemindersSection({
   const [dueDate, setDueDate] = useState('');
   const [note, setNote] = useState('');
   const [adding, setAdding] = useState(false);
+  const [addingSaving, setAddingSaving] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editDueDate, setEditDueDate] = useState('');
   const [editNote, setEditNote] = useState('');
@@ -357,18 +358,23 @@ function RemindersSection({
   }
 
   async function handleAdd() {
-    if (!dueDate || !note.trim()) return;
-    const ts = Math.floor(new Date(`${dueDate}T09:00:00`).getTime() / 1000);
-    const r = await window.sourcerer.createReminder({
-      contactId,
-      projectId,
-      dueDate: ts,
-      note: note.trim(),
-    });
-    setReminders((prev) => [...prev, r].sort(sortReminders));
-    setDueDate('');
-    setNote('');
-    setAdding(false);
+    if (!dueDate || !note.trim() || addingSaving) return;
+    setAddingSaving(true);
+    try {
+      const ts = Math.floor(new Date(`${dueDate}T09:00:00`).getTime() / 1000);
+      const r = await window.sourcerer.createReminder({
+        contactId,
+        projectId,
+        dueDate: ts,
+        note: note.trim(),
+      });
+      setReminders((prev) => [...prev, r].sort(sortReminders));
+      setDueDate('');
+      setNote('');
+      setAdding(false);
+    } finally {
+      setAddingSaving(false);
+    }
   }
 
   function handleStartEdit(r: Reminder) {
@@ -530,7 +536,7 @@ function RemindersSection({
             placeholder="Note"
           />
           <div className="pt-reminder-form-actions">
-            <button className="pt-log-submit" onClick={handleAdd} disabled={!dueDate || !note.trim()}>
+            <button className="pt-log-submit" onClick={handleAdd} disabled={!dueDate || !note.trim() || addingSaving}>
               Add
             </button>
             <button className="pt-reminder-cancel" onClick={() => setAdding(false)}>


### PR DESCRIPTION
Closes #132

## Summary

`handleAdd` in `GlobalRemindersSection` and the reminder section of `ProjectTab` had no in-flight guard. Once the due date and note were filled in, rapid clicks each fired a separate `createReminder` IPC call before the first resolved, creating duplicate reminders.

Fix: add an `addingSaving` flag, set it in a `try/finally` block, and include it in the button's `disabled` condition — matching the pattern already used by `handleSaveEdit` and `QuickReminderModal` in the same codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)