### PR TITLE
Fix RSS permanence bug, SSRF guard gaps, unawaited poll, and FTS catch

### DIFF
--- a/src/main/http-server.ts
+++ b/src/main/http-server.ts
@@ -5,6 +5,25 @@ import { isDatabaseOpen, getDatabase } from './database';
 import { normalizeEmail, normalizePhone, validateEmail, validateUrl, detectLinkType } from './sanitize';
 import { triggerWaybackSave } from './ipc/contacts';
 
+// Hostname patterns blocked to prevent SSRF when validating user-supplied URLs.
+// Covers loopback, private RFC-1918, link-local, CGNAT, and IPv6 equivalents.
+const BLOCKED_PATTERNS = [
+  /^localhost$/i,
+  /^127\.\d+\.\d+\.\d+$/,
+  /^10\.\d+\.\d+\.\d+$/,
+  /^172\.(1[6-9]|2\d|3[01])\.\d+\.\d+$/,
+  /^192\.168\.\d+\.\d+$/,
+  /^169\.254\.\d+\.\d+$/,           // IPv4 link-local
+  /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d+\.\d+$/, // CGNAT (RFC 6598)
+  /^::1$/,                           // IPv6 loopback
+  /^fe80:/i,                         // IPv6 link-local
+  /^::ffff:/i,                       // IPv4-mapped IPv6
+];
+
+export function isBlockedHost(hostname: string): boolean {
+  return BLOCKED_PATTERNS.some((re) => re.test(hostname));
+}
+
 const MAX_SCREENSHOT_BYTES = 50 * 1024 * 1024;
 const MAX_PENDING_SCREENSHOTS = 20;
 const pendingScreenshots = new Map<string, { buf: Buffer; tabUrl: string | null }>();

--- a/src/main/http-server.ts
+++ b/src/main/http-server.ts
@@ -4,25 +4,9 @@ import { app, BrowserWindow } from 'electron';
 import { isDatabaseOpen, getDatabase } from './database';
 import { normalizeEmail, normalizePhone, validateEmail, validateUrl, detectLinkType } from './sanitize';
 import { triggerWaybackSave } from './ipc/contacts';
+import { isBlockedHost } from './sync/rss-poller';
 
-// Hostname patterns blocked to prevent SSRF when validating user-supplied URLs.
-// Covers loopback, private RFC-1918, link-local, CGNAT, and IPv6 equivalents.
-const BLOCKED_PATTERNS = [
-  /^localhost$/i,
-  /^127\.\d+\.\d+\.\d+$/,
-  /^10\.\d+\.\d+\.\d+$/,
-  /^172\.(1[6-9]|2\d|3[01])\.\d+\.\d+$/,
-  /^192\.168\.\d+\.\d+$/,
-  /^169\.254\.\d+\.\d+$/,           // IPv4 link-local
-  /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d+\.\d+$/, // CGNAT (RFC 6598)
-  /^::1$/,                           // IPv6 loopback
-  /^fe80:/i,                         // IPv6 link-local
-  /^::ffff:/i,                       // IPv4-mapped IPv6
-];
-
-export function isBlockedHost(hostname: string): boolean {
-  return BLOCKED_PATTERNS.some((re) => re.test(hostname));
-}
+export { isBlockedHost };
 
 const MAX_SCREENSHOT_BYTES = 50 * 1024 * 1024;
 const MAX_PENDING_SCREENSHOTS = 20;
@@ -273,6 +257,9 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
         }
         const rawUrl = typeof url === 'string' ? url.trim() || null : null;
         if (rawUrl && !validateUrl(rawUrl)) {
+          json(res, 400, { error: 'URL is invalid.' }); return;
+        }
+        if (rawUrl && isBlockedHost(rawUrl)) {
           json(res, 400, { error: 'URL is invalid.' }); return;
         }
         const rawOrg = typeof organization === 'string' ? organization.trim() || null : null;

--- a/src/main/http-server.ts
+++ b/src/main/http-server.ts
@@ -2,11 +2,8 @@ import { createServer, IncomingMessage, ServerResponse } from 'http';
 import { randomBytes, randomUUID, timingSafeEqual } from 'crypto';
 import { app, BrowserWindow } from 'electron';
 import { isDatabaseOpen, getDatabase } from './database';
-import { normalizeEmail, normalizePhone, validateEmail, validateUrl, detectLinkType } from './sanitize';
+import { normalizeEmail, normalizePhone, validateEmail, validateUrl, detectLinkType, isBlockedHost } from './sanitize';
 import { triggerWaybackSave } from './ipc/contacts';
-import { isBlockedHost } from './sync/rss-poller';
-
-export { isBlockedHost };
 
 const MAX_SCREENSHOT_BYTES = 50 * 1024 * 1024;
 const MAX_PENDING_SCREENSHOTS = 20;

--- a/src/main/ipc/alerts.ts
+++ b/src/main/ipc/alerts.ts
@@ -23,7 +23,7 @@ export function registerAlertHandlers(): void {
       db.prepare(
         `INSERT INTO contact_alert_rss (id, contact_id, rss_url) VALUES (?, ?, ?)`,
       ).run(id, contactId, rssUrl);
-      pollContactRss(contactId).catch(() => {});
+      pollContactRss(contactId).catch((err) => console.error('[rss] initial poll failed:', err));
     },
   );
 

--- a/src/main/ipc/search.ts
+++ b/src/main/ipc/search.ts
@@ -70,7 +70,8 @@ export function performSearch(query: string, db: Database.Database): SearchResul
     // Only swallow FTS query syntax errors; rethrow anything else
     // (e.g. table corruption whose message might also contain "fts5:").
     if (e instanceof Error && /fts5: syntax error/i.test(e.message)) {
-      // fall back to the LIKE results already computed above
+      // FTS log results are simply omitted — contacts and projects still return
+      // their LIKE results computed above.
     } else {
       throw e;
     }

--- a/src/main/ipc/search.ts
+++ b/src/main/ipc/search.ts
@@ -67,8 +67,13 @@ export function performSearch(query: string, db: Database.Database): SearchResul
       )
       .all(ftsQuery) as typeof logResults;
   } catch (e) {
-    // Only swallow FTS query syntax errors; rethrow anything else.
-    if (!(e instanceof Error) || !e.message.includes('fts5:')) throw e;
+    // Only swallow FTS query syntax errors; rethrow anything else
+    // (e.g. table corruption whose message might also contain "fts5:").
+    if (e instanceof Error && /fts5: syntax error/i.test(e.message)) {
+      // fall back to the LIKE results already computed above
+    } else {
+      throw e;
+    }
   }
 
   return [

--- a/src/main/sanitize.ts
+++ b/src/main/sanitize.ts
@@ -17,15 +17,24 @@ export function normalizePhone(raw: string, defaultCountry: string = 'US'): stri
   return null;
 }
 
+function isPrivateIPv4(hostname: string): boolean {
+  const parts = hostname.split('.').map(Number);
+  const [a, b] = parts;
+  if (a === 127) return true;                            // loopback
+  if (a === 10) return true;                             // RFC 1918
+  if (a === 172 && b >= 16 && b <= 31) return true;     // RFC 1918
+  if (a === 192 && b === 168) return true;               // RFC 1918
+  if (a === 169 && b === 254) return true;               // link-local
+  if (a === 100 && b >= 64 && b <= 127) return true;    // CGNAT RFC 6598
+  if (a === 0) return true;                              // "this" network
+  return false;
+}
+
 /**
- * Returns true when the URL's hostname resolves to a private/loopback/link-local
- * address that should be blocked to prevent SSRF.  Uses net.isIP() to classify
- * addresses rather than regular expressions, which avoids bypass variants such as
- * `127.1`, `localhost.` (trailing dot), `0.0.0.0`, and long-form IPv6 loopback.
- *
- * For hostnames (non-IP strings): only `localhost` (exact, case-insensitive,
- * after stripping any trailing dots) is blocked — DNS resolution of other names
- * is left to the OS and is outside the scope of this guard.
+ * Returns true when the URL's hostname is a private/loopback/link-local
+ * IP address that should be blocked to prevent SSRF.  Uses net.isIP() to
+ * classify literal IP addresses; for non-IP hostnames only `localhost` is
+ * blocked — no DNS resolution is performed.
  */
 export function isBlockedHost(urlStr: string): boolean {
   let hostname: string;
@@ -39,30 +48,41 @@ export function isBlockedHost(urlStr: string): boolean {
     hostname = hostname.slice(1, -1);
   }
 
+  // Strip trailing dots — net.isIP() rejects "127.0.0.1." even though some
+  // URL parsers accept it, allowing a bypass without this strip.
+  hostname = hostname.replace(/\.+$/, '');
+
   const ipVersion = net.isIP(hostname);
 
   if (ipVersion === 4) {
-    const parts = hostname.split('.').map(Number);
-    const [a, b] = parts;
-    if (a === 127) return true;
-    if (a === 10) return true;
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    if (a === 192 && b === 168) return true;
-    if (a === 169 && b === 254) return true;
-    if (a === 0) return true;
-    return false;
+    return isPrivateIPv4(hostname);
   }
 
   if (ipVersion === 6) {
     const lower = hostname.toLowerCase();
     if (lower === '::1' || lower === '0:0:0:0:0:0:0:1') return true;
+    // IPv4-mapped IPv6: handles both dotted-quad (::ffff:127.0.0.1) and the
+    // hex-pairs form the WHATWG URL parser produces (::ffff:7f00:1).
+    if (lower.startsWith('::ffff:')) {
+      const embedded = lower.slice(7);
+      if (net.isIP(embedded) === 4) return isPrivateIPv4(embedded);
+      const hexParts = embedded.split(':');
+      if (hexParts.length === 2) {
+        const hi = parseInt(hexParts[0], 16);
+        const lo = parseInt(hexParts[1], 16);
+        if (!isNaN(hi) && !isNaN(lo)) {
+          const ipv4 = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+          return isPrivateIPv4(ipv4);
+        }
+      }
+    }
     const firstGroup = parseInt(lower.split(':')[0] || '0', 16);
-    if ((firstGroup & 0xfe00) === 0xfc00) return true;
-    if ((firstGroup & 0xffc0) === 0xfe80) return true;
+    if ((firstGroup & 0xfe00) === 0xfc00) return true;   // ULA fc00::/7
+    if ((firstGroup & 0xffc0) === 0xfe80) return true;   // link-local fe80::/10
     return false;
   }
 
-  return hostname.replace(/\.+$/, '').toLowerCase() === 'localhost';
+  return hostname.toLowerCase() === 'localhost';
 }
 
 export function detectLinkType(url: string): 'linkedin' | 'x' | 'instagram' | 'facebook' | 'website' {

--- a/src/main/sanitize.ts
+++ b/src/main/sanitize.ts
@@ -1,3 +1,4 @@
+import net from 'net';
 import { parsePhoneNumberFromString } from 'libphonenumber-js';
 import type { CountryCode } from 'libphonenumber-js';
 export { validateEmail, validateUrl } from '@shared/validation';
@@ -14,6 +15,54 @@ export function normalizePhone(raw: string, defaultCountry: string = 'US'): stri
     return parsed.formatInternational();
   }
   return null;
+}
+
+/**
+ * Returns true when the URL's hostname resolves to a private/loopback/link-local
+ * address that should be blocked to prevent SSRF.  Uses net.isIP() to classify
+ * addresses rather than regular expressions, which avoids bypass variants such as
+ * `127.1`, `localhost.` (trailing dot), `0.0.0.0`, and long-form IPv6 loopback.
+ *
+ * For hostnames (non-IP strings): only `localhost` (exact, case-insensitive,
+ * after stripping any trailing dots) is blocked — DNS resolution of other names
+ * is left to the OS and is outside the scope of this guard.
+ */
+export function isBlockedHost(urlStr: string): boolean {
+  let hostname: string;
+  try {
+    hostname = new URL(urlStr).hostname;
+  } catch {
+    return true;
+  }
+
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    hostname = hostname.slice(1, -1);
+  }
+
+  const ipVersion = net.isIP(hostname);
+
+  if (ipVersion === 4) {
+    const parts = hostname.split('.').map(Number);
+    const [a, b] = parts;
+    if (a === 127) return true;
+    if (a === 10) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 0) return true;
+    return false;
+  }
+
+  if (ipVersion === 6) {
+    const lower = hostname.toLowerCase();
+    if (lower === '::1' || lower === '0:0:0:0:0:0:0:1') return true;
+    const firstGroup = parseInt(lower.split(':')[0] || '0', 16);
+    if ((firstGroup & 0xfe00) === 0xfc00) return true;
+    if ((firstGroup & 0xffc0) === 0xfe80) return true;
+    return false;
+  }
+
+  return hostname.replace(/\.+$/, '').toLowerCase() === 'localhost';
 }
 
 export function detectLinkType(url: string): 'linkedin' | 'x' | 'instagram' | 'facebook' | 'website' {

--- a/src/main/sync/rss-poller.ts
+++ b/src/main/sync/rss-poller.ts
@@ -1,3 +1,4 @@
+import net from 'net';
 import Parser from 'rss-parser';
 import { BrowserWindow, Notification } from 'electron';
 import { v4 as uuidv4 } from 'uuid';
@@ -5,20 +6,66 @@ import { getDatabase, isDatabaseOpen } from '../database';
 
 const parser = new Parser();
 
-// Hostname patterns that are blocked to prevent SSRF.  Covers loopback,
-// private RFC-1918, link-local, CGNAT, and IPv6 equivalents.
-const BLOCKED_HOST_PATTERNS: RegExp[] = [
-  /^localhost$/i,
-  /^127\.\d+\.\d+\.\d+$/,
-  /^10\.\d+\.\d+\.\d+$/,
-  /^172\.(1[6-9]|2\d|3[01])\.\d+\.\d+$/,
-  /^192\.168\.\d+\.\d+$/,
-  /^169\.254\.\d+\.\d+$/,           // IPv4 link-local
-  /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d+\.\d+$/, // CGNAT (RFC 6598)
-  /^::1$/,                           // IPv6 loopback
-  /^fe80:/i,                         // IPv6 link-local
-  /^::ffff:/i,                       // IPv4-mapped IPv6
-];
+/**
+ * Returns true when the URL's hostname resolves to a private/loopback/link-local
+ * address that should be blocked to prevent SSRF.  Uses net.isIP() to classify
+ * addresses rather than regular expressions, which avoids bypass variants such as
+ * `127.1`, `localhost.` (trailing dot), `0.0.0.0`, and long-form IPv6 loopback.
+ *
+ * For hostnames (non-IP strings): only `localhost` (exact, case-insensitive,
+ * after stripping any trailing dots) is blocked — DNS resolution of other names
+ * is left to the OS and is outside the scope of this guard.
+ */
+export function isBlockedHost(urlStr: string): boolean {
+  let hostname: string;
+  try {
+    hostname = new URL(urlStr).hostname;
+  } catch {
+    // Invalid URL — block it
+    return true;
+  }
+
+  // Strip surrounding brackets from IPv6 literals (e.g. "[::1]" → "::1")
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    hostname = hostname.slice(1, -1);
+  }
+
+  const ipVersion = net.isIP(hostname);
+
+  if (ipVersion === 4) {
+    const parts = hostname.split('.').map(Number);
+    const [a, b] = parts;
+    // 127.0.0.0/8  — loopback
+    if (a === 127) return true;
+    // 10.0.0.0/8   — RFC-1918 private
+    if (a === 10) return true;
+    // 172.16.0.0/12 — RFC-1918 private
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    // 192.168.0.0/16 — RFC-1918 private
+    if (a === 192 && b === 168) return true;
+    // 169.254.0.0/16 — link-local
+    if (a === 169 && b === 254) return true;
+    // 0.0.0.0/8 — "this" network
+    if (a === 0) return true;
+    return false;
+  }
+
+  if (ipVersion === 6) {
+    const lower = hostname.toLowerCase();
+    // ::1  — loopback (also catches 0:0:0:0:0:0:0:1 after normalization)
+    if (lower === '::1' || lower === '0:0:0:0:0:0:0:1') return true;
+    // fc00::/7 — ULA (first byte 0xfc or 0xfd)
+    const firstGroup = parseInt(lower.split(':')[0] || '0', 16);
+    if ((firstGroup & 0xfe00) === 0xfc00) return true;
+    // fe80::/10 — link-local
+    if ((firstGroup & 0xffc0) === 0xfe80) return true;
+    return false;
+  }
+
+  // Plain hostname — block `localhost` (strip trailing dots first)
+  const stripped = hostname.replace(/\.+$/, '').toLowerCase();
+  return stripped === 'localhost';
+}
 
 function cleanHeadline(raw: string): string {
   return raw
@@ -111,8 +158,7 @@ async function pollOneFeed(feedId: string, contactId: string, rssUrl: string): P
   try {
     const parsed = new URL(rssUrl);
     if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return 0;
-    const host = parsed.hostname;
-    if (BLOCKED_HOST_PATTERNS.some((re) => re.test(host))) return 0;
+    if (isBlockedHost(rssUrl)) return 0;
   } catch {
     return 0;
   }
@@ -122,8 +168,16 @@ async function pollOneFeed(feedId: string, contactId: string, rssUrl: string): P
 
   try {
     // Fetch the feed URL manually first so we can inspect the HTTP status code
-    // before handing it off to the parser.
-    const response = await fetch(rssUrl);
+    // before handing it off to the parser.  A 10-second AbortController timeout
+    // prevents a slow server from stalling the entire poll loop.
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+    let response: Response;
+    try {
+      response = await fetch(rssUrl, { signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
     if (response.status >= 400 && response.status < 500) {
       // Permanent client error — the URL is genuinely broken; mark invalid.
       db.prepare(`UPDATE contact_alert_rss SET is_invalid = 1 WHERE id = ?`).run(feedId);

--- a/src/main/sync/rss-poller.ts
+++ b/src/main/sync/rss-poller.ts
@@ -1,71 +1,11 @@
-import net from 'net';
 import Parser from 'rss-parser';
 import { BrowserWindow, Notification } from 'electron';
 import { v4 as uuidv4 } from 'uuid';
 import { getDatabase, isDatabaseOpen } from '../database';
+import { isBlockedHost } from '../sanitize';
 
 const parser = new Parser();
 
-/**
- * Returns true when the URL's hostname resolves to a private/loopback/link-local
- * address that should be blocked to prevent SSRF.  Uses net.isIP() to classify
- * addresses rather than regular expressions, which avoids bypass variants such as
- * `127.1`, `localhost.` (trailing dot), `0.0.0.0`, and long-form IPv6 loopback.
- *
- * For hostnames (non-IP strings): only `localhost` (exact, case-insensitive,
- * after stripping any trailing dots) is blocked — DNS resolution of other names
- * is left to the OS and is outside the scope of this guard.
- */
-export function isBlockedHost(urlStr: string): boolean {
-  let hostname: string;
-  try {
-    hostname = new URL(urlStr).hostname;
-  } catch {
-    // Invalid URL — block it
-    return true;
-  }
-
-  // Strip surrounding brackets from IPv6 literals (e.g. "[::1]" → "::1")
-  if (hostname.startsWith('[') && hostname.endsWith(']')) {
-    hostname = hostname.slice(1, -1);
-  }
-
-  const ipVersion = net.isIP(hostname);
-
-  if (ipVersion === 4) {
-    const parts = hostname.split('.').map(Number);
-    const [a, b] = parts;
-    // 127.0.0.0/8  — loopback
-    if (a === 127) return true;
-    // 10.0.0.0/8   — RFC-1918 private
-    if (a === 10) return true;
-    // 172.16.0.0/12 — RFC-1918 private
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    // 192.168.0.0/16 — RFC-1918 private
-    if (a === 192 && b === 168) return true;
-    // 169.254.0.0/16 — link-local
-    if (a === 169 && b === 254) return true;
-    // 0.0.0.0/8 — "this" network
-    if (a === 0) return true;
-    return false;
-  }
-
-  if (ipVersion === 6) {
-    const lower = hostname.toLowerCase();
-    // ::1  — loopback (also catches 0:0:0:0:0:0:0:1 after normalization)
-    if (lower === '::1' || lower === '0:0:0:0:0:0:0:1') return true;
-    // fc00::/7 — ULA (first byte 0xfc or 0xfd)
-    const firstGroup = parseInt(lower.split(':')[0] || '0', 16);
-    if ((firstGroup & 0xfe00) === 0xfc00) return true;
-    // fe80::/10 — link-local
-    if ((firstGroup & 0xffc0) === 0xfe80) return true;
-    return false;
-  }
-
-  // Plain hostname — block `localhost` (strip trailing dots first)
-  const stripped = hostname.replace(/\.+$/, '').toLowerCase();
-  return stripped === 'localhost';
-}
 
 function cleanHeadline(raw: string): string {
   return raw

--- a/src/main/sync/rss-poller.ts
+++ b/src/main/sync/rss-poller.ts
@@ -3,7 +3,22 @@ import { BrowserWindow, Notification } from 'electron';
 import { v4 as uuidv4 } from 'uuid';
 import { getDatabase, isDatabaseOpen } from '../database';
 
-const parser = new Parser({ timeout: 10000 });
+const parser = new Parser();
+
+// Hostname patterns that are blocked to prevent SSRF.  Covers loopback,
+// private RFC-1918, link-local, CGNAT, and IPv6 equivalents.
+const BLOCKED_HOST_PATTERNS: RegExp[] = [
+  /^localhost$/i,
+  /^127\.\d+\.\d+\.\d+$/,
+  /^10\.\d+\.\d+\.\d+$/,
+  /^172\.(1[6-9]|2\d|3[01])\.\d+\.\d+$/,
+  /^192\.168\.\d+\.\d+$/,
+  /^169\.254\.\d+\.\d+$/,           // IPv4 link-local
+  /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d+\.\d+$/, // CGNAT (RFC 6598)
+  /^::1$/,                           // IPv6 loopback
+  /^fe80:/i,                         // IPv6 link-local
+  /^::ffff:/i,                       // IPv4-mapped IPv6
+];
 
 function cleanHeadline(raw: string): string {
   return raw
@@ -97,7 +112,7 @@ async function pollOneFeed(feedId: string, contactId: string, rssUrl: string): P
     const parsed = new URL(rssUrl);
     if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return 0;
     const host = parsed.hostname;
-    if (/^(localhost$|127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|::1$|\[::1\])/.test(host)) return 0;
+    if (BLOCKED_HOST_PATTERNS.some((re) => re.test(host))) return 0;
   } catch {
     return 0;
   }
@@ -106,7 +121,21 @@ async function pollOneFeed(feedId: string, contactId: string, rssUrl: string): P
   const now = Math.floor(Date.now() / 1000);
 
   try {
-    const feed = await parser.parseURL(rssUrl);
+    // Fetch the feed URL manually first so we can inspect the HTTP status code
+    // before handing it off to the parser.
+    const response = await fetch(rssUrl);
+    if (response.status >= 400 && response.status < 500) {
+      // Permanent client error — the URL is genuinely broken; mark invalid.
+      db.prepare(`UPDATE contact_alert_rss SET is_invalid = 1 WHERE id = ?`).run(feedId);
+      return 0;
+    } else if (!response.ok) {
+      // Transient server-side or network error — skip this poll, do not mark invalid.
+      console.warn(`[rss] Transient HTTP ${response.status} for feed ${feedId}, will retry`);
+      return 0;
+    }
+
+    const text = await response.text();
+    const feed = await parser.parseString(text);
     let newCount = 0;
 
     for (const item of feed.items ?? []) {
@@ -137,8 +166,10 @@ async function pollOneFeed(feedId: string, contactId: string, rssUrl: string): P
     ).run(now, feedId);
 
     return newCount;
-  } catch {
-    db.prepare(`UPDATE contact_alert_rss SET is_invalid = 1 WHERE id = ?`).run(feedId);
+  } catch (err) {
+    // Network-level exception (DNS failure, timeout, connection refused, etc.) — transient;
+    // log a warning but do NOT mark the feed invalid so it will be retried next poll.
+    console.warn(`[rss] Network error polling feed ${feedId}:`, err);
     return 0;
   }
 }

--- a/src/main/sync/rss-poller.ts
+++ b/src/main/sync/rss-poller.ts
@@ -118,6 +118,13 @@ async function pollOneFeed(feedId: string, contactId: string, rssUrl: string): P
     } finally {
       clearTimeout(timeout);
     }
+    // Re-check the final URL in case a redirect led to a private address.
+    if (isBlockedHost(response.url)) return 0;
+    if (response.status === 408 || response.status === 429) {
+      // Transient — request timeout or rate-limited; will retry next poll.
+      console.warn(`[rss] Transient HTTP ${response.status} for feed ${feedId}, will retry`);
+      return 0;
+    }
     if (response.status >= 400 && response.status < 500) {
       // Permanent client error — the URL is genuinely broken; mark invalid.
       db.prepare(`UPDATE contact_alert_rss SET is_invalid = 1 WHERE id = ?`).run(feedId);
@@ -129,7 +136,14 @@ async function pollOneFeed(feedId: string, contactId: string, rssUrl: string): P
     }
 
     const text = await response.text();
-    const feed = await parser.parseString(text);
+    let feed: Awaited<ReturnType<typeof parser.parseString>>;
+    try {
+      feed = await parser.parseString(text);
+    } catch {
+      // Malformed feed content — treat as permanent; mark invalid so we stop polling.
+      db.prepare(`UPDATE contact_alert_rss SET is_invalid = 1 WHERE id = ?`).run(feedId);
+      return 0;
+    }
     let newCount = 0;
 
     for (const item of feed.items ?? []) {
@@ -161,8 +175,8 @@ async function pollOneFeed(feedId: string, contactId: string, rssUrl: string): P
 
     return newCount;
   } catch (err) {
-    // Network-level exception (DNS failure, timeout, connection refused, etc.) — transient;
-    // log a warning but do NOT mark the feed invalid so it will be retried next poll.
+    // Network-level exception (DNS failure, timeout, connection refused) — transient;
+    // do not mark invalid so it will be retried next poll.
     console.warn(`[rss] Network error polling feed ${feedId}:`, err);
     return 0;
   }

--- a/src/test/sanitize.test.ts
+++ b/src/test/sanitize.test.ts
@@ -5,6 +5,7 @@ import {
   normalizePhone,
   validateUrl,
   detectLinkType,
+  isBlockedHost,
 } from '../main/sanitize';
 
 describe('normalizeEmail', () => {
@@ -187,6 +188,78 @@ describe('validateUrl', () => {
 
   it('rejects a URL with an embedded newline', () => {
     expect(validateUrl('https://example.com/path\nwith\nnewlines')).toBe(false);
+  });
+});
+
+describe('isBlockedHost', () => {
+  it('blocks loopback 127.0.0.1', () => {
+    expect(isBlockedHost('http://127.0.0.1/feed')).toBe(true);
+  });
+
+  it('blocks localhost hostname', () => {
+    expect(isBlockedHost('http://localhost/feed')).toBe(true);
+  });
+
+  it('blocks RFC 1918 10.x.x.x', () => {
+    expect(isBlockedHost('http://10.0.0.1/feed')).toBe(true);
+  });
+
+  it('blocks RFC 1918 192.168.x.x', () => {
+    expect(isBlockedHost('http://192.168.1.1/feed')).toBe(true);
+  });
+
+  it('blocks RFC 1918 172.16–31.x.x', () => {
+    expect(isBlockedHost('http://172.16.0.1/feed')).toBe(true);
+    expect(isBlockedHost('http://172.31.255.255/feed')).toBe(true);
+  });
+
+  it('allows 172.15.x.x (not RFC 1918)', () => {
+    expect(isBlockedHost('http://172.15.0.1/feed')).toBe(false);
+  });
+
+  it('blocks CGNAT 100.64.x.x (RFC 6598)', () => {
+    expect(isBlockedHost('http://100.64.0.1/feed')).toBe(true);
+    expect(isBlockedHost('http://100.127.255.255/feed')).toBe(true);
+  });
+
+  it('allows 100.63.x.x (not CGNAT)', () => {
+    expect(isBlockedHost('http://100.63.0.1/feed')).toBe(false);
+  });
+
+  it('blocks link-local 169.254.x.x', () => {
+    expect(isBlockedHost('http://169.254.1.1/feed')).toBe(true);
+  });
+
+  it('blocks IPv6 loopback ::1', () => {
+    expect(isBlockedHost('http://[::1]/feed')).toBe(true);
+  });
+
+  it('blocks IPv6 link-local fe80::', () => {
+    expect(isBlockedHost('http://[fe80::1]/feed')).toBe(true);
+  });
+
+  it('blocks IPv4-mapped IPv6 ::ffff:127.0.0.1', () => {
+    expect(isBlockedHost('http://[::ffff:127.0.0.1]/feed')).toBe(true);
+  });
+
+  it('blocks IPv4-mapped IPv6 for private range ::ffff:192.168.1.1', () => {
+    expect(isBlockedHost('http://[::ffff:192.168.1.1]/feed')).toBe(true);
+  });
+
+  it('blocks trailing-dot loopback 127.0.0.1.', () => {
+    expect(isBlockedHost('http://127.0.0.1./feed')).toBe(true);
+  });
+
+  it('allows a public address', () => {
+    expect(isBlockedHost('https://feeds.example.com/rss')).toBe(false);
+  });
+
+  it('blocks an invalid URL', () => {
+    expect(isBlockedHost('not-a-url')).toBe(true);
+  });
+
+  it('blocks non-http protocols', () => {
+    expect(isBlockedHost('file:///etc/passwd')).toBe(false); // isBlockedHost only checks host, not protocol
   });
 });
 

--- a/src/test/search.test.ts
+++ b/src/test/search.test.ts
@@ -144,3 +144,49 @@ describe('performSearch — FTS input escaping', () => {
     expect(() => performSearch('()', testDb)).not.toThrow();
   });
 });
+
+describe('performSearch — FTS5 error classification', () => {
+  it('swallows an fts5 syntax error and returns partial results (contacts/projects via LIKE)', () => {
+    // Insert a contact that will be found by the LIKE fallback
+    insertContact(testDb, 'Alice Syntax');
+
+    // Monkey-patch prepare so that MATCH queries throw a syntax error
+    const originalPrepare = testDb.prepare.bind(testDb);
+    const spy = vi.spyOn(testDb, 'prepare').mockImplementation((sql: string) => {
+      if (sql.includes('MATCH')) {
+        return {
+          all: () => { throw new Error('fts5: syntax error at position 1'); },
+        } as ReturnType<typeof testDb.prepare>;
+      }
+      return originalPrepare(sql);
+    });
+
+    let results: ReturnType<typeof performSearch>;
+    expect(() => {
+      results = performSearch('Alice', testDb);
+    }).not.toThrow();
+
+    // Contacts are still returned via LIKE
+    expect(results!.filter((r) => r.type === 'contact')).toHaveLength(1);
+    // No log results because FTS threw
+    expect(results!.filter((r) => r.type === 'log')).toHaveLength(0);
+
+    spy.mockRestore();
+  });
+
+  it('rethrows a non-syntax fts5 error (e.g. database corruption)', () => {
+    const originalPrepare = testDb.prepare.bind(testDb);
+    const spy = vi.spyOn(testDb, 'prepare').mockImplementation((sql: string) => {
+      if (sql.includes('MATCH')) {
+        return {
+          all: () => { throw new Error('fts5: database disk image is malformed'); },
+        } as ReturnType<typeof testDb.prepare>;
+      }
+      return originalPrepare(sql);
+    });
+
+    expect(() => performSearch('anything', testDb)).toThrow('fts5: database disk image is malformed');
+
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- RSS poller: only mark feed invalid on permanent 4xx errors — transient failures (network errors, 5xx) no longer permanently disable feeds (#188)
- HTTP server SSRF guard: add IPv6 loopback, link-local, IPv4-mapped IPv6, 169.254.x.x, and CGNAT ranges (#249)
- alerts:add-rss: await pollContactRss (or add .catch) to prevent unhandled rejections (#277)
- search.ts: tighten FTS5 error catch to /fts5: syntax error/i so DB corruption errors propagate (#301)

Closes #188, #249, #277, #301