### PR TITLE
Wrap multi-statement DB writes in transactions; remove --font alias

### DIFF
--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -358,14 +358,16 @@ export function registerContactHandlers(): void {
         .get() as { label: string } | undefined;
       const membershipId = uuidv4();
       const now = Math.floor(Date.now() / 1000);
-      const result = db.prepare(
-        `INSERT OR IGNORE INTO project_memberships
-         (id, contact_id, project_id, reporter_email, reporter_name, status, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-      ).run(membershipId, contactId, projectId, user.email, `${user.first_name} ${user.last_name}`, defaultStatus?.label ?? null, now, now);
-      if (result.changes > 0) {
-        db.prepare('UPDATE contacts SET default_membership_id = ? WHERE id = ? AND default_membership_id IS NULL').run(membershipId, contactId);
-      }
+      db.transaction(() => {
+        const result = db.prepare(
+          `INSERT OR IGNORE INTO project_memberships
+           (id, contact_id, project_id, reporter_email, reporter_name, status, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(membershipId, contactId, projectId, user.email, `${user.first_name} ${user.last_name}`, defaultStatus?.label ?? null, now, now);
+        if (result.changes > 0) {
+          db.prepare('UPDATE contacts SET default_membership_id = ? WHERE id = ? AND default_membership_id IS NULL').run(membershipId, contactId);
+        }
+      })();
       broadcastContactsChanged();
     },
   );
@@ -537,35 +539,38 @@ export function registerContactHandlers(): void {
       && data.reporterEmail !== current?.reporter_email
       && validateEmail(data.reporterEmail);
 
-    db.prepare(
-      `UPDATE project_memberships
-       SET status = ?, priority = ?, theme = ?,
-           outreach_reminders_enabled = ?,
-           reporter_email = COALESCE(?, reporter_email),
-           reporter_name  = COALESCE(?, reporter_name),
-           reporter_assigned_at = CASE WHEN ? THEN ? ELSE reporter_assigned_at END,
-           reporter_conflict = CASE WHEN ? OR ? THEN 0 ELSE reporter_conflict END,
-           updated_at = ?
-       WHERE id = ?`,
-    ).run(
-      data.status ?? null,
-      data.priority ?? null,
-      data.theme ?? null,
-      newEnabled,
-      (data.reporterEmail && validateEmail(data.reporterEmail)) ? data.reporterEmail : null,
-      data.reporterName ?? null,
-      reporterChanging ? 1 : 0, now,
-      reporterChanging ? 1 : 0, data.clearConflict ? 1 : 0,
-      now,
-      data.membershipId,
-    );
-
-    if (newEnabled === 0) {
+    db.transaction(() => {
       db.prepare(
-        `DELETE FROM reminders WHERE membership_id = ? AND is_auto_outreach = 1`,
-      ).run(data.membershipId);
-      broadcastRemindersChanged();
-    }
+        `UPDATE project_memberships
+         SET status = ?, priority = ?, theme = ?,
+             outreach_reminders_enabled = ?,
+             reporter_email = COALESCE(?, reporter_email),
+             reporter_name  = COALESCE(?, reporter_name),
+             reporter_assigned_at = CASE WHEN ? THEN ? ELSE reporter_assigned_at END,
+             reporter_conflict = CASE WHEN ? OR ? THEN 0 ELSE reporter_conflict END,
+             updated_at = ?
+         WHERE id = ?`,
+      ).run(
+        data.status ?? null,
+        data.priority ?? null,
+        data.theme ?? null,
+        newEnabled,
+        (data.reporterEmail && validateEmail(data.reporterEmail)) ? data.reporterEmail : null,
+        data.reporterName ?? null,
+        reporterChanging ? 1 : 0, now,
+        reporterChanging ? 1 : 0, data.clearConflict ? 1 : 0,
+        now,
+        data.membershipId,
+      );
+
+      if (newEnabled === 0) {
+        db.prepare(
+          `DELETE FROM reminders WHERE membership_id = ? AND is_auto_outreach = 1`,
+        ).run(data.membershipId);
+      }
+    })();
+
+    if (newEnabled === 0) broadcastRemindersChanged();
     broadcastContactsChanged();
   });
 
@@ -731,11 +736,15 @@ export function registerContactHandlers(): void {
 
   ipcMain.handle('interaction-log:delete', (_, interactionId: string): void => {
     const db = getDatabase();
-    // Collect affected memberships before deleting so we can re-evaluate reminders.
-    const membershipIds = (
-      db.prepare('SELECT membership_id FROM interaction_projects WHERE interaction_id = ?').all(interactionId) as Array<{ membership_id: string }>
-    ).map((r) => r.membership_id);
-    db.prepare('DELETE FROM interaction_log_entries WHERE id = ?').run(interactionId);
+    // Collect affected memberships and delete in one transaction to close the
+    // TOCTOU window between the SELECT and DELETE.
+    const membershipIds = db.transaction(() => {
+      const ids = (
+        db.prepare('SELECT membership_id FROM interaction_projects WHERE interaction_id = ?').all(interactionId) as Array<{ membership_id: string }>
+      ).map((r) => r.membership_id);
+      db.prepare('DELETE FROM interaction_log_entries WHERE id = ?').run(interactionId);
+      return ids;
+    })();
     // Re-run outreach checker so reminders are recreated if this was the last log.
     checkOutreachReminders();
     broadcastContactsChanged();

--- a/src/main/ipc/projects.ts
+++ b/src/main/ipc/projects.ts
@@ -150,20 +150,21 @@ export function registerProjectHandlers(): void {
       const projectDesc = meta?.description ?? decoded.description ?? null;
       const now = Math.floor(Date.now() / 1000);
 
-      db.prepare(
-        `INSERT INTO projects (id, name, description, is_shared, shared_db_path, shared_db_key, created_at)
-         VALUES (?, ?, ?, 1, ?, ?, ?)`,
-      ).run(id, projectName, projectDesc, localPath, keyBytes, now);
+      db.transaction(() => {
+        db.prepare(
+          `INSERT INTO projects (id, name, description, is_shared, shared_db_path, shared_db_key, created_at)
+           VALUES (?, ?, ?, 1, ?, ?, ?)`,
+        ).run(id, projectName, projectDesc, localPath, keyBytes, now);
 
-      // Add self to project_reporters
-      db.prepare(
-        'INSERT INTO project_reporters (id, project_id, name, email, is_self) VALUES (?, ?, ?, ?, 1)',
-      ).run(
-        uuidv4(),
-        id,
-        `${user.first_name} ${user.last_name}`.trim(),
-        user.email,
-      );
+        db.prepare(
+          'INSERT INTO project_reporters (id, project_id, name, email, is_self) VALUES (?, ?, ?, ?, 1)',
+        ).run(
+          uuidv4(),
+          id,
+          `${user.first_name} ${user.last_name}`.trim(),
+          user.email,
+        );
+      })();
 
       // Initial pull from shared
       try {
@@ -343,21 +344,22 @@ export function registerProjectHandlers(): void {
         project.description,
       );
 
-      // Update local project record with new path and key
-      db.prepare(
-        'UPDATE projects SET shared_db_path = ?, shared_db_key = ? WHERE id = ?',
-      ).run(filePath, keyBytes, projectId);
+      // Update local project record and reset synced_at atomically.
+      db.transaction(() => {
+        db.prepare(
+          'UPDATE projects SET shared_db_path = ?, shared_db_key = ? WHERE id = ?',
+        ).run(filePath, keyBytes, projectId);
 
-      // Reset synced_at so all contacts/memberships get pushed to the new file.
-      const memberContactIds = (db
-        .prepare('SELECT contact_id FROM project_memberships WHERE project_id = ?')
-        .all(projectId) as { contact_id: string }[])
-        .map((r) => r.contact_id);
-      if (memberContactIds.length > 0) {
-        const ph = memberContactIds.map(() => '?').join(',');
-        db.prepare(`UPDATE contacts SET synced_at = NULL WHERE id IN (${ph})`).run(...memberContactIds);
-      }
-      db.prepare('UPDATE project_memberships SET synced_at = NULL WHERE project_id = ?').run(projectId);
+        const memberContactIds = (db
+          .prepare('SELECT contact_id FROM project_memberships WHERE project_id = ?')
+          .all(projectId) as { contact_id: string }[])
+          .map((r) => r.contact_id);
+        if (memberContactIds.length > 0) {
+          const ph = memberContactIds.map(() => '?').join(',');
+          db.prepare(`UPDATE contacts SET synced_at = NULL WHERE id IN (${ph})`).run(...memberContactIds);
+        }
+        db.prepare('UPDATE project_memberships SET synced_at = NULL WHERE project_id = ?').run(projectId);
+      })();
 
       // Push all local project data to the fresh shared file
       try {

--- a/src/renderer/src/global.css
+++ b/src/renderer/src/global.css
@@ -96,7 +96,6 @@
   /* ── Typography ───────────────────────────────── */
   --font-serif: 'Spectral', serif;
   --font-mono:  'JetBrains Mono', monospace;
-  --font:       var(--font-serif);
 
   /* ── Chrome ───────────────────────────────────── */
   --titlebar-height: 38px;
@@ -132,7 +131,7 @@ body,
 }
 
 body {
-  font-family: var(--font);
+  font-family: var(--font-serif);
   font-size: 14px;
   color: var(--color-text);
   background: var(--color-surface);

--- a/src/renderer/src/screens/Setup.css
+++ b/src/renderer/src/screens/Setup.css
@@ -63,7 +63,7 @@
   padding: 0 10px;
   border: 1px solid var(--color-border);
   font-size: 14px;
-  font-family: var(--font);
+  font-family: var(--font-serif);
   color: var(--color-text);
   background: var(--color-surface);
   outline: none;

--- a/src/renderer/src/screens/Unlock.css
+++ b/src/renderer/src/screens/Unlock.css
@@ -51,7 +51,7 @@
   padding: 0 10px;
   border: 1px solid var(--color-border);
   font-size: 14px;
-  font-family: var(--font);
+  font-family: var(--font-serif);
   color: var(--color-text);
   background: var(--color-surface);
   outline: none;

--- a/src/renderer/src/shell/Sidebar.css
+++ b/src/renderer/src/shell/Sidebar.css
@@ -359,7 +359,7 @@
   border: 1px solid var(--color-border-strong);
   color: var(--color-text);
   font-size: 13px;
-  font-family: var(--font);
+  font-family: var(--font-serif);
   outline: none;
 }
 

--- a/src/test/__mocks__/electron.ts
+++ b/src/test/__mocks__/electron.ts
@@ -3,7 +3,13 @@
 // Tests that need specific behaviour (e.g. Notification) use vi.mock() directly.
 export const app = {};
 export const ipcMain = { handle: () => {} };
-export const ipcRenderer = { invoke: () => Promise.resolve() };
+export const ipcRenderer = {
+  invoke: (channel: string) => {
+    throw new Error(
+      `ipcRenderer.invoke('${channel}') called in test — call handler functions directly instead of going through the IPC bridge`,
+    );
+  },
+};
 export const dialog = {
   showOpenDialog: () => Promise.resolve({ canceled: true, filePaths: [] }),
   showSaveDialog: () => Promise.resolve({ canceled: true }),

--- a/src/test/migrations.test.ts
+++ b/src/test/migrations.test.ts
@@ -3,6 +3,7 @@ import Database from 'better-sqlite3-multiple-ciphers';
 import { LOCAL_SCHEMA_SQL } from '../main/database/schema';
 import { seedDefaults } from '../main/database/seeds';
 import { runMigrations, DB_VERSION } from '../main/database';
+import { createDbAtVersion } from './vitest.setup';
 
 function createBaseDb(): Database.Database {
   const db = new Database(':memory:');
@@ -50,10 +51,18 @@ describe('runMigrations', () => {
     db.close();
   });
 
-  // Skeleton for individual migration-step tests.
-  // When DB_VERSION is incremented and the first real migration block is added to
-  // src/main/database/index.ts, add a describe block here that:
-  //   1. Creates a DB at version N-1 (with the pre-migration schema state).
-  //   2. Calls runMigrations(db).
-  //   3. Asserts that the new column / table / index exists.
+  // Per-migration-step tests go here. For each new migration block in index.ts:
+  //   1. Call createDbAtVersion(N - 1) to get a DB stamped at the previous version.
+  //   2. Manually DROP or ALTER the table to reproduce the pre-migration schema.
+  //   3. Call runMigrations(db) and assert the new column / table / index now exists.
+  //   4. Assert user_version === N.
+  // Example:
+  //   it('migration 2: adds foo column to contacts', () => {
+  //     const db = createDbAtVersion(1);
+  //     db.prepare('ALTER TABLE contacts DROP COLUMN foo').run();
+  //     runMigrations(db);
+  //     const cols = db.pragma('table_info(contacts)') as { name: string }[];
+  //     expect(cols.some((c) => c.name === 'foo')).toBe(true);
+  //     expect(db.pragma('user_version', { simple: true })).toBe(2);
+  //   });
 });

--- a/src/test/vitest.setup.ts
+++ b/src/test/vitest.setup.ts
@@ -27,6 +27,17 @@ export function createTestDb(): Database.Database {
   return db;
 }
 
+/**
+ * Creates a test DB stamped at a specific user_version, for migration-step tests.
+ * The caller is responsible for removing columns/tables that didn't exist at version n
+ * before calling runMigrations() — this helper only sets the version counter.
+ */
+export function createDbAtVersion(version: number): Database.Database {
+  const db = createTestDb();
+  db.pragma(`user_version = ${version}`);
+  return db;
+}
+
 export function insertProject(db: Database.Database, name: string): string {
   const id = uuidv4();
   db.prepare(


### PR DESCRIPTION
## Summary

- Wraps multi-statement DB operations in `db.transaction()` across `contacts.ts` and `projects.ts`, closing TOCTOU windows where a partial write could leave the DB inconsistent (adding a contact to a project, updating a membership, deleting an interaction log entry, importing/converting a shared project)
- Removes the `--font` CSS custom property (an alias for `--font-serif`) and inlines `var(--font-serif)` at the three remaining call sites
- Hardens the `ipcRenderer` test mock to throw on `invoke()` instead of silently resolving, making accidental IPC calls in tests immediately obvious
- Adds `createDbAtVersion()` helper for future migration-step tests; updates `migrations.test.ts` comment with a concrete usage example

## Test plan

- [x] `npm test` passes
- [x] Add a contact to a project, update a membership, delete an interaction log — verify no partial-write state if interrupted
- [x] UI renders correctly (fonts unchanged visually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)