### PR TITLE
Migrate AddContactModal to shared Modal component

### DIFF
--- a/src/renderer/src/contacts/AddContactModal.css
+++ b/src/renderer/src/contacts/AddContactModal.css
@@ -1,53 +1,22 @@
-.ac-card {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 0;
+.ac-add-contact {
   width: 480px;
   max-height: 88vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+  padding: 0;
 }
 
-.ac-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+.ac-add-contact .modal-title {
   padding: 18px 20px 14px;
+  margin-bottom: 0;
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
 }
 
-.ac-title {
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--color-text);
-}
-
-.ac-close {
-  background: none;
-  border: none;
-  font-size: 20px;
-  color: var(--color-text-muted);
-  cursor: pointer;
-  padding: 0 4px;
-  line-height: 1;
-}
-
-.ac-close:hover {
-  color: var(--color-text);
-}
-
 .ac-form {
   overflow-y: auto;
+  flex: 1;
   padding: 16px 20px 20px;
-}
-
-.ac-description {
-  font-size: 13px;
-  color: var(--color-text-muted);
-  margin-bottom: 16px;
-  line-height: 1.5;
 }
 
 .ac-expand-toggle {

--- a/src/renderer/src/contacts/AddContactModal.tsx
+++ b/src/renderer/src/contacts/AddContactModal.tsx
@@ -11,7 +11,7 @@ import {
   normalizePhoneForComparison,
   findDuplicates,
 } from './contactValidation';
-import '../shell/Modal.css';
+import Modal from '../shell/Modal';
 import './AddContactModal.css';
 
 interface Props {
@@ -82,12 +82,6 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
   const formRef = useRef<HTMLFormElement>(null);
   const projectInputRef = useRef<HTMLInputElement>(null);
   const projectWrapRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onCancel(); };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onCancel]);
 
   useEffect(() => {
     window.sourcerer.listProjects().then(setProjects);
@@ -191,18 +185,9 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
   }
 
   return (
-    <div
-      className="modal-overlay"
-      onMouseDown={(e) => { if (e.target === e.currentTarget) onCancel(); }}
-    >
-      <div className="ac-card">
-        <div className="ac-header">
-          <h2 className="ac-title">Add Contact</h2>
-          <button className="ac-close" onClick={onCancel}>×</button>
-        </div>
-
-        <form ref={formRef} onSubmit={handleSubmit} className="ac-form">
-          <p className="ac-description">Only a name is required — everything else can be filled in later.</p>
+    <Modal title="Add contact" onDismiss={onCancel} className="ac-add-contact">
+      <form ref={formRef} onSubmit={handleSubmit} className="ac-form">
+        <p className="modal-description">Only a name is required — everything else can be filled in later.</p>
 
           <div className="ac-field">
             <label htmlFor="ac-name" className="modal-label">
@@ -572,8 +557,7 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
               {submitting ? 'Saving…' : 'Add contact'}
             </Button>
           </div>
-        </form>
-      </div>
-    </div>
+      </form>
+    </Modal>
   );
 }


### PR DESCRIPTION
Closes #135

## Summary

- Replaces the hand-rolled `modal-overlay` / `ac-card` / `ac-header` scaffold with `<Modal>`
- Removes the manual `document.addEventListener('keydown', …)` Escape handler — `Modal` centralises this
- Gains focus trap, ARIA semantics (`role="dialog"`, `aria-modal`, `aria-labelledby`), entry/exit animation, and focus restoration
- Renames `ac-description` → `modal-description` per the design system
- Lowers case on the modal title: "Add Contact" → "Add contact"
- `ac-add-contact` CSS override sets the wider width (480px), max-height, flex column layout, and zero padding so `ac-form` can continue managing its own scroll and padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)