### PR TITLE
Fix file operation safety: temp-file writes and operation ordering

### DIFF
--- a/src/main/ipc/auto-backup.ts
+++ b/src/main/ipc/auto-backup.ts
@@ -1,5 +1,7 @@
 import { ipcMain } from 'electron';
 import fs from 'fs/promises';
+import { rename, unlink } from 'fs/promises';
+import { randomBytes } from 'crypto';
 import path from 'path';
 import { getPaths } from '../utils';
 import { getDatabase, isDatabaseOpen, getPassword } from '../database';
@@ -33,7 +35,14 @@ export async function runAutoBackup(): Promise<{ success: boolean; error?: strin
 
     const { dbPath, saltPath, screenshotsPath } = getPaths();
     const outPath = path.join(destPath, timestampedName());
-    await writeBackupFile(createBackupEntries(dbPath, saltPath, screenshotsPath), outPath, getPassword());
+    const tmpPath = path.join(destPath, `.tmp-${randomBytes(8).toString('hex')}`);
+    try {
+      await writeBackupFile(createBackupEntries(dbPath, saltPath, screenshotsPath), tmpPath, getPassword());
+      await rename(tmpPath, outPath);
+    } catch (err) {
+      await unlink(tmpPath).catch(() => {});
+      throw err;
+    }
 
     // Prune old backups beyond maxCount
     const allFiles = await fs.readdir(destPath);

--- a/src/main/ipc/export.ts
+++ b/src/main/ipc/export.ts
@@ -1,6 +1,8 @@
 import { ipcMain, dialog, BrowserWindow } from 'electron';
 import { promises as fs } from 'fs';
+import { rename, unlink } from 'fs/promises';
 import ExcelJS from 'exceljs';
+import path from 'path';
 import { getDatabase } from '../database';
 import { filenameDateStamp } from '../utils';
 
@@ -214,6 +216,7 @@ export function registerExportHandlers(): void {
         });
       }
 
+      const tmpPath = path.join(path.dirname(filePath), '.tmp-export-' + Date.now());
       try {
         const wb = new ExcelJS.Workbook();
         const ws = wb.addWorksheet('Contacts');
@@ -222,12 +225,14 @@ export function registerExportHandlers(): void {
         }
         ws.addRows(rows);
         if (isXlsx) {
-          await wb.xlsx.writeFile(filePath);
+          await wb.xlsx.writeFile(tmpPath);
         } else {
-          await wb.csv.writeFile(filePath);
+          await wb.csv.writeFile(tmpPath);
         }
+        await rename(tmpPath, filePath);
         return { success: true };
       } catch (err) {
+        await unlink(tmpPath).catch(() => {});
         return { success: false, error: String(err) };
       }
     },
@@ -317,6 +322,7 @@ export function registerExportHandlers(): void {
         };
       });
 
+      const tmpPath2 = path.join(path.dirname(filePath), '.tmp-export-' + Date.now());
       try {
         const wb = new ExcelJS.Workbook();
         const ws = wb.addWorksheet('Contacts');
@@ -325,12 +331,14 @@ export function registerExportHandlers(): void {
         }
         ws.addRows(rows);
         if (isXlsx) {
-          await wb.xlsx.writeFile(filePath);
+          await wb.xlsx.writeFile(tmpPath2);
         } else {
-          await wb.csv.writeFile(filePath);
+          await wb.csv.writeFile(tmpPath2);
         }
+        await rename(tmpPath2, filePath);
         return { success: true };
       } catch (err) {
+        await unlink(tmpPath2).catch(() => {});
         return { success: false, error: String(err) };
       }
     },

--- a/src/main/ipc/export.ts
+++ b/src/main/ipc/export.ts
@@ -1,10 +1,26 @@
 import { ipcMain, dialog, BrowserWindow } from 'electron';
+import { randomUUID } from 'crypto';
 import { promises as fs } from 'fs';
 import { rename, unlink } from 'fs/promises';
 import ExcelJS from 'exceljs';
 import path from 'path';
 import { getDatabase } from '../database';
 import { filenameDateStamp } from '../utils';
+
+// rename() on Windows throws EEXIST when the destination already exists.
+// This helper handles that by unlinking the destination and retrying once.
+async function atomicRename(tmpPath: string, destPath: string): Promise<void> {
+  try {
+    await rename(tmpPath, destPath);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      await unlink(destPath);
+      await rename(tmpPath, destPath);
+    } else {
+      throw err;
+    }
+  }
+}
 
 interface ExportRow {
   Name: string;
@@ -216,7 +232,7 @@ export function registerExportHandlers(): void {
         });
       }
 
-      const tmpPath = path.join(path.dirname(filePath), '.tmp-export-' + Date.now());
+      const tmpPath = path.join(path.dirname(filePath), `.tmp-export-${randomUUID()}`);
       try {
         const wb = new ExcelJS.Workbook();
         const ws = wb.addWorksheet('Contacts');
@@ -229,7 +245,7 @@ export function registerExportHandlers(): void {
         } else {
           await wb.csv.writeFile(tmpPath);
         }
-        await rename(tmpPath, filePath);
+        await atomicRename(tmpPath, filePath);
         return { success: true };
       } catch (err) {
         await unlink(tmpPath).catch(() => {});
@@ -322,7 +338,7 @@ export function registerExportHandlers(): void {
         };
       });
 
-      const tmpPath2 = path.join(path.dirname(filePath), '.tmp-export-' + Date.now());
+      const tmpPath2 = path.join(path.dirname(filePath), `.tmp-export-${randomUUID()}`);
       try {
         const wb = new ExcelJS.Workbook();
         const ws = wb.addWorksheet('Contacts');
@@ -335,7 +351,7 @@ export function registerExportHandlers(): void {
         } else {
           await wb.csv.writeFile(tmpPath2);
         }
-        await rename(tmpPath2, filePath);
+        await atomicRename(tmpPath2, filePath);
         return { success: true };
       } catch (err) {
         await unlink(tmpPath2).catch(() => {});

--- a/src/main/ipc/screenshots.ts
+++ b/src/main/ipc/screenshots.ts
@@ -50,6 +50,7 @@ export function registerScreenshotHandlers(): void {
       const entry = consumePendingScreenshot(tempId);
       if (!entry) return { success: false, error: 'Screenshot expired or not found.' };
 
+      let insertedId: string | null = null;
       try {
         const dir = screenshotsDir();
         await fs.mkdir(dir, { recursive: true });
@@ -60,17 +61,25 @@ export function registerScreenshotHandlers(): void {
         const id = randomUUID();
         const fileName = `${id}.enc`;
         const filePath = path.join(dir, fileName);
-        await fs.writeFile(filePath, encrypted);
 
         const db = getDatabase();
-        db.prepare(
-          `INSERT INTO contact_screenshots (id, contact_id, tab_url, file_path, iv, captured_at)
-           VALUES (?, ?, ?, ?, ?, ?)`,
-        ).run(id, contactId, entry.tabUrl, fileName, iv, Math.floor(Date.now() / 1000));
+        db.transaction(() => {
+          db.prepare(
+            `INSERT INTO contact_screenshots (id, contact_id, tab_url, file_path, iv, captured_at)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+          ).run(id, contactId, entry.tabUrl, fileName, iv, Math.floor(Date.now() / 1000));
+        })();
+        insertedId = id;
+
+        await fs.writeFile(filePath, encrypted);
 
         BrowserWindow.getAllWindows()[0]?.webContents.send('screenshots:assigned', contactId);
         return { success: true };
       } catch (err) {
+        if (insertedId) {
+          const db = getDatabase();
+          db.prepare('DELETE FROM contact_screenshots WHERE id = ?').run(insertedId);
+        }
         return { success: false, error: String(err) };
       }
     },
@@ -155,10 +164,12 @@ export function registerScreenshotHandlers(): void {
       const row = db
         .prepare('SELECT file_path FROM contact_screenshots WHERE id = ?')
         .get(screenshotId) as { file_path: string } | undefined;
-      db.prepare('DELETE FROM contact_screenshots WHERE id = ?').run(screenshotId);
       if (row) {
-        await fs.unlink(safeScreenshotPath(row.file_path)).catch(() => {});
+        await fs.unlink(safeScreenshotPath(row.file_path)).catch((err) => {
+          if (err.code !== 'ENOENT') throw err;
+        });
       }
+      db.prepare('DELETE FROM contact_screenshots WHERE id = ?').run(screenshotId);
     },
   );
 

--- a/src/main/ipc/screenshots.ts
+++ b/src/main/ipc/screenshots.ts
@@ -51,6 +51,7 @@ export function registerScreenshotHandlers(): void {
       if (!entry) return { success: false, error: 'Screenshot expired or not found.' };
 
       let insertedId: string | null = null;
+      let fileAttemptedPath: string | null = null;
       try {
         const dir = screenshotsDir();
         await fs.mkdir(dir, { recursive: true });
@@ -71,15 +72,18 @@ export function registerScreenshotHandlers(): void {
         })();
         insertedId = id;
 
+        fileAttemptedPath = filePath;
         await fs.writeFile(filePath, encrypted);
 
         BrowserWindow.getAllWindows()[0]?.webContents.send('screenshots:assigned', contactId);
         return { success: true };
       } catch (err) {
-        if (insertedId) {
-          const db = getDatabase();
-          db.prepare('DELETE FROM contact_screenshots WHERE id = ?').run(insertedId);
-        }
+        try {
+          if (insertedId) getDatabase().prepare('DELETE FROM contact_screenshots WHERE id = ?').run(insertedId);
+        } catch { /* ignore cleanup errors */ }
+        try {
+          if (fileAttemptedPath) await fs.unlink(fileAttemptedPath);
+        } catch { /* ignore cleanup errors */ }
         return { success: false, error: String(err) };
       }
     },


### PR DESCRIPTION
## Summary
- Auto-backup: write to temp file then atomic rename — a crash never leaves a corrupt backup (#190)
- screenshots:assign: DB record inserted before file write; if file write fails the insert is rolled back (#205)
- screenshots:delete: file deleted before DB record; ENOENT treated as non-fatal (#209)
- export:project / export:all-contacts: write to temp then rename so partial exports can't corrupt the destination (#236)

Closes #190, #205, #209, #236