### PR TITLE
Remove deprecated release:patch / release:minor scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,6 @@ Releases are triggered by pushing a version tag (`v*`). Because `main` is protec
    ```
 6. The `build.yml` workflow builds on macOS, Windows, and Linux, then creates a GitHub Release with all artifacts automatically
 
-> The old `npm run release:patch` / `npm run release:minor` scripts do steps 2+5 in one shot but bypass the PR requirement — don't use them now that `main` is protected.
-
 ## UI design system
 
 All design tokens are CSS custom properties defined in `src/renderer/src/global.css`.

--- a/package.json
+++ b/package.json
@@ -6,8 +6,6 @@
   "author": "Tom Cardoso",
   "main": "out/main/index.js",
   "scripts": {
-    "release:patch": "npm version patch && git push origin main --follow-tags",
-    "release:minor": "npm version minor && git push origin main --follow-tags",
     "build:extension": "node scripts/build-extension.mjs",
     "postinstall": "electron-builder install-app-deps",
     "dev": "electron-vite dev",


### PR DESCRIPTION
## Summary

`release:patch` and `release:minor` both do `git push origin main --follow-tags`, which fails now that `main` is branch-protected. They're dead code that will confuse anyone who runs them. Removes both scripts and the associated note in `CLAUDE.md`.

The correct release workflow is fully documented in `CLAUDE.md` and `DISTRIBUTION.md` (updated in #348).

## Test plan

- [x] `npm run release:patch` and `npm run release:minor` no longer exist in `package.json`
- [x] `CLAUDE.md` no longer has a trailing note about these scripts
- [x] All other `npm` scripts still present and unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)