### PR TITLE
Fix db:export to find vault via vault.json

### DIFF
--- a/scripts/export-plain-db.js
+++ b/scripts/export-plain-db.js
@@ -69,10 +69,25 @@ function validateOutputPath(p) {
   return p;
 }
 
-async function main() {
+function getVaultPaths() {
   const userData = getUserDataPath();
-  const dbPath = path.join(userData, 'sourcerer.db');
-  const saltPath = path.join(userData, 'sourcerer.salt');
+  try {
+    const config = JSON.parse(fs.readFileSync(path.join(userData, 'vault.json'), 'utf8'));
+    if (typeof config?.bundlePath === 'string' && config.bundlePath.length > 0) {
+      return {
+        dbPath: path.join(config.bundlePath, 'db.sqlite'),
+        saltPath: path.join(config.bundlePath, 'salt'),
+      };
+    }
+  } catch { /* no vault.json — fall through to legacy paths */ }
+  return {
+    dbPath: path.join(userData, 'sourcerer.db'),
+    saltPath: path.join(userData, 'sourcerer.salt'),
+  };
+}
+
+async function main() {
+  const { dbPath, saltPath } = getVaultPaths();
   const outPath = validateOutputPath(path.resolve(process.argv[2] || 'sourcerer-plain.db'));
 
   if (!fs.existsSync(dbPath)) {


### PR DESCRIPTION
The `npm run db:export` script was hardcoded to look for `sourcerer.db` and `sourcerer.salt` in the Electron userData directory. Since the vault was made portable (stored as a `Vault.sourcerer` bundle anywhere the user chooses), the script would always fail with "Database not found."

Fix: read `vault.json` from userData first to get the `bundlePath`, then derive `db.sqlite` and `salt` from that. Falls back to the legacy paths if `vault.json` is absent (e.g. fresh installs that haven't moved the vault yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)