### PR TITLE
Replace off-palette hardcoded colours in Sidebar.css

### DIFF
--- a/src/renderer/src/global.css
+++ b/src/renderer/src/global.css
@@ -75,6 +75,7 @@
   --color-primary-hover:   #a8641a;
 
   /* ── Semantic ─────────────────────────────────── */
+  --color-success:         #2d8f6a;
   --color-danger:          #b91c1c;
   --color-warning-bg:      #fef3c7;
   --color-warning-border:  #f59e0b;

--- a/src/renderer/src/shell/Sidebar.css
+++ b/src/renderer/src/shell/Sidebar.css
@@ -276,7 +276,7 @@
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: #34d399;
+  background: var(--color-success);
   flex-shrink: 0;
   opacity: 0.85;
 }
@@ -370,8 +370,8 @@
 /* Delete confirmation */
 .sidebar-delete-confirm {
   padding: 6px 8px;
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  background: color-mix(in srgb, var(--color-danger) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-danger) 30%, transparent);
   margin-bottom: 5px;
 }
 
@@ -409,7 +409,7 @@
 }
 
 .sidebar-delete-yes:hover {
-  background: #991b1b;
+  opacity: 0.85;
 }
 
 .sidebar-delete-no {


### PR DESCRIPTION
Closes #136

## Summary

Three colour values in `Sidebar.css` were outside the design system palette:

| Before | After |
|---|---|
| `background: #34d399` (Tailwind green-400) on shared-project dot | `var(--color-success)` — new `#2d8f6a` token added to `global.css` |
| `rgba(239, 68, 68, 0.1/0.3)` on delete confirm box | `color-mix(in srgb, var(--color-danger) 10/30%, transparent)` |
| `background: #991b1b` on delete button hover | `opacity: 0.85` (same pattern as `.modal-btn-danger`) |

`--color-success` is placed in the Semantic section of `global.css` alongside `--color-danger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)