### PR TITLE
Fix four security bugs in preload, linkify, and shared types

### DIFF
--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -1,7 +1,7 @@
 import { ipcMain, BrowserWindow } from 'electron';
 import { getDatabase } from '../database';
 import { autoLock } from '../auto-lock';
-import type { User } from '@shared/types';
+import { getSafeUser } from './settings';
 
 export function registerAppHandlers(): void {
   ipcMain.handle('app:expand-for-setup', (event): void => {
@@ -13,18 +13,9 @@ export function registerAppHandlers(): void {
     autoLock.lock();
   });
 
-  ipcMain.handle('app:get-user', (): User => {
+  ipcMain.handle('app:get-user', (): ReturnType<typeof getSafeUser> => {
     // calendar_token is a sensitive secret; it is exposed only via the dedicated
     // settings:get-calendar-url handler which constructs the full URL server-side.
-    return getDatabase()
-      .prepare(
-        `SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
-                phone_country, outreach_reminders_enabled, outreach_require_interaction,
-                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
-                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
-                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured
-         FROM users WHERE id = 1`,
-      )
-      .get() as User;
+    return getSafeUser(getDatabase());
   });
 }

--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -22,7 +22,7 @@ export function registerAppHandlers(): void {
                 phone_country, outreach_reminders_enabled, outreach_require_interaction,
                 staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
                 reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
-                archive_access_key, archive_secret_key
+                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured
          FROM users WHERE id = 1`,
       )
       .get() as User;

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -47,7 +47,13 @@ export function registerSettingsHandlers(): void {
         }
       })();
 
-      return db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
+      return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
+                phone_country, outreach_reminders_enabled, outreach_require_interaction,
+                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
+                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
+                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
+                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
+         FROM users WHERE id = 1`).get() as User;
     },
   );
 
@@ -69,25 +75,49 @@ export function registerSettingsHandlers(): void {
   ipcMain.handle('settings:set-staleness-enabled', (_, enabled: boolean): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET staleness_enabled = ? WHERE id = 1').run(enabled ? 1 : 0);
-    return db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
+    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
+                phone_country, outreach_reminders_enabled, outreach_require_interaction,
+                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
+                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
+                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
+                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
+         FROM users WHERE id = 1`).get() as User;
   });
 
   ipcMain.handle('settings:set-staleness-threshold', (_, days: number): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET staleness_threshold_days = ? WHERE id = 1').run(Math.max(1, days));
-    return db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
+    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
+                phone_country, outreach_reminders_enabled, outreach_require_interaction,
+                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
+                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
+                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
+                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
+         FROM users WHERE id = 1`).get() as User;
   });
 
   ipcMain.handle('settings:set-outreach-reminders-enabled', (_, enabled: boolean): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET outreach_reminders_enabled = ? WHERE id = 1').run(enabled ? 1 : 0);
-    return db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
+    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
+                phone_country, outreach_reminders_enabled, outreach_require_interaction,
+                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
+                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
+                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
+                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
+         FROM users WHERE id = 1`).get() as User;
   });
 
   ipcMain.handle('settings:set-outreach-require-interaction', (_, required: boolean): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET outreach_require_interaction = ? WHERE id = 1').run(required ? 1 : 0);
-    return db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
+    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
+                phone_country, outreach_reminders_enabled, outreach_require_interaction,
+                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
+                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
+                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
+                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
+         FROM users WHERE id = 1`).get() as User;
   });
 
   ipcMain.handle('settings:set-rss-poll-interval', (_, hours: number): User => {
@@ -95,7 +125,13 @@ export function registerSettingsHandlers(): void {
     const clamped = Math.max(1, Math.floor(hours));
     db.prepare('UPDATE users SET rss_poll_interval_hours = ? WHERE id = 1').run(clamped);
     setRssPollIntervalHours(clamped);
-    return db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
+    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
+                phone_country, outreach_reminders_enabled, outreach_require_interaction,
+                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
+                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
+                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
+                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
+         FROM users WHERE id = 1`).get() as User;
   });
 
   ipcMain.handle(
@@ -110,25 +146,49 @@ export function registerSettingsHandlers(): void {
   ipcMain.handle('settings:set-alert-notifications-enabled', (_, enabled: boolean): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET alert_notifications_enabled = ? WHERE id = 1').run(enabled ? 1 : 0);
-    return db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
+    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
+                phone_country, outreach_reminders_enabled, outreach_require_interaction,
+                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
+                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
+                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
+                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
+         FROM users WHERE id = 1`).get() as User;
   });
 
   ipcMain.handle('settings:set-reminder-notifications-enabled', (_, enabled: boolean): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET reminder_notifications_enabled = ? WHERE id = 1').run(enabled ? 1 : 0);
-    return db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
+    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
+                phone_country, outreach_reminders_enabled, outreach_require_interaction,
+                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
+                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
+                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
+                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
+         FROM users WHERE id = 1`).get() as User;
   });
 
   ipcMain.handle('settings:set-phone-country', (_, country: string): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET phone_country = ? WHERE id = 1').run(country);
-    return db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
+    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
+                phone_country, outreach_reminders_enabled, outreach_require_interaction,
+                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
+                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
+                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
+                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
+         FROM users WHERE id = 1`).get() as User;
   });
 
   ipcMain.handle('settings:set-wayback-enabled', (_, enabled: boolean): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET wayback_enabled = ? WHERE id = 1').run(enabled ? 1 : 0);
-    return db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
+    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
+                phone_country, outreach_reminders_enabled, outreach_require_interaction,
+                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
+                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
+                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
+                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
+         FROM users WHERE id = 1`).get() as User;
   });
 
   ipcMain.handle('settings:set-archive-keys', (_, { accessKey, secretKey }: { accessKey: string; secretKey: string }): User => {
@@ -138,7 +198,13 @@ export function registerSettingsHandlers(): void {
     const db = getDatabase();
     db.prepare('UPDATE users SET archive_access_key = ?, archive_secret_key = ? WHERE id = 1')
       .run(accessKey.trim() || null, secretKey.trim() || null);
-    return db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
+    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
+                phone_country, outreach_reminders_enabled, outreach_require_interaction,
+                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
+                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
+                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
+                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
+         FROM users WHERE id = 1`).get() as User;
   });
 
   ipcMain.handle(
@@ -212,7 +278,8 @@ export function registerSettingsHandlers(): void {
                 phone_country, outreach_reminders_enabled, outreach_require_interaction,
                 staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
                 reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
-                archive_access_key, archive_secret_key
+                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
+                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
          FROM users WHERE id = 1`,
       )
       .get() as User;

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -11,6 +11,19 @@ import { setRssPollIntervalHours } from '../sync/poller';
 import { validateEmail } from '@shared/validation';
 import type { User } from '@shared/types';
 
+const SAFE_USER_SQL = `
+  SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
+         phone_country, outreach_reminders_enabled, outreach_require_interaction,
+         staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
+         reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
+         CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
+         auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
+  FROM users WHERE id = 1`;
+
+export function getSafeUser(db: Database.Database): User {
+  return db.prepare(SAFE_USER_SQL).get() as User;
+}
+
 export function registerSettingsHandlers(): void {
   ipcMain.handle(
     'users:update',
@@ -47,13 +60,7 @@ export function registerSettingsHandlers(): void {
         }
       })();
 
-      return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
-                phone_country, outreach_reminders_enabled, outreach_require_interaction,
-                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
-                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
-                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
-                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
-         FROM users WHERE id = 1`).get() as User;
+      return getSafeUser(db);
     },
   );
 
@@ -75,49 +82,25 @@ export function registerSettingsHandlers(): void {
   ipcMain.handle('settings:set-staleness-enabled', (_, enabled: boolean): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET staleness_enabled = ? WHERE id = 1').run(enabled ? 1 : 0);
-    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
-                phone_country, outreach_reminders_enabled, outreach_require_interaction,
-                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
-                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
-                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
-                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
-         FROM users WHERE id = 1`).get() as User;
+    return getSafeUser(db);
   });
 
   ipcMain.handle('settings:set-staleness-threshold', (_, days: number): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET staleness_threshold_days = ? WHERE id = 1').run(Math.max(1, days));
-    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
-                phone_country, outreach_reminders_enabled, outreach_require_interaction,
-                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
-                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
-                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
-                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
-         FROM users WHERE id = 1`).get() as User;
+    return getSafeUser(db);
   });
 
   ipcMain.handle('settings:set-outreach-reminders-enabled', (_, enabled: boolean): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET outreach_reminders_enabled = ? WHERE id = 1').run(enabled ? 1 : 0);
-    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
-                phone_country, outreach_reminders_enabled, outreach_require_interaction,
-                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
-                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
-                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
-                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
-         FROM users WHERE id = 1`).get() as User;
+    return getSafeUser(db);
   });
 
   ipcMain.handle('settings:set-outreach-require-interaction', (_, required: boolean): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET outreach_require_interaction = ? WHERE id = 1').run(required ? 1 : 0);
-    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
-                phone_country, outreach_reminders_enabled, outreach_require_interaction,
-                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
-                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
-                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
-                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
-         FROM users WHERE id = 1`).get() as User;
+    return getSafeUser(db);
   });
 
   ipcMain.handle('settings:set-rss-poll-interval', (_, hours: number): User => {
@@ -125,13 +108,7 @@ export function registerSettingsHandlers(): void {
     const clamped = Math.max(1, Math.floor(hours));
     db.prepare('UPDATE users SET rss_poll_interval_hours = ? WHERE id = 1').run(clamped);
     setRssPollIntervalHours(clamped);
-    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
-                phone_country, outreach_reminders_enabled, outreach_require_interaction,
-                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
-                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
-                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
-                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
-         FROM users WHERE id = 1`).get() as User;
+    return getSafeUser(db);
   });
 
   ipcMain.handle(
@@ -146,49 +123,25 @@ export function registerSettingsHandlers(): void {
   ipcMain.handle('settings:set-alert-notifications-enabled', (_, enabled: boolean): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET alert_notifications_enabled = ? WHERE id = 1').run(enabled ? 1 : 0);
-    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
-                phone_country, outreach_reminders_enabled, outreach_require_interaction,
-                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
-                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
-                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
-                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
-         FROM users WHERE id = 1`).get() as User;
+    return getSafeUser(db);
   });
 
   ipcMain.handle('settings:set-reminder-notifications-enabled', (_, enabled: boolean): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET reminder_notifications_enabled = ? WHERE id = 1').run(enabled ? 1 : 0);
-    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
-                phone_country, outreach_reminders_enabled, outreach_require_interaction,
-                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
-                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
-                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
-                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
-         FROM users WHERE id = 1`).get() as User;
+    return getSafeUser(db);
   });
 
   ipcMain.handle('settings:set-phone-country', (_, country: string): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET phone_country = ? WHERE id = 1').run(country);
-    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
-                phone_country, outreach_reminders_enabled, outreach_require_interaction,
-                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
-                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
-                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
-                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
-         FROM users WHERE id = 1`).get() as User;
+    return getSafeUser(db);
   });
 
   ipcMain.handle('settings:set-wayback-enabled', (_, enabled: boolean): User => {
     const db = getDatabase();
     db.prepare('UPDATE users SET wayback_enabled = ? WHERE id = 1').run(enabled ? 1 : 0);
-    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
-                phone_country, outreach_reminders_enabled, outreach_require_interaction,
-                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
-                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
-                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
-                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
-         FROM users WHERE id = 1`).get() as User;
+    return getSafeUser(db);
   });
 
   ipcMain.handle('settings:set-archive-keys', (_, { accessKey, secretKey }: { accessKey: string; secretKey: string }): User => {
@@ -198,13 +151,7 @@ export function registerSettingsHandlers(): void {
     const db = getDatabase();
     db.prepare('UPDATE users SET archive_access_key = ?, archive_secret_key = ? WHERE id = 1')
       .run(accessKey.trim() || null, secretKey.trim() || null);
-    return db.prepare(`SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
-                phone_country, outreach_reminders_enabled, outreach_require_interaction,
-                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
-                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
-                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
-                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
-         FROM users WHERE id = 1`).get() as User;
+    return getSafeUser(db);
   });
 
   ipcMain.handle(
@@ -272,17 +219,7 @@ export function registerSettingsHandlers(): void {
     const db = getDatabase();
     const token = uuidv4();
     db.prepare('UPDATE users SET calendar_token = ? WHERE id = 1').run(token);
-    return db
-      .prepare(
-        `SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
-                phone_country, outreach_reminders_enabled, outreach_require_interaction,
-                staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
-                reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
-                CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
-                auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
-         FROM users WHERE id = 1`,
-      )
-      .get() as User;
+    return getSafeUser(db);
   });
 
   ipcMain.handle('settings:get-vault-path', (): string => {

--- a/src/main/ipc/updater.ts
+++ b/src/main/ipc/updater.ts
@@ -201,12 +201,11 @@ export function registerUpdaterHandlers(): void {
     }
   });
   ipcMain.handle('update:get-state', () => cachedUpdateInfo);
-  ipcMain.handle('update:show-error', (_event, message: string) => {
+  ipcMain.handle('update:show-error', () => {
     return dialog.showMessageBox({
       type: 'error',
       title: 'Update failed',
       message: 'The update could not be downloaded. Please try again.',
-      detail: message,
     });
   });
 

--- a/src/main/ipc/updater.ts
+++ b/src/main/ipc/updater.ts
@@ -83,12 +83,11 @@ export function registerUpdaterHandlers(): void {
       cachedUpdateInfo = { event: 'available', version: '99.0.0' };
       sendToWindow('update:available', { version: '99.0.0' });
     });
-    ipcMain.handle('update:show-error', (_event, message: string) => {
+    ipcMain.handle('update:show-error', () => {
       return dialog.showMessageBox({
         type: 'error',
         title: 'Update failed',
-        message: 'The update could not be downloaded. Please try again.',
-        detail: message,
+        message: 'An update error occurred. Please restart the app and try again.',
       });
     });
     return;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
+import { is } from '@electron-toolkit/utils';
 import type {
   SetupFormData,
   SetupResult,
@@ -395,10 +396,10 @@ const sourcererApi = {
   },
   downloadUpdate: (): Promise<void> => ipcRenderer.invoke('update:download'),
   quitAndInstall: (): Promise<void> => ipcRenderer.invoke('update:quit-and-install'),
-  simulateUpdate: (): Promise<void> => ipcRenderer.invoke('update:dev-simulate'),
+  ...(is.dev ? { simulateUpdate: (): Promise<void> => ipcRenderer.invoke('update:dev-simulate') } : {}),
   getUpdateState: (): Promise<{ event: 'available' | 'downloading' | 'downloaded'; version: string; percent?: number } | null> =>
     ipcRenderer.invoke('update:get-state'),
-  showUpdateError: (message: string): Promise<void> => ipcRenderer.invoke('update:show-error', message),
+  showUpdateError: (): Promise<void> => ipcRenderer.invoke('update:show-error'),
 };
 
 contextBridge.exposeInMainWorld('sourcerer', sourcererApi);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,4 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { is } from '@electron-toolkit/utils';
 import type {
   SetupFormData,
   SetupResult,
@@ -396,7 +395,7 @@ const sourcererApi = {
   },
   downloadUpdate: (): Promise<void> => ipcRenderer.invoke('update:download'),
   quitAndInstall: (): Promise<void> => ipcRenderer.invoke('update:quit-and-install'),
-  ...(is.dev ? { simulateUpdate: (): Promise<void> => ipcRenderer.invoke('update:dev-simulate') } : {}),
+  ...(process.env.NODE_ENV === 'development' ? { simulateUpdate: (): Promise<void> => ipcRenderer.invoke('update:dev-simulate') } : {}),
   getUpdateState: (): Promise<{ event: 'available' | 'downloading' | 'downloaded'; version: string; percent?: number } | null> =>
     ipcRenderer.invoke('update:get-state'),
   showUpdateError: (): Promise<void> => ipcRenderer.invoke('update:show-error'),

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -595,7 +595,6 @@
   border-bottom: 1px solid var(--color-border);
   font-size: 11px;
   font-family: var(--font-mono);
-  letter-spacing: 0.14em;
   letter-spacing: normal;
   color: var(--color-text);
   cursor: pointer;
@@ -731,7 +730,7 @@
   text-transform: uppercase;
   color: var(--color-text-muted);
   background: var(--color-border);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0px 4px;
 }
 
@@ -1513,7 +1512,7 @@
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
-  border-radius: 4px;
+  border-radius: 0;
   display: block;
   user-select: none;
   -webkit-user-drag: none;

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -679,7 +679,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                 })
             )}
           />
-          {user?.wayback_enabled !== 0 && user?.wayback_keys_configured && (
+          {user?.wayback_enabled !== 0 && user?.wayback_keys_configured !== 0 && (
             <p className="ac-field-hint">Wayback Machine archiving is enabled.</p>
           )}
         </div>
@@ -796,10 +796,10 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                   archived ↗
                 </a>
               )}
-              {!l.wayback_url && user?.wayback_enabled !== 0 && user?.wayback_keys_configured && waybackStatus.get(l.url) === 'pending' && (
+              {!l.wayback_url && user?.wayback_enabled !== 0 && user?.wayback_keys_configured !== 0 && waybackStatus.get(l.url) === 'pending' && (
                 <span className="detail-wayback-pending">archiving…</span>
               )}
-              {!l.wayback_url && user?.wayback_enabled !== 0 && user?.wayback_keys_configured && waybackStatus.get(l.url) === 'failed' && (
+              {!l.wayback_url && user?.wayback_enabled !== 0 && user?.wayback_keys_configured !== 0 && waybackStatus.get(l.url) === 'failed' && (
                 <span className="detail-wayback-failed" title="Wayback Machine could not archive this URL">archive failed</span>
               )}
             </div>

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -679,7 +679,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                 })
             )}
           />
-          {user?.wayback_enabled !== 0 && user?.archive_access_key && user?.archive_secret_key && (
+          {user?.wayback_enabled !== 0 && user?.wayback_keys_configured && (
             <p className="ac-field-hint">Wayback Machine archiving is enabled.</p>
           )}
         </div>
@@ -796,10 +796,10 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                   archived ↗
                 </a>
               )}
-              {!l.wayback_url && user?.wayback_enabled !== 0 && user?.archive_access_key && user?.archive_secret_key && waybackStatus.get(l.url) === 'pending' && (
+              {!l.wayback_url && user?.wayback_enabled !== 0 && user?.wayback_keys_configured && waybackStatus.get(l.url) === 'pending' && (
                 <span className="detail-wayback-pending">archiving…</span>
               )}
-              {!l.wayback_url && user?.wayback_enabled !== 0 && user?.archive_access_key && user?.archive_secret_key && waybackStatus.get(l.url) === 'failed' && (
+              {!l.wayback_url && user?.wayback_enabled !== 0 && user?.wayback_keys_configured && waybackStatus.get(l.url) === 'failed' && (
                 <span className="detail-wayback-failed" title="Wayback Machine could not archive this URL">archive failed</span>
               )}
             </div>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -246,9 +246,9 @@ declare global {
       onUpdateError: (callback: (info: { message: string }) => void) => () => void;
       downloadUpdate: () => Promise<void>;
       quitAndInstall: () => Promise<void>;
-      simulateUpdate: () => Promise<void>;
+      simulateUpdate?: () => Promise<void>;
       getUpdateState: () => Promise<{ event: 'available' | 'downloading' | 'downloaded'; version: string; percent?: number } | null>;
-      showUpdateError: (message: string) => Promise<void>;
+      showUpdateError: () => Promise<void>;
     };
   }
 }

--- a/src/renderer/src/global.css
+++ b/src/renderer/src/global.css
@@ -150,7 +150,7 @@ body {
 
 ::-webkit-scrollbar-thumb {
   background: transparent;
-  border-radius: 3px;
+  border-radius: 0;
   transition: background 0.2s;
 }
 
@@ -186,7 +186,7 @@ code {
   font-family: var(--font-mono);
   background: var(--color-surface-2);
   padding: 2px 4px;
-  border-radius: 2px;
+  border-radius: 0;
   margin: 0 2px;
   font-size: 12px;
 }

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -121,13 +121,13 @@ export default function AppShell() {
       setUpdateVersion(version);
       setUpdateState('ready');
     });
-    const offError = window.sourcerer.onUpdateError(({ message }) => {
+    const offError = window.sourcerer.onUpdateError(() => {
       // update:error is only sent for download-phase failures (check errors are handled
       // by the main process directly). Revert to 'available' if we were downloading or
       // ready (a post-download verification error), then show a main-process dialog.
       if (updateStateRef.current === 'downloading' || updateStateRef.current === 'ready') {
         setUpdateState('available');
-        window.sourcerer.showUpdateError(message);
+        window.sourcerer.showUpdateError();
       }
     });
     // Replay any update event that fired before AppShell mounted (e.g. the
@@ -223,8 +223,7 @@ export default function AppShell() {
                 } catch (err) {
                   setUpdatePercent(null);
                   setUpdateState('available');
-                  const message = err instanceof Error ? err.message : String(err);
-                  window.sourcerer.showUpdateError(message);
+                  window.sourcerer.showUpdateError();
                 }
               }}
             >

--- a/src/renderer/src/utils/linkify.tsx
+++ b/src/renderer/src/utils/linkify.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 const URL_PATTERN = /https?:\/\/[^\s<>"',;]+/g;
 
-function safeOpen(url: string): void {
+export function safeOpen(url: string): void {
   try {
     const parsed = new URL(url);
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return;

--- a/src/renderer/src/utils/linkify.tsx
+++ b/src/renderer/src/utils/linkify.tsx
@@ -2,6 +2,16 @@ import type { ReactNode } from 'react';
 
 const URL_PATTERN = /https?:\/\/[^\s<>"',;]+/g;
 
+function safeOpen(url: string): void {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return;
+    window.open(url, '_blank', 'noopener,noreferrer');
+  } catch {
+    // invalid URL — do nothing
+  }
+}
+
 function trimTrailing(url: string): string {
   return url.replace(/[.,;:!?)\]]+$/, '');
 }
@@ -19,7 +29,7 @@ export function linkifyText(text: string): ReactNode[] {
         key={match.index}
         href={url}
         className="notes-link"
-        onClick={(e) => { e.preventDefault(); window.open(url); }}
+        onClick={(e) => { e.preventDefault(); safeOpen(url); }}
       >
         {url}
       </a>

--- a/src/renderer/src/views/RemindersView.css
+++ b/src/renderer/src/views/RemindersView.css
@@ -247,7 +247,7 @@
   font-size: 10px;
   letter-spacing: 0.10em;
   text-transform: uppercase;
-  border-radius: 3px;
+  border-radius: 0;
   padding: 1px 4px;
   color: var(--color-text-muted);
   background: var(--color-surface-2);

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -131,8 +131,6 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
       setStalenessThresholdInput(String(user.staleness_threshold_days ?? 90));
       setRssPollIntervalHours(user.rss_poll_interval_hours ?? 6);
       setWaybackEnabled(user.wayback_enabled !== 0);
-      setArchiveAccessKey(user.archive_access_key ?? '');
-      setArchiveSecretKey(user.archive_secret_key ?? '');
     }
     window.sourcerer.getIdleTimeout().then(setIdleTimeout);
     window.sourcerer.getCalendarUrl().then(setCalendarUrl);

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -663,7 +663,7 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
                 disabled={!waybackEnabled}
               />
             </div>
-            <Button variant="accent" size="sm" onClick={handleArchiveKeysSave} disabled={!waybackEnabled}>
+            <Button variant="accent" size="sm" onClick={handleArchiveKeysSave} disabled={!waybackEnabled || !archiveAccessKey.trim() || !archiveSecretKey.trim()}>
               Save keys
             </Button>
           </div>

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -646,6 +646,7 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
                 type="password"
                 value={archiveAccessKey}
                 onChange={(e) => setArchiveAccessKey(e.target.value)}
+                placeholder={user?.wayback_keys_configured !== 0 ? 'saved — enter to replace' : ''}
                 autoComplete="new-password"
                 disabled={!waybackEnabled}
               />
@@ -657,6 +658,7 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
                 type="password"
                 value={archiveSecretKey}
                 onChange={(e) => setArchiveSecretKey(e.target.value)}
+                placeholder={user?.wayback_keys_configured !== 0 ? 'saved — enter to replace' : ''}
                 autoComplete="new-password"
                 disabled={!waybackEnabled}
               />
@@ -667,6 +669,9 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
           </div>
           {archiveKeysSaved && (
             <p className="sv-success">Keys saved.</p>
+          )}
+          {!archiveKeysSaved && waybackEnabled && user?.wayback_keys_configured === 0 && (
+            <p className="sv-error">No keys saved — archiving won&apos;t work until you add and save your keys.</p>
           )}
           <p className="sv-hint sv-hint--top">
             Required for Wayback Machine submissions. Get your keys at{' '}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -66,8 +66,7 @@ export interface User {
   reminder_notifications_enabled: 0 | 1;
   rss_poll_interval_hours: number;
   wayback_enabled: 0 | 1;
-  archive_access_key: string | null;
-  archive_secret_key: string | null;
+  wayback_keys_configured: 0 | 1;
   auto_backup_enabled: 0 | 1;
   auto_backup_dest_path: string | null;
   auto_backup_max_count: number;

--- a/src/test/linkify.test.ts
+++ b/src/test/linkify.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { isValidElement, type ReactElement } from 'react';
-import { linkifyText } from '../renderer/src/utils/linkify';
+import { linkifyText, safeOpen } from '../renderer/src/utils/linkify';
 
 function isLink(node: unknown): node is ReactElement {
   return isValidElement(node) && (node as ReactElement).type === 'a';
@@ -81,5 +81,39 @@ describe('linkifyText', () => {
   it('uses the URL as anchor text', () => {
     const result = linkifyText('https://example.com/path');
     expect((result[0] as ReactElement<{ children: string }>).props.children).toBe('https://example.com/path');
+  });
+});
+
+describe('safeOpen', () => {
+  let openMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    openMock = vi.fn();
+    vi.stubGlobal('window', { open: openMock });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('opens http URLs with _blank and noopener,noreferrer', () => {
+    safeOpen('http://example.com');
+    expect(openMock).toHaveBeenCalledWith('http://example.com', '_blank', 'noopener,noreferrer');
+  });
+
+  it('opens https URLs with _blank and noopener,noreferrer', () => {
+    safeOpen('https://example.com/path?q=1');
+    expect(openMock).toHaveBeenCalledWith('https://example.com/path?q=1', '_blank', 'noopener,noreferrer');
+  });
+
+  it('does not open non-http(s) URLs', () => {
+    safeOpen('javascript:alert(1)');
+    safeOpen('ftp://files.example.com');
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  it('does not open malformed URLs', () => {
+    safeOpen('not a url at all');
+    expect(openMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Gate \`simulateUpdate\` preload exposure behind \`is.dev\` — was reachable in production builds (#245)
- Replace renderer-controlled message string in update error dialog with hardcoded text — prevents social engineering via compromised renderer (#250)
- Add \`noopener,noreferrer\` and \`http\`/\`https\`-only scheme check to \`window.open\` calls in \`linkify.tsx\` (#252)
- Remove \`archive_access_key\` and \`archive_secret_key\` from the \`User\` type and from the SELECT query that sends the user object to the renderer (#312)

Closes #245, #250, #252, #312