### PR TITLE
Fix border-radius and duplicate CSS declaration violations

### DIFF
--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -595,7 +595,6 @@
   border-bottom: 1px solid var(--color-border);
   font-size: 11px;
   font-family: var(--font-mono);
-  letter-spacing: 0.14em;
   letter-spacing: normal;
   color: var(--color-text);
   cursor: pointer;
@@ -731,7 +730,7 @@
   text-transform: uppercase;
   color: var(--color-text-muted);
   background: var(--color-border);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0px 4px;
 }
 
@@ -1513,7 +1512,7 @@
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
-  border-radius: 4px;
+  border-radius: 0;
   display: block;
   user-select: none;
   -webkit-user-drag: none;

--- a/src/renderer/src/global.css
+++ b/src/renderer/src/global.css
@@ -150,7 +150,7 @@ body {
 
 ::-webkit-scrollbar-thumb {
   background: transparent;
-  border-radius: 3px;
+  border-radius: 0;
   transition: background 0.2s;
 }
 
@@ -186,7 +186,7 @@ code {
   font-family: var(--font-mono);
   background: var(--color-surface-2);
   padding: 2px 4px;
-  border-radius: 2px;
+  border-radius: 0;
   margin: 0 2px;
   font-size: 12px;
 }

--- a/src/renderer/src/views/RemindersView.css
+++ b/src/renderer/src/views/RemindersView.css
@@ -247,7 +247,7 @@
   font-size: 10px;
   letter-spacing: 0.10em;
   text-transform: uppercase;
-  border-radius: 3px;
+  border-radius: 0;
   padding: 1px 4px;
   color: var(--color-text-muted);
   background: var(--color-surface-2);


### PR DESCRIPTION
## Summary
- Remove `border-radius` from project badge, screenshot viewer image, scrollbar thumb, and code element — all must be `0` per design system rules (#247, #286, #289, #306, #319)
- Remove duplicate `letter-spacing` declaration in `.pt-reporter-option` (#251)

Closes #247, #251, #286, #289, #306, #319