### PR TITLE
Fix CSS design violations and accessibility gaps

### DIFF
--- a/src/renderer/src/contacts/AddContactModal.tsx
+++ b/src/renderer/src/contacts/AddContactModal.tsx
@@ -230,7 +230,7 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
           >
             <span className="ac-expand-toggle-label">
               {expanded ? 'Fewer details' : 'More details'}
-              <span className="ac-expand-toggle-icon">{expanded ? '▴' : '▾'}</span>
+              <span className="ac-expand-toggle-icon" aria-hidden="true">{expanded ? '▴' : '▾'}</span>
             </span>
           </button>
 

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -318,22 +318,22 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
     return (
       <div className="detail-body" ref={formRef}>
         <div className="ac-field">
-          <label className="ac-label">Name <span className="ac-required">*</span></label>
+          <label className="modal-label">Name <span className="modal-required">*</span></label>
           <input className="ac-input" value={editName} onChange={(e) => setEditName(e.target.value)} autoFocus />
         </div>
 
         <div className="ac-field">
-          <label className="ac-label">Organization</label>
+          <label className="modal-label">Organization</label>
           <input className="ac-input" value={editOrg} onChange={(e) => setEditOrg(e.target.value)} />
         </div>
 
         <div className="ac-field">
-          <label className="ac-label">Title / Role</label>
+          <label className="modal-label">Title / Role</label>
           <input className="ac-input" value={editTitle} onChange={(e) => setEditTitle(e.target.value)} placeholder="e.g. Senior Editor" />
         </div>
 
         <div className="ac-field">
-          <label className="ac-label">Date of birth</label>
+          <label className="modal-label">Date of birth</label>
           <CalendarPicker
             label="Select date"
             value={editDob}
@@ -344,7 +344,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         </div>
 
         <div className="ac-field">
-          <label className="ac-label">Email</label>
+          <label className="modal-label">Email</label>
           {editEmails.map((entry, i) => (
             <div
               key={i}
@@ -423,7 +423,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         </div>
 
         <div className="ac-field">
-          <label className="ac-label">Phone</label>
+          <label className="modal-label">Phone</label>
           {editPhones.map((entry, i) => (
             <div
               key={i}
@@ -504,7 +504,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         </div>
 
         <div className="ac-field">
-          <label className="ac-label">Messaging</label>
+          <label className="modal-label">Messaging</label>
           {editHandles.map((entry, i) => (
             <div key={i} className="ac-phone-row">
               <select
@@ -550,7 +550,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
 
         {NON_OTHER_SOCIAL_TYPES.map((type) => (
           <div key={type} className="ac-field">
-            <label className="ac-label">{SOCIAL_META[type].label}</label>
+            <label className="modal-label">{SOCIAL_META[type].label}</label>
             <DynamicList
               enableDragReorder
               values={editSocials[type]}
@@ -583,7 +583,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         ))}
 
         <div className="ac-field">
-          <label className="ac-label">Other social</label>
+          <label className="modal-label">Other social</label>
           {editOtherSocials.map((entry, i) => (
             <div
               key={i}
@@ -656,7 +656,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         </div>
 
         <div className="ac-field">
-          <label className="ac-label">Website</label>
+          <label className="modal-label">Website</label>
           <DynamicList
             enableDragReorder
             values={editWebsites}
@@ -691,7 +691,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         </div>
 
         <div className="ac-field">
-          <label className="ac-label">Notes</label>
+          <label className="modal-label">Notes</label>
           <textarea
             className="ac-textarea"
             value={editNotes}

--- a/src/renderer/src/global.css
+++ b/src/renderer/src/global.css
@@ -77,6 +77,8 @@
   /* ── Semantic ─────────────────────────────────── */
   --color-success:         #2d8f6a;
   --color-danger:          #b91c1c;
+  --color-danger-bg:       #fff5f5;
+  --color-danger-bg-hover: #fee2e2;
   --color-warning-bg:      #fef3c7;
   --color-warning-border:  #f59e0b;
   --color-warning-text:    #92400e;

--- a/src/renderer/src/views/AlertMentions.css
+++ b/src/renderer/src/views/AlertMentions.css
@@ -179,24 +179,3 @@
 .alerts-item:hover .alerts-dismiss-btn {
   opacity: 1;
 }
-
-.alerts-dismiss-btn {
-  background: none;
-  border: none;
-  padding: 0 2px;
-  font-size: 16px;
-  line-height: 1;
-  color: var(--color-text-dim);
-  cursor: pointer;
-  margin-top: 2px;
-  opacity: 0;
-  transition: opacity 0.1s;
-}
-
-.alerts-dismiss-btn:hover {
-  color: var(--color-text);
-}
-
-.alerts-item:hover .alerts-dismiss-btn {
-  opacity: 1;
-}

--- a/src/renderer/src/views/ContactsTable.tsx
+++ b/src/renderer/src/views/ContactsTable.tsx
@@ -265,6 +265,7 @@ export default function ContactsTable(props: ContactsTableProps) {
               ref={selectAllRef}
               checked={allChecked}
               onChange={() => onCheckAll()}
+              aria-label="Select all contacts"
             />
           </th>
 

--- a/src/renderer/src/views/RemindersView.css
+++ b/src/renderer/src/views/RemindersView.css
@@ -154,11 +154,11 @@
 }
 
 .reminders-item-overdue {
-  background: #fff5f5;
+  background: var(--color-danger-bg);
 }
 
 .reminders-item-overdue:hover {
-  background: #fee2e2;
+  background: var(--color-danger-bg-hover);
 }
 
 .reminders-item-overdue-outreach {

--- a/src/renderer/src/views/Timeline.css
+++ b/src/renderer/src/views/Timeline.css
@@ -417,7 +417,7 @@
   font-size: 11px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  border-radius: 3px;
+  border-radius: 0;
   padding: 1px 5px;
 }
 


### PR DESCRIPTION
## Summary
- #331 `Timeline.css`: badge `border-radius: 3px` → `0` (square corners rule)
- #284 `AlertMentions.css`: remove duplicate `.alerts-dismiss-btn` rule block
- #293 `RemindersView.css`: replace raw hex danger background colours (`#fff5f5`, `#fee2e2`) with new design tokens `--color-danger-bg` / `--color-danger-bg-hover` added to `global.css`
- #299 `GlobalTab`: replace `ac-label` / `ac-required` with `modal-label` / `modal-required` throughout
- #292 `AddContactModal`: add `aria-hidden="true"` to expand-toggle icon span
- #322 `ContactsTable`: add `aria-label="Select all contacts"` to select-all checkbox

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)