### PR TITLE
Fix import bugs: CSV malformed quotes/BOM, VCF name fallback, 50 MB size limit

### DIFF
--- a/src/main/ipc/import.ts
+++ b/src/main/ipc/import.ts
@@ -104,7 +104,7 @@ export function parseVcf(text: string): VcfContact[] {
       continue;
     }
     if (upper === 'END:VCARD') {
-      if (cur?.name) contacts.push(cur);
+      if (cur) contacts.push(cur);
       cur = null;
       continue;
     }
@@ -126,7 +126,7 @@ export function parseVcf(text: string): VcfContact[] {
       case 'N':
         // Synthesise display name from structured N field only if FN was absent
         if (!cur.name) {
-          const [last, first, middle] = value.split(';').map(decodeVcfValue);
+          const [last, first, middle] = value.split(/(?<!\\);/).map(decodeVcfValue);
           const synthesised = [first, middle, last].filter(Boolean).join(' ').trim();
           if (synthesised) cur.name = synthesised;
         }

--- a/src/main/ipc/import.ts
+++ b/src/main/ipc/import.ts
@@ -10,6 +10,9 @@ const SAMPLE_HEADERS =
   'Name,Organization,Title,DOB,Notes,Email,Phone,LinkedIn,X,Website,Theme,Status,Priority\n';
 
 export function parseCsv(text: string): string[][] {
+  // Strip UTF-8 BOM so Excel-exported files parse correctly
+  if (text.charCodeAt(0) === 0xfeff) text = text.slice(1);
+
   const result: string[][] = [];
   let i = 0;
   const n = text.length;
@@ -24,6 +27,8 @@ export function parseCsv(text: string): string[][] {
           i += 2;
         } else if (text[i] === '"') {
           i++;
+          // Consume any junk after the closing quote (non-RFC-4180 suffix like "Smith, Jr."suffix)
+          while (i < n && text[i] !== ',' && text[i] !== '\r' && text[i] !== '\n') i++;
           break;
         } else {
           s += text[i++];
@@ -118,6 +123,14 @@ export function parseVcf(text: string): VcfContact[] {
       case 'FN':
         cur.name = decodeVcfValue(value);
         break;
+      case 'N':
+        // Synthesise display name from structured N field only if FN was absent
+        if (!cur.name) {
+          const [last, first, middle] = value.split(';').map(decodeVcfValue);
+          const synthesised = [first, middle, last].filter(Boolean).join(' ').trim();
+          if (synthesised) cur.name = synthesised;
+        }
+        break;
       case 'ORG':
         cur.organization = decodeVcfValue(value.split(';')[0]) || null;
         break;
@@ -196,7 +209,7 @@ export function processVcfContacts(
 
   db.transaction(() => {
     for (const c of vcfContacts) {
-      if (!c.name) continue;
+      if (!c.name) { skipped.push({ name: '(unnamed contact)', reason: 'missing-name' }); continue; }
 
       const emails = [
         ...new Set(
@@ -407,6 +420,9 @@ export function registerImportHandlers(): void {
       });
       if (canceled || filePaths.length === 0) return { imported: 0, skipped: [], cancelled: true };
 
+      const stat = await fs.stat(filePaths[0]);
+      if (stat.size > 50 * 1024 * 1024) return { imported: 0, skipped: [], cancelled: false, error: 'File too large (max 50 MB).' };
+
       const content = await fs.readFile(filePaths[0], 'utf-8');
       const rows = parseCsv(content);
       const db = getDatabase();
@@ -445,6 +461,9 @@ export function registerImportHandlers(): void {
         properties: ['openFile'],
       });
       if (canceled || filePaths.length === 0) return { imported: 0, skipped: [], cancelled: true };
+
+      const stat = await fs.stat(filePaths[0]);
+      if (stat.size > 50 * 1024 * 1024) return { imported: 0, skipped: [], cancelled: false, error: 'File too large (max 50 MB).' };
 
       const content = await fs.readFile(filePaths[0], 'utf-8');
       const vcfContacts = parseVcf(content);

--- a/src/renderer/src/views/ImportResultModal.css
+++ b/src/renderer/src/views/ImportResultModal.css
@@ -63,3 +63,9 @@
   line-height: 1.8;
   list-style-type: none;
 }
+
+.ir-error {
+  font-size: 13px;
+  color: var(--color-danger);
+  margin: 0 0 10px;
+}

--- a/src/renderer/src/views/ImportResultModal.tsx
+++ b/src/renderer/src/views/ImportResultModal.tsx
@@ -11,47 +11,59 @@ interface Props {
 export default function ImportResultModal({ result, onClose }: Props) {
   const nameCollisions = result.skipped.filter((s) => s.reason === 'name');
   const emailCollisions = result.skipped.filter((s) => s.reason === 'email');
+  const missingName = result.skipped.filter((s) => s.reason === 'missing-name');
 
   return (
     <Modal title="Import complete" onDismiss={onClose} className="import-result-modal">
-      <div className="ir-summary">
-          <span className="ir-count">{result.imported}</span>
-          <span className="ir-label">
-            {result.imported === 1 ? 'contact imported' : 'contacts imported'}
-          </span>
-        </div>
-
-        {result.skipped.length > 0 && (
-          <div className="ir-skipped-section">
-            <div className="ir-collision-label">Result</div>
-            <p className="ir-skipped-intro">
-              {result.skipped.length} {result.skipped.length === 1 ? 'row was' : 'rows were'} skipped
-              due to existing contacts with the same name or email:
-            </p>
-
-            {nameCollisions.length > 0 && (
-              <div className="ir-collision-group">
-                <div className="ir-collision-label">Name collision{nameCollisions.length > 1 ? 's' : ''}</div>
-                <ul className="ir-collision-list">
-                  {nameCollisions.map((s) => (
-                    <li key={s.name}>{s.name}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-
-            {emailCollisions.length > 0 && (
-              <div className="ir-collision-group">
-                <div className="ir-collision-label">Email collision</div>
-                <ul className="ir-collision-list">
-                  {emailCollisions.map((s) => (
-                    <li key={s.name}>{s.name}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
+      {result.error ? (
+        <p className="ir-error">{result.error}</p>
+      ) : (
+        <>
+          <div className="ir-summary">
+            <span className="ir-count">{result.imported}</span>
+            <span className="ir-label">
+              {result.imported === 1 ? 'contact imported' : 'contacts imported'}
+            </span>
           </div>
-        )}
+
+          {result.skipped.length > 0 && (
+            <div className="ir-skipped-section">
+              <div className="ir-collision-label">Result</div>
+              <p className="ir-skipped-intro">
+                {result.skipped.length} {result.skipped.length === 1 ? 'row was' : 'rows were'} skipped:
+              </p>
+
+              {nameCollisions.length > 0 && (
+                <div className="ir-collision-group">
+                  <div className="ir-collision-label">Name collision{nameCollisions.length > 1 ? 's' : ''}</div>
+                  <ul className="ir-collision-list">
+                    {nameCollisions.map((s) => (
+                      <li key={s.name}>{s.name}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {emailCollisions.length > 0 && (
+                <div className="ir-collision-group">
+                  <div className="ir-collision-label">Email collision</div>
+                  <ul className="ir-collision-list">
+                    {emailCollisions.map((s) => (
+                      <li key={s.name}>{s.name}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {missingName.length > 0 && (
+                <div className="ir-collision-group">
+                  <div className="ir-collision-label">No name ({missingName.length})</div>
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      )}
 
       <div className="form-actions">
         <Button variant="primary" onClick={onClose}>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -322,8 +322,9 @@ export interface Reminder {
 
 export interface ImportResult {
   imported: number;
-  skipped: Array<{ name: string; reason: 'name' | 'email' }>;
+  skipped: Array<{ name: string; reason: 'name' | 'email' | 'missing-name' }>;
   cancelled: boolean;
+  error?: string;
 }
 
 export interface ContactAlertRss {

--- a/src/test/csv-parser.test.ts
+++ b/src/test/csv-parser.test.ts
@@ -81,4 +81,18 @@ describe('parseCsv', () => {
     expect(rows[0][2]).toBe('');
     expect(rows[1][2]).toBe('');
   });
+
+  it('strips a leading UTF-8 BOM so Excel exports parse correctly (#328)', () => {
+    const bom = '﻿';
+    const input = `${bom}Name,Email\nAlice,alice@example.com\n`;
+    const rows = parseCsv(input);
+    expect(rows[0][0]).toBe('Name');
+  });
+
+  it('heals malformed quoted fields with junk after closing quote (#328)', () => {
+    // "Smith, Jr."suffix — the suffix should be discarded, not shift columns
+    const input = 'Name,Email\n"Smith, Jr."suffix,alice@example.com\n';
+    const rows = parseCsv(input);
+    expect(rows[1]).toEqual(['Smith, Jr.', 'alice@example.com']);
+  });
 });

--- a/src/test/vcf-import.test.ts
+++ b/src/test/vcf-import.test.ts
@@ -43,9 +43,11 @@ describe('parseVcf — single contact', () => {
     expect(c.name).toBe('Bob Jones');
   });
 
-  it('returns [] when FN and N are both absent', () => {
+  it('returns a contact with empty name when FN and N are both absent', () => {
     const vcf = ['BEGIN:VCARD', 'EMAIL:anon@example.com', 'END:VCARD'].join('\n');
-    expect(parseVcf(vcf)).toHaveLength(0);
+    const contacts = parseVcf(vcf);
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].name).toBe('');
   });
 
   it('synthesises name from N field when FN is absent', () => {
@@ -60,9 +62,17 @@ describe('parseVcf — single contact', () => {
     expect(c.name).toBe('Alice Smith');
   });
 
-  it('returns [] when FN is empty', () => {
+  it('handles escaped semicolons in N field components', () => {
+    const vcf = ['BEGIN:VCARD', 'N:Smith\\;Jr;Alice;;;', 'END:VCARD'].join('\n');
+    const [c] = parseVcf(vcf);
+    expect(c.name).toBe('Alice Smith;Jr');
+  });
+
+  it('returns a contact with empty name when FN is empty', () => {
     const vcf = ['BEGIN:VCARD', 'FN:', 'END:VCARD'].join('\n');
-    expect(parseVcf(vcf)).toHaveLength(0);
+    const contacts = parseVcf(vcf);
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].name).toBe('');
   });
 });
 
@@ -79,12 +89,15 @@ describe('parseVcf — multi-contact file', () => {
     expect(contacts.map((c) => c.name)).toEqual(['Alice Smith', 'Bob Jones', 'Carol White']);
   });
 
-  it('skips invalid blocks and still returns valid ones', () => {
+  it('returns all blocks including nameless ones', () => {
     const vcf = [
       'BEGIN:VCARD', 'FN:Good Contact', 'END:VCARD',
       'BEGIN:VCARD', 'NOTE:no name here', 'END:VCARD',
     ].join('\n');
-    expect(parseVcf(vcf)).toHaveLength(1);
+    const contacts = parseVcf(vcf);
+    expect(contacts).toHaveLength(2);
+    expect(contacts[0].name).toBe('Good Contact');
+    expect(contacts[1].name).toBe('');
   });
 });
 
@@ -309,6 +322,14 @@ function makeContact(overrides: Partial<VcfContact> = {}): VcfContact {
 beforeEach(() => {
   db = createTestDb();
   projectId = insertProject(db, 'Test Project');
+});
+
+describe('processVcfContacts — missing name', () => {
+  it('skips a nameless contact and reports missing-name', () => {
+    const result = processVcfContacts([makeContact({ name: '' })], db, BASE_OPTS);
+    expect(result.imported).toBe(0);
+    expect(result.skipped).toEqual([{ name: '(unnamed contact)', reason: 'missing-name' }]);
+  });
 });
 
 describe('processVcfContacts — basic import', () => {

--- a/src/test/vcf-import.test.ts
+++ b/src/test/vcf-import.test.ts
@@ -43,9 +43,21 @@ describe('parseVcf — single contact', () => {
     expect(c.name).toBe('Bob Jones');
   });
 
-  it('returns [] when FN is absent', () => {
+  it('returns [] when FN and N are both absent', () => {
     const vcf = ['BEGIN:VCARD', 'EMAIL:anon@example.com', 'END:VCARD'].join('\n');
     expect(parseVcf(vcf)).toHaveLength(0);
+  });
+
+  it('synthesises name from N field when FN is absent', () => {
+    const vcf = ['BEGIN:VCARD', 'N:Smith;Alice;M;;', 'EMAIL:alice@example.com', 'END:VCARD'].join('\n');
+    const [c] = parseVcf(vcf);
+    expect(c.name).toBe('Alice M Smith');
+  });
+
+  it('prefers FN over N when both are present', () => {
+    const vcf = ['BEGIN:VCARD', 'FN:Alice Smith', 'N:Smith;Alice;;;', 'END:VCARD'].join('\n');
+    const [c] = parseVcf(vcf);
+    expect(c.name).toBe('Alice Smith');
   });
 
   it('returns [] when FN is empty', () => {


### PR DESCRIPTION
Closes #328
Closes #227
Closes #194

## Summary

- **#328** `parseCsv` now strips a leading UTF-8 BOM so files exported from Excel are parsed correctly. Also heals malformed quoted fields (e.g. `"Smith, Jr."suffix`) by consuming the junk suffix rather than silently shifting all subsequent columns right.
- **#227** `parseVcf` now synthesises a display name from the structured `N` field when `FN` is absent — matching what Outlook, Android, and LinkedIn commonly export. Contacts that still have no name after the fallback are now tracked in `skipped` with `reason: 'missing-name'` instead of silently dropped.
- **#194** Both `import:csv` and `import:vcf` now `stat` the file before reading and reject files over 50 MB with a clear error message (`error: 'File too large (max 50 MB).'`). The `ImportResult` type gains an optional `error` field, and `ImportResultModal` displays it when present.

## Test plan
- [ ] Import a CSV exported from Excel with BOM — first column header parses as `Name`, not `﻿Name`
- [ ] Import a CSV with a malformed quoted field like `"Smith, Jr."extra` — contact imports with `Smith, Jr.`, subsequent columns correct
- [ ] Import a VCF with only `N:Smith;Alice;;` and no `FN` — contact imports with name `Alice Smith`
- [ ] Import a file larger than 50 MB — result modal shows "File too large" error, 0 contacts imported
- [ ] Normal CSV and VCF imports still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)