### PR TITLE
Debounce search modal IPC calls by 250ms

### DIFF
--- a/src/renderer/src/shell/SearchModal.tsx
+++ b/src/renderer/src/shell/SearchModal.tsx
@@ -19,16 +19,17 @@ export default function SearchModal({ onClose, onNav, onOpenContact }: Props) {
 
   useEffect(() => {
     let cancelled = false;
-    const cleanup = () => { cancelled = true; };
     setSelectedIndex(0);
     latestQueryRef.current = query;
-    if (!query.trim()) { setResults([]); return cleanup; }
-    window.sourcerer.searchGlobal(query).then((r) => {
-      if (!cancelled && latestQueryRef.current === query) setResults(r);
-    }).catch(() => {
-      if (!cancelled && latestQueryRef.current === query) setResults([]);
-    });
-    return cleanup;
+    if (!query.trim()) { setResults([]); return () => { cancelled = true; }; }
+    const timer = setTimeout(() => {
+      window.sourcerer.searchGlobal(query).then((r) => {
+        if (!cancelled && latestQueryRef.current === query) setResults(r);
+      }).catch(() => {
+        if (!cancelled && latestQueryRef.current === query) setResults([]);
+      });
+    }, 250);
+    return () => { cancelled = true; clearTimeout(timer); };
   }, [query]);
 
   function pick(result: SearchResult) {

--- a/src/renderer/src/shell/SearchModal.tsx
+++ b/src/renderer/src/shell/SearchModal.tsx
@@ -14,19 +14,28 @@ export default function SearchModal({ onClose, onNav, onOpenContact }: Props) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [searching, setSearching] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const latestQueryRef = useRef('');
 
   useEffect(() => {
+    const normalized = query.trim();
     let cancelled = false;
     setSelectedIndex(0);
-    latestQueryRef.current = query;
-    if (!query.trim()) { setResults([]); return () => { cancelled = true; }; }
+    if (!normalized) {
+      latestQueryRef.current = '';
+      setResults([]);
+      setSearching(false);
+      return () => { cancelled = true; };
+    }
+    if (normalized === latestQueryRef.current) return () => { cancelled = true; };
+    latestQueryRef.current = normalized;
+    setSearching(true);
     const timer = setTimeout(() => {
-      window.sourcerer.searchGlobal(query).then((r) => {
-        if (!cancelled && latestQueryRef.current === query) setResults(r);
+      window.sourcerer.searchGlobal(normalized).then((r) => {
+        if (!cancelled && latestQueryRef.current === normalized) { setResults(r); setSearching(false); }
       }).catch(() => {
-        if (!cancelled && latestQueryRef.current === query) setResults([]);
+        if (!cancelled && latestQueryRef.current === normalized) { setResults([]); setSearching(false); }
       });
     }, 250);
     return () => { cancelled = true; clearTimeout(timer); };
@@ -132,7 +141,7 @@ export default function SearchModal({ onClose, onNav, onOpenContact }: Props) {
         </div>
       )}
 
-      {query.trim() !== '' && results.length === 0 && (
+      {query.trim() !== '' && results.length === 0 && !searching && (
         <div className="search-empty">No results for "{query}"</div>
       )}
 

--- a/src/renderer/src/shell/SearchModal.tsx
+++ b/src/renderer/src/shell/SearchModal.tsx
@@ -18,28 +18,28 @@ export default function SearchModal({ onClose, onNav, onOpenContact }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const latestQueryRef = useRef('');
 
+  const normalizedQuery = query.trim();
+
   useEffect(() => {
-    const normalized = query.trim();
     let cancelled = false;
     setSelectedIndex(0);
-    if (!normalized) {
+    if (!normalizedQuery) {
       latestQueryRef.current = '';
       setResults([]);
       setSearching(false);
       return () => { cancelled = true; };
     }
-    if (normalized === latestQueryRef.current) return () => { cancelled = true; };
-    latestQueryRef.current = normalized;
+    latestQueryRef.current = normalizedQuery;
     setSearching(true);
     const timer = setTimeout(() => {
-      window.sourcerer.searchGlobal(normalized).then((r) => {
-        if (!cancelled && latestQueryRef.current === normalized) { setResults(r); setSearching(false); }
+      window.sourcerer.searchGlobal(normalizedQuery).then((r) => {
+        if (!cancelled && latestQueryRef.current === normalizedQuery) { setResults(r); setSearching(false); }
       }).catch(() => {
-        if (!cancelled && latestQueryRef.current === normalized) { setResults([]); setSearching(false); }
+        if (!cancelled && latestQueryRef.current === normalizedQuery) { setResults([]); setSearching(false); }
       });
     }, 250);
     return () => { cancelled = true; clearTimeout(timer); };
-  }, [query]);
+  }, [normalizedQuery]);
 
   function pick(result: SearchResult) {
     if (result.type === 'contact') {


### PR DESCRIPTION
## Summary

`SearchModal` was calling `searchGlobal` on every keystroke with no debounce. On a large database, this fires a full-table-scan SQL query (joining `contacts`, `contact_emails`, `contact_phones`) on every character typed, which blocks the main process synchronously.

Adding a 250ms debounce means rapid typing queues at most one query per pause rather than one per character. The existing `cancelled` flag and `latestQueryRef` already discard stale results — the debounce reduces the number of queries issued in the first place.

Note: issue #213 (FTS5 index for the underlying LIKE scan) is a separate, larger change that requires a migration + FTS rebuild for existing databases. Deferred for now.

Closes #211.

## Test plan

- [ ] `npm test` passes
- [ ] Typing quickly in the search modal still returns correct results after a short pause
- [ ] Results clear immediately when the query is emptied

🤖 Generated with [Claude Code](https://claude.com/claude-code)