### PR TITLE
Fix CalendarPicker: disabled day cursor and year grid centering

### DIFF
--- a/src/renderer/src/views/CalendarPicker.css
+++ b/src/renderer/src/views/CalendarPicker.css
@@ -189,7 +189,6 @@
 .cal-day--disabled {
   opacity: 0.25;
   cursor: not-allowed;
-  pointer-events: none;
 }
 
 /* ── Footer clear link ─────────────────────────────────────── */

--- a/src/renderer/src/views/CalendarPicker.tsx
+++ b/src/renderer/src/views/CalendarPicker.tsx
@@ -182,7 +182,7 @@ export function CalendarPicker({
                 <button
                   type="button"
                   className={`cal-year-btn${mode !== 'days' ? ' cal-year-btn--active' : ''}`}
-                  onClick={() => { setYearPageOffset(0); setMode('years'); }}
+                  onClick={() => { setYearPageOffset(0); if (value) setViewYear(isoToYMD(value).y); setMode('years'); }}
                 >
                   {viewYear}
                 </button>
@@ -263,7 +263,7 @@ export function CalendarPicker({
                       isToday ? 'cal-day--today' : '',
                       isDisabled ? 'cal-day--disabled' : '',
                     ].filter(Boolean).join(' ')}
-                    onClick={() => !isDisabled && selectDay(cell.y, cell.m, cell.d)}
+                    onClick={() => selectDay(cell.y, cell.m, cell.d)}
                     disabled={isDisabled}
                   >
                     {cell.d}


### PR DESCRIPTION
Closes #246
Closes #242

## Summary

- **#246** Disabled day cells showed no cursor feedback — `pointer-events: none` suppressed the cursor before `cursor: not-allowed` could render. Removed `pointer-events: none` so the `disabled` attribute handles click prevention and `cursor: not-allowed` is visible on hover. Also removed the now-redundant `!isDisabled &&` guard in `onClick`.
- **#242** Entering year mode by clicking the year label would centre the grid around `viewYear`, which could have drifted from the selected value if the user navigated months first. The year button click now re-sets `viewYear` to the selected date's year before switching to year mode.

## Test plan
- [x] Hover over a disabled day cell — `cursor: not-allowed` is visible
- [x] Click a disabled day cell — nothing happens, calendar stays open
- [x] Open calendar for a date in November 2019, navigate forward two months to January 2020 (crossing the year boundary), then click the year label showing "2020" — year grid opens centred on 2019 (the selected year), not 2020
- [x] Open calendar with no value, click year label — grid centred on current year

🤖 Generated with [Claude Code](https://claude.com/claude-code)