### PR TITLE
Fix timer lifecycle: stop auto-lock and auto-backup timers on lock/quit

### DIFF
--- a/src/main/auto-backup-timer.ts
+++ b/src/main/auto-backup-timer.ts
@@ -16,6 +16,7 @@ export function startAutoBackupTimer(): void {
       .get() as { auto_backup_enabled: number; auto_backup_dest_path: string | null } | undefined;
     if (!user?.auto_backup_enabled || !user.auto_backup_dest_path) return;
     const lastMs = await getLastAutoBackupTime(user.auto_backup_dest_path);
+    if (!isDatabaseOpen()) return;
     if (lastMs === null || Date.now() - lastMs >= ONE_DAY) {
       runAutoBackup().catch(() => {});
     }

--- a/src/main/auto-backup-timer.ts
+++ b/src/main/auto-backup-timer.ts
@@ -1,0 +1,30 @@
+import { isDatabaseOpen, getDatabase } from './database';
+import { runAutoBackup, getLastAutoBackupTime } from './ipc/auto-backup';
+
+const ONE_HOUR = 60 * 60 * 1000;
+const ONE_DAY = 24 * ONE_HOUR;
+
+let autoBackupInterval: ReturnType<typeof setInterval> | null = null;
+
+export function startAutoBackupTimer(): void {
+  stopAutoBackupTimer();
+  autoBackupInterval = setInterval(async () => {
+    if (!isDatabaseOpen()) return;
+    const db = getDatabase();
+    const user = db
+      .prepare('SELECT auto_backup_enabled, auto_backup_dest_path FROM users WHERE id = 1')
+      .get() as { auto_backup_enabled: number; auto_backup_dest_path: string | null } | undefined;
+    if (!user?.auto_backup_enabled || !user.auto_backup_dest_path) return;
+    const lastMs = await getLastAutoBackupTime(user.auto_backup_dest_path);
+    if (lastMs === null || Date.now() - lastMs >= ONE_DAY) {
+      runAutoBackup().catch(() => {});
+    }
+  }, ONE_HOUR);
+}
+
+export function stopAutoBackupTimer(): void {
+  if (autoBackupInterval) {
+    clearInterval(autoBackupInterval);
+    autoBackupInterval = null;
+  }
+}

--- a/src/main/auto-lock.ts
+++ b/src/main/auto-lock.ts
@@ -3,6 +3,7 @@ import { closeDatabase, isDatabaseOpen } from './database';
 import { closeAllSharedDbs } from './database/shared-db';
 import { stopPoller } from './sync/poller';
 import { clearExtensionSession } from './http-server';
+import { stopAutoBackupTimer } from './auto-backup-timer';
 
 const IDLE_CHECK_INTERVAL_MS = 15_000;
 const DEFAULT_IDLE_THRESHOLD_MS = 15 * 60 * 1000;
@@ -37,6 +38,7 @@ class AutoLockManager {
 
   lock(): void {
     if (!isDatabaseOpen()) return;
+    stopAutoBackupTimer();
     stopPoller();
     closeAllSharedDbs();
     clearExtensionSession();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,12 +16,13 @@ import { registerAlertHandlers } from './ipc/alerts';
 import { registerReminderHandlers } from './ipc/reminders';
 import { registerImportHandlers } from './ipc/import';
 import { registerBackupHandlers } from './ipc/backup';
-import { registerAutoBackupHandlers, runAutoBackup, getLastAutoBackupTime } from './ipc/auto-backup';
+import { registerAutoBackupHandlers, runAutoBackup } from './ipc/auto-backup';
+import { startAutoBackupTimer, stopAutoBackupTimer } from './auto-backup-timer';
 import { registerScreenshotHandlers } from './ipc/screenshots';
 import { registerSearchHandlers } from './ipc/search';
 import { registerUpdaterHandlers, triggerUpdateCheck } from './ipc/updater';
 import { autoLock } from './auto-lock';
-import { closeDatabase, getDatabase, isDatabaseOpen } from './database';
+import { closeDatabase } from './database';
 import { closeAllSharedDbs } from './database/shared-db';
 import { startHttpServer } from './http-server';
 import { stopPoller } from './sync/poller';
@@ -224,6 +225,8 @@ app.whenReady().then(() => {
 // so it won't recurse.
 app.on('before-quit', (event) => {
   event.preventDefault();
+  autoLock.stop();
+  stopAutoBackupTimer();
   runAutoBackup().catch(() => {}).finally(() => app.exit(0));
 });
 
@@ -231,35 +234,8 @@ app.on('window-all-closed', () => {
   stopPoller();
   closeAllSharedDbs();
   closeDatabase();
+  stopAutoBackupTimer();
   autoLock.stop();
   if (process.platform !== 'darwin') app.quit();
 });
-
-// Daily auto-backup timer: check every hour if 24h have passed since the last backup
-let autoBackupInterval: ReturnType<typeof setInterval> | null = null;
-
-export function startAutoBackupTimer(): void {
-  if (autoBackupInterval) return;
-  const ONE_HOUR = 60 * 60 * 1000;
-  const ONE_DAY = 24 * ONE_HOUR;
-  autoBackupInterval = setInterval(async () => {
-    if (!isDatabaseOpen()) return;
-    const db = getDatabase();
-    const user = db
-      .prepare('SELECT auto_backup_enabled, auto_backup_dest_path FROM users WHERE id = 1')
-      .get() as { auto_backup_enabled: number; auto_backup_dest_path: string | null } | undefined;
-    if (!user?.auto_backup_enabled || !user.auto_backup_dest_path) return;
-    const lastMs = await getLastAutoBackupTime(user.auto_backup_dest_path);
-    if (lastMs === null || Date.now() - lastMs >= ONE_DAY) {
-      runAutoBackup().catch(() => {});
-    }
-  }, ONE_HOUR);
-}
-
-export function stopAutoBackupTimer(): void {
-  if (autoBackupInterval) {
-    clearInterval(autoBackupInterval);
-    autoBackupInterval = null;
-  }
-}
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,7 +17,7 @@ import { registerReminderHandlers } from './ipc/reminders';
 import { registerImportHandlers } from './ipc/import';
 import { registerBackupHandlers } from './ipc/backup';
 import { registerAutoBackupHandlers, runAutoBackup } from './ipc/auto-backup';
-import { startAutoBackupTimer, stopAutoBackupTimer } from './auto-backup-timer';
+import { stopAutoBackupTimer } from './auto-backup-timer';
 import { registerScreenshotHandlers } from './ipc/screenshots';
 import { registerSearchHandlers } from './ipc/search';
 import { registerUpdaterHandlers, triggerUpdateCheck } from './ipc/updater';

--- a/src/main/ipc/unlock.ts
+++ b/src/main/ipc/unlock.ts
@@ -4,7 +4,7 @@ import { getPaths, deriveKey } from '../utils';
 import { unlockDatabase, maybeRunDevSeeds, setActivePassword } from '../database';
 import { autoLock } from '../auto-lock';
 import { startPoller } from '../sync/poller';
-import { startAutoBackupTimer } from '../index';
+import { startAutoBackupTimer } from '../auto-backup-timer';
 import { checkOutreachReminders, clearOutreachNotificationCache } from '../sync/outreach-checker';
 import { checkReminders, clearReminderNotificationCache } from '../sync/reminder-checker';
 import { runDedupScan } from './contacts';


### PR DESCRIPTION
Closes #222
Closes #179
Closes #157
Closes #272

## Summary

Extracts the auto-backup timer into `src/main/auto-backup-timer.ts` to avoid a circular import, then wires all missing stop/start calls:

- **#222 / #179 / #157** `AutoLockManager.lock()` now calls `stopAutoBackupTimer()` before closing the DB, preventing the hourly timer from firing against a closed DB handle after a lock. `startAutoBackupTimer()` now calls `stopAutoBackupTimer()` before creating the new interval (replacing the `if (interval) return` guard), so each unlock gets a fresh, correctly-timed interval instead of reusing a stale one from the previous session.
- **#272** `before-quit` now calls `autoLock.stop()` and `stopAutoBackupTimer()` before starting the async `runAutoBackup()`, so neither the idle-check nor the backup-tick interval can fire concurrently with the shutdown backup.
- `window-all-closed` also calls `stopAutoBackupTimer()` for symmetry.

## Test plan
- [ ] Lock the app — auto-backup timer stops (no hourly ticks while locked)
- [ ] Unlock → lock → unlock — auto-backup timer restarts cleanly on second unlock, not stale from first
- [ ] Quit the app — backup completes, no idle-check fires mid-backup
- [ ] Normal unlock and auto-backup still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)