### PR TITLE
Three sync engine performance fixes

### DIFF
--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -491,9 +491,14 @@ function pullAppendOnly(
     .prepare('SELECT COALESCE(MAX(fetched_at), 0) AS m FROM contact_alert_mentions')
     .get() as { m: number }).m;
 
+  // Subtract a 30-second overlap window so rows that arrive late (due to clock
+  // skew between clients) are always eventually reconciled. Duplicates are safe
+  // because the INSERT below uses OR IGNORE.
+  const fetchedAtWatermark = Math.max(0, maxFetchedAt - 30);
+
   for (const sm of shared.prepare(
     'SELECT * FROM contact_alert_mentions WHERE fetched_at > ?',
-  ).all(maxFetchedAt) as {
+  ).all(fetchedAtWatermark) as {
     id: string;
     contact_id: string;
     headline: string;
@@ -516,9 +521,12 @@ function pullAppendOnly(
     .prepare('SELECT COALESCE(MAX(created_at), 0) AS m FROM interaction_log_entries')
     .get() as { m: number }).m;
 
+  // Same 30-second overlap window as above.
+  const createdAtWatermark = Math.max(0, maxCreatedAt - 30);
+
   for (const se of shared.prepare(
     'SELECT * FROM interaction_log_entries WHERE created_at > ?',
-  ).all(maxCreatedAt) as {
+  ).all(createdAtWatermark) as {
     id: string;
     contact_id: string;
     reporter_email: string;

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -1,6 +1,22 @@
 import { v4 as uuidv4 } from 'uuid';
 import Database from 'better-sqlite3-multiple-ciphers';
 
+// All tables with a contact_id FK to contacts — used by adoptSharedUuid to
+// remap UUIDs without querying PRAGMA foreign_key_list on every sync cycle.
+const CONTACT_ID_FK_TABLES = [
+  'contact_emails',
+  'contact_phones',
+  'contact_links',
+  'contact_handles',
+  'contact_alert_rss',
+  'contact_alert_mentions',
+  'project_memberships',
+  'interaction_log_entries',
+  'message_scratchpad_drafts',
+  'reminders',
+  'contact_screenshots',
+];
+
 export interface SyncResult {
   success: boolean;
   error?: string;
@@ -93,13 +109,8 @@ function adoptSharedUuid(local: Database.Database, fromId: string, toId: string)
       'INSERT INTO contacts (id, name, organization, title, dob, notes, created_at, updated_at, synced_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
     )
     .run(toId, c.name, c.organization, c.title ?? null, c.dob ?? null, c.notes, c.created_at, c.updated_at, null);
-  // Remap every table with a contact_id FK — derived at runtime so new tables are never missed.
-  const allTableNames = (local.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as { name: string }[]).map((r) => r.name);
-  for (const table of allTableNames) {
-    const fks = local.prepare(`PRAGMA foreign_key_list("${table}")`).all() as { from: string; table: string }[];
-    if (fks.some((fk) => fk.from === 'contact_id' && fk.table === 'contacts')) {
-      local.prepare(`UPDATE "${table}" SET contact_id = ? WHERE contact_id = ?`).run(toId, fromId);
-    }
+  for (const table of CONTACT_ID_FK_TABLES) {
+    local.prepare(`UPDATE "${table}" SET contact_id = ? WHERE contact_id = ?`).run(toId, fromId);
   }
   // dedup_dismissed_pairs has two separate contact FK columns — remap before delete
   const dedupRows = local
@@ -472,7 +483,17 @@ function pullAppendOnly(
   local: Database.Database,
   shared: Database.Database,
 ): void {
-  for (const sm of shared.prepare('SELECT * FROM contact_alert_mentions').all() as {
+  // Use high-watermarks to avoid loading entire shared tables on every sync.
+  // INSERT OR IGNORE is idempotent so re-fetching rows we already have is safe;
+  // the watermark merely avoids the memory cost of loading them all upfront.
+
+  const maxFetchedAt = (local
+    .prepare('SELECT COALESCE(MAX(fetched_at), 0) AS m FROM contact_alert_mentions')
+    .get() as { m: number }).m;
+
+  for (const sm of shared.prepare(
+    'SELECT * FROM contact_alert_mentions WHERE fetched_at > ?',
+  ).all(maxFetchedAt) as {
     id: string;
     contact_id: string;
     headline: string;
@@ -488,19 +509,16 @@ function pullAppendOnly(
            (id, contact_id, headline, source_url, published_at, fetched_at, guid, seen)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(
-        sm.id,
-        sm.contact_id,
-        sm.headline,
-        sm.source_url,
-        sm.published_at,
-        sm.fetched_at,
-        sm.guid,
-        sm.seen,
-      );
+      .run(sm.id, sm.contact_id, sm.headline, sm.source_url, sm.published_at, sm.fetched_at, sm.guid, sm.seen);
   }
 
-  for (const se of shared.prepare('SELECT * FROM interaction_log_entries').all() as {
+  const maxCreatedAt = (local
+    .prepare('SELECT COALESCE(MAX(created_at), 0) AS m FROM interaction_log_entries')
+    .get() as { m: number }).m;
+
+  for (const se of shared.prepare(
+    'SELECT * FROM interaction_log_entries WHERE created_at > ?',
+  ).all(maxCreatedAt) as {
     id: string;
     contact_id: string;
     reporter_email: string;
@@ -517,7 +535,11 @@ function pullAppendOnly(
       .run(se.id, se.contact_id, se.reporter_email, se.reporter_name, se.body, se.created_at);
   }
 
-  for (const sip of shared.prepare('SELECT * FROM interaction_projects').all() as {
+  for (const sip of shared.prepare(
+    `SELECT ip.* FROM interaction_projects ip
+     JOIN interaction_log_entries ile ON ile.id = ip.interaction_id
+     WHERE ile.created_at > ?`,
+  ).all(maxCreatedAt) as {
     interaction_id: string;
     membership_id: string;
   }[]) {

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -497,7 +497,7 @@ function pullAppendOnly(
   const fetchedAtWatermark = Math.max(0, maxFetchedAt - 30);
 
   for (const sm of shared.prepare(
-    'SELECT * FROM contact_alert_mentions WHERE fetched_at > ?',
+    'SELECT * FROM contact_alert_mentions WHERE fetched_at >= ?',
   ).all(fetchedAtWatermark) as {
     id: string;
     contact_id: string;
@@ -525,7 +525,7 @@ function pullAppendOnly(
   const createdAtWatermark = Math.max(0, maxCreatedAt - 30);
 
   for (const se of shared.prepare(
-    'SELECT * FROM interaction_log_entries WHERE created_at > ?',
+    'SELECT * FROM interaction_log_entries WHERE created_at >= ?',
   ).all(createdAtWatermark) as {
     id: string;
     contact_id: string;
@@ -546,8 +546,8 @@ function pullAppendOnly(
   for (const sip of shared.prepare(
     `SELECT ip.* FROM interaction_projects ip
      JOIN interaction_log_entries ile ON ile.id = ip.interaction_id
-     WHERE ile.created_at > ?`,
-  ).all(maxCreatedAt) as {
+     WHERE ile.created_at >= ?`,
+  ).all(createdAtWatermark) as {
     interaction_id: string;
     membership_id: string;
   }[]) {

--- a/src/main/sync/poller.ts
+++ b/src/main/sync/poller.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { BrowserWindow } from 'electron';
 import { getDatabase, isDatabaseOpen } from '../database';
@@ -82,7 +82,7 @@ export function syncOne(projectId: string, filePath: string, keyBytes: Buffer): 
     // Close after each sync so the file handle is released and Dropbox/OneDrive
     // can detect the change and upload it promptly.
     closeSharedDb(projectId);
-    deleteConflictCopies(filePath);
+    deleteConflictCopies(filePath).catch(() => {});
 
     const project = localDb
       .prepare('SELECT shared_pending_writes FROM projects WHERE id = ?')
@@ -119,19 +119,20 @@ export function syncOne(projectId: string, filePath: string, keyBytes: Buffer): 
   return result;
 }
 
-function deleteConflictCopies(filePath: string): void {
+async function deleteConflictCopies(filePath: string): Promise<void> {
   const dir = path.dirname(filePath);
   const ext = path.extname(filePath);
   const base = path.basename(filePath, ext);
   try {
-    for (const file of fs.readdirSync(dir)) {
+    const files = await fs.readdir(dir);
+    for (const file of files) {
       if (
         file !== path.basename(filePath) &&
         file.startsWith(base) &&
         file.endsWith(ext) &&
         /conflicted copy/i.test(file)
       ) {
-        try { fs.unlinkSync(path.join(dir, file)); } catch { /* best-effort */ }
+        try { await fs.unlink(path.join(dir, file)); } catch { /* best-effort */ }
       }
     }
   } catch { /* best-effort */ }

--- a/src/renderer/src/shell/SearchModal.tsx
+++ b/src/renderer/src/shell/SearchModal.tsx
@@ -19,16 +19,17 @@ export default function SearchModal({ onClose, onNav, onOpenContact }: Props) {
 
   useEffect(() => {
     let cancelled = false;
-    const cleanup = () => { cancelled = true; };
     setSelectedIndex(0);
     latestQueryRef.current = query;
-    if (!query.trim()) { setResults([]); return cleanup; }
-    window.sourcerer.searchGlobal(query).then((r) => {
-      if (!cancelled && latestQueryRef.current === query) setResults(r);
-    }).catch(() => {
-      if (!cancelled && latestQueryRef.current === query) setResults([]);
-    });
-    return cleanup;
+    if (!query.trim()) { setResults([]); return () => { cancelled = true; }; }
+    const timer = setTimeout(() => {
+      window.sourcerer.searchGlobal(query).then((r) => {
+        if (!cancelled && latestQueryRef.current === query) setResults(r);
+      }).catch(() => {
+        if (!cancelled && latestQueryRef.current === query) setResults([]);
+      });
+    }, 250);
+    return () => { cancelled = true; clearTimeout(timer); };
   }, [query]);
 
   function pick(result: SearchResult) {

--- a/src/test/sync-engine.test.ts
+++ b/src/test/sync-engine.test.ts
@@ -306,6 +306,51 @@ describe('syncProject — push path', () => {
 });
 
 // ---------------------------------------------------------------------------
+// pullAppendOnly — overlap window reconciliation
+// ---------------------------------------------------------------------------
+
+describe('pullAppendOnly — overlap window', () => {
+  it('pulls a late-arriving log entry whose created_at falls within the 30s overlap window', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Overlap Test');
+
+    // Pre-seed both DBs with the same contact UUID so syncProject skips UUID adoption.
+    const contactId = uuidv4();
+    const membershipId = uuidv4();
+    localDb.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Alice', NOW, NOW);
+    localDb.prepare('INSERT INTO contact_emails (id, contact_id, email, sort_order) VALUES (?, ?, ?, ?)').run(uuidv4(), contactId, 'alice@example.com', 0);
+    sharedInsertContact(sharedDb, contactId, 'Alice', { emails: ['alice@example.com'] });
+
+    // Matching membership with the same ID in both DBs.
+    localDb.prepare(
+      'INSERT INTO project_memberships (id, contact_id, project_id, reporter_email, reporter_name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    ).run(membershipId, contactId, projectId, 'r@r.com', 'Reporter', NOW, NOW);
+    sharedInsertMembership(sharedDb, membershipId, contactId);
+
+    // Existing local entry at NOW establishes the high-watermark.
+    localDb.prepare(
+      'INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run(uuidv4(), contactId, 'r@r.com', 'Reporter', 'existing', NOW);
+
+    // Shared entry at NOW - 25 is below the local max but within the 30s overlap window.
+    const lateEntryId = uuidv4();
+    sharedDb.prepare(
+      'INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run(lateEntryId, contactId, 'r@r.com', 'Reporter', 'late entry', NOW - 25);
+    sharedDb.prepare('INSERT INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)').run(lateEntryId, membershipId);
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+
+    // Late entry and its project link should be pulled into local DB.
+    expect(localDb.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(lateEntryId)).toBeDefined();
+    const ip = localDb.prepare('SELECT membership_id FROM interaction_projects WHERE interaction_id = ?').get(lateEntryId) as { membership_id: string } | undefined;
+    expect(ip?.membership_id).toBe(membershipId);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // LWW (last-write-wins): newer version should win (#268)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **#255 `deleteConflictCopies`**: Switched from `readdirSync`/`unlinkSync` to `fs.promises` equivalents and called fire-and-forget after `closeSharedDb`. Sync filesystem I/O on a network-backed folder (Dropbox, OneDrive) blocks the Electron main thread for the full network round-trip. Conflict-copy cleanup is best-effort and doesn't need to hold up the sync result.

- **#258 `adoptSharedUuid`**: Replaced the per-call `PRAGMA foreign_key_list` loop with a static `CONTACT_ID_FK_TABLES` constant. The old code issued N+1 PRAGMA queries per UUID adoption on every sync cycle. The set of tables with a `contact_id` FK is fixed by the schema and never changes at runtime.

- **#243 `pullAppendOnly`**: Added high-watermark filtering to avoid loading entire shared tables into memory on every sync poll. `contact_alert_mentions` is now filtered by `fetched_at > local max`; `interaction_log_entries` and `interaction_projects` by `created_at > local max`. `INSERT OR IGNORE` ensures correctness if the watermark overlaps an existing row.

  **Follow-up (Copilot review):** Both high-watermark queries now subtract a 30-second overlap window (`Math.max(0, max - 30)`) before querying the shared DB. Without this, rows written by a client with a slightly behind clock — or rows that arrive out-of-order — can be permanently skipped once the local max advances past them. The overlap means we re-fetch a small tail of already-seen rows on each poll, but `INSERT OR IGNORE` discards duplicates harmlessly.

- **SearchModal debounce (also in PR #358):** This branch also contains the 250ms debounce added to `SearchModal` (commit `3eb8f9c`). That change originated separately on `fix/perf-search-debounce` (#358). The two branches share that commit due to the order they were cut; whichever merges second will be a no-op for that file.

Closes #255, closes #258, closes #243.

## Test plan

- [ ] `npm test` passes
- [ ] Sync works correctly for a shared project (new contacts/logs appear locally after sync)
- [ ] Alert mentions sync correctly across clients
- [ ] Interaction log entries sync correctly across clients
- [ ] No main-thread freezes during sync on a network drive
- [ ] Rows written by a clock-skewed client eventually appear after the next poll (overlap window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)