### PR TITLE
Wrap settings:set-auto-backup writes in a transaction

### DIFF
--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -370,15 +370,17 @@ export function registerSettingsHandlers(): void {
     'settings:set-auto-backup',
     (_, data: { enabled?: boolean; destPath?: string | null; maxCount?: number }): void => {
       const db = getDatabase();
-      if (data.enabled !== undefined) {
-        db.prepare('UPDATE users SET auto_backup_enabled = ? WHERE id = 1').run(data.enabled ? 1 : 0);
-      }
-      if (data.destPath !== undefined) {
-        db.prepare('UPDATE users SET auto_backup_dest_path = ? WHERE id = 1').run(data.destPath ?? null);
-      }
-      if (data.maxCount !== undefined) {
-        db.prepare('UPDATE users SET auto_backup_max_count = ? WHERE id = 1').run(Math.max(1, data.maxCount));
-      }
+      db.transaction(() => {
+        if (data.enabled !== undefined) {
+          db.prepare('UPDATE users SET auto_backup_enabled = ? WHERE id = 1').run(data.enabled ? 1 : 0);
+        }
+        if (data.destPath !== undefined) {
+          db.prepare('UPDATE users SET auto_backup_dest_path = ? WHERE id = 1').run(data.destPath ?? null);
+        }
+        if (data.maxCount !== undefined) {
+          db.prepare('UPDATE users SET auto_backup_max_count = ? WHERE id = 1').run(Math.max(1, data.maxCount));
+        }
+      })();
     },
   );
 


### PR DESCRIPTION
## Summary

The `settings:set-auto-backup` handler performed up to three conditional `UPDATE` statements sequentially without a transaction. A crash between any two writes could leave the `users` row in a partially-updated state (e.g. `auto_backup_enabled` flipped but `auto_backup_dest_path` not yet written).

Wraps all three conditional writes in a single `db.transaction()` call.

This is the last remaining gap from the audit in #345 — the other handlers were addressed in #350.

Closes #345.

## Test plan

- [x] `npm test` passes
- [x] Toggle auto-backup on/off in Settings, change destination path and max count — verify all fields save correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)