### PR TITLE
Fix UI error handling: optimistic revert, allSettled bulk ops, dropdown stability

### DIFF
--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -1034,6 +1034,11 @@
   background: rgba(200, 122, 26, 0.08);
 }
 
+.pt-draft-error {
+  font-size: 12px;
+  color: var(--color-danger);
+  margin: 0 0 8px;
+}
 
 .detail-rss-feed {
   margin-bottom: 6px;

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -231,6 +231,7 @@ function ScratchpadSection({
 }) {
   const [drafts, setDrafts] = useState<ScratchpadDraft[]>([]);
   const [draftEdits, setDraftEdits] = useState<Record<string, { label: string; body: string }>>({});
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -255,20 +256,25 @@ function ScratchpadSection({
   }
 
   async function handleSave(draft: ScratchpadDraft) {
+    setSaveError(null);
     const edit = getEdit(draft);
-    const saved = await window.sourcerer.saveScratchpad({
-      id: draft.id,
-      contactId,
-      projectId: membership.id,
-      label: edit.label,
-      body: edit.body,
-    });
-    setDrafts((prev) => prev.map((d) => (d.id === saved.id ? saved : d)));
-    setDraftEdits((prev) => {
-      const next = { ...prev };
-      delete next[draft.id];
-      return next;
-    });
+    try {
+      const saved = await window.sourcerer.saveScratchpad({
+        id: draft.id,
+        contactId,
+        projectId: membership.id,
+        label: edit.label,
+        body: edit.body,
+      });
+      setDrafts((prev) => prev.map((d) => (d.id === saved.id ? saved : d)));
+      setDraftEdits((prev) => {
+        const next = { ...prev };
+        delete next[draft.id];
+        return next;
+      });
+    } catch {
+      setSaveError('Failed to save draft. Please try again.');
+    }
   }
 
   async function handleNewDraft() {
@@ -294,6 +300,7 @@ function ScratchpadSection({
           + Add
         </Button>
       </div>
+      {saveError && <p className="pt-draft-error">{saveError}</p>}
       {drafts.length === 0 && <p className="pt-reminders-empty">No drafts yet.</p>}
       {drafts.map((draft) => {
         const edit = getEdit(draft);

--- a/src/renderer/src/contacts/QuickLogModal.tsx
+++ b/src/renderer/src/contacts/QuickLogModal.tsx
@@ -4,6 +4,7 @@ import Modal from '../shell/Modal';
 import Button from '../shell/Button';
 import { CalendarPicker } from '../views/CalendarPicker';
 import LogProjectPicker from './LogProjectPicker';
+import { useClickOutside } from '../hooks/useClickOutside';
 import './QuickLogModal.css';
 
 function todayISO(): string {
@@ -28,6 +29,8 @@ export default function QuickLogModal({ onClose, onSaved }: Props) {
   const [body, setBody] = useState('');
   const [saving, setSaving] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const pickerWrapRef = useRef<HTMLDivElement>(null);
+  useClickOutside(pickerWrapRef, () => setDropdownOpen(false), { isOpen: dropdownOpen, escapeKey: false });
 
   useEffect(() => {
     window.sourcerer.listContacts().then(setContacts);
@@ -99,7 +102,7 @@ export default function QuickLogModal({ onClose, onSaved }: Props) {
             <button type="button" className="qlm-clear-btn" onClick={clearContact} aria-label="Clear contact">×</button>
           </div>
         ) : (
-          <div className="qlm-picker-wrap">
+          <div className="qlm-picker-wrap" ref={pickerWrapRef}>
             <input
               ref={inputRef}
               className="qlm-picker-input"
@@ -107,7 +110,6 @@ export default function QuickLogModal({ onClose, onSaved }: Props) {
               value={query}
               onChange={(e) => { setQuery(e.target.value); setDropdownOpen(true); }}
               onFocus={() => setDropdownOpen(true)}
-              onBlur={() => setTimeout(() => setDropdownOpen(false), 150)}
               autoFocus
             />
             {dropdownOpen && filtered.length > 0 && (

--- a/src/renderer/src/contacts/QuickReminderModal.tsx
+++ b/src/renderer/src/contacts/QuickReminderModal.tsx
@@ -3,6 +3,7 @@ import type { ContactDetail, ContactListItem } from '@shared/types';
 import Modal from '../shell/Modal';
 import Button from '../shell/Button';
 import { CalendarPicker } from '../views/CalendarPicker';
+import { useClickOutside } from '../hooks/useClickOutside';
 import './QuickLogModal.css';
 
 interface Props {
@@ -26,6 +27,8 @@ export default function QuickReminderModal({ onClose, onSaved }: Props) {
   const [note, setNote] = useState('');
   const [saving, setSaving] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const pickerWrapRef = useRef<HTMLDivElement>(null);
+  useClickOutside(pickerWrapRef, () => setDropdownOpen(false), { isOpen: dropdownOpen, escapeKey: false });
 
   useEffect(() => {
     window.sourcerer.listContacts().then(setContacts);
@@ -96,7 +99,7 @@ export default function QuickReminderModal({ onClose, onSaved }: Props) {
             <button type="button" className="qlm-clear-btn" onClick={clearContact} aria-label="Clear contact">×</button>
           </div>
         ) : (
-          <div className="qlm-picker-wrap">
+          <div className="qlm-picker-wrap" ref={pickerWrapRef}>
             <input
               ref={inputRef}
               className="qlm-picker-input"
@@ -104,7 +107,6 @@ export default function QuickReminderModal({ onClose, onSaved }: Props) {
               value={query}
               onChange={(e) => { setQuery(e.target.value); setDropdownOpen(true); }}
               onFocus={() => setDropdownOpen(true)}
-              onBlur={() => setTimeout(() => setDropdownOpen(false), 150)}
               autoFocus
             />
             {dropdownOpen && filtered.length > 0 && (

--- a/src/renderer/src/views/AllContacts.tsx
+++ b/src/renderer/src/views/AllContacts.tsx
@@ -237,11 +237,12 @@ export default function AllContacts({ projects, user, openContactId, onOpenConta
   async function handleBulkDelete() {
     setBulkWorking(true);
     try {
-      await Promise.all([...checkedIds].map((id) => window.sourcerer.deleteContact(id)));
-      const deleted = checkedIds;
+      const ids = [...checkedIds];
+      const results = await Promise.allSettled(ids.map((id) => window.sourcerer.deleteContact(id)));
+      const deleted = new Set(ids.filter((_, i) => results[i].status === 'fulfilled'));
       setContacts((prev) => prev.filter((c) => !deleted.has(c.id)));
       if (detailId && deleted.has(detailId)) setDetailId(null);
-      setCheckedIds(new Set());
+      setCheckedIds((prev) => new Set([...prev].filter((id) => !deleted.has(id))));
       setConfirmDelete(false);
     } finally {
       setBulkWorking(false);

--- a/src/renderer/src/views/ProjectView.tsx
+++ b/src/renderer/src/views/ProjectView.tsx
@@ -310,13 +310,14 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
     if (!project) return;
     setBulkWorking(true);
     try {
-      await Promise.all(
-        [...checkedIds].map((id) => window.sourcerer.removeFromProject(id, project.id)),
+      const ids = [...checkedIds];
+      const results = await Promise.allSettled(
+        ids.map((id) => window.sourcerer.removeFromProject(id, project.id)),
       );
-      const removed = checkedIds;
+      const removed = new Set(ids.filter((_, i) => results[i].status === 'fulfilled'));
       setRows((prev) => prev.filter((r) => !removed.has(r.id)));
       if (selectedId && removed.has(selectedId)) setSelectedId(null);
-      setCheckedIds(new Set());
+      setCheckedIds((prev) => new Set([...prev].filter((id) => !removed.has(id))));
       setConfirmRemove(false);
     } finally {
       setBulkWorking(false);
@@ -350,11 +351,12 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
   async function handleBulkDelete() {
     setBulkWorking(true);
     try {
-      await Promise.all([...checkedIds].map((id) => window.sourcerer.deleteContact(id)));
-      const deleted = checkedIds;
+      const ids = [...checkedIds];
+      const results = await Promise.allSettled(ids.map((id) => window.sourcerer.deleteContact(id)));
+      const deleted = new Set(ids.filter((_, i) => results[i].status === 'fulfilled'));
       setRows((prev) => prev.filter((r) => !deleted.has(r.id)));
       if (selectedId && deleted.has(selectedId)) setSelectedId(null);
-      setCheckedIds(new Set());
+      setCheckedIds((prev) => new Set([...prev].filter((id) => !deleted.has(id))));
       setConfirmDelete(false);
     } finally {
       setBulkWorking(false);

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -255,22 +255,36 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
   }
 
   async function handleTimeoutChange(seconds: number) {
+    const prev = idleTimeout;
     setIdleTimeout(seconds);
-    await window.sourcerer.setIdleTimeout(seconds);
+    try {
+      await window.sourcerer.setIdleTimeout(seconds);
+    } catch {
+      setIdleTimeout(prev);
+    }
   }
 
   async function handleStalenessToggle(enabled: boolean) {
     setStalenessEnabled(enabled);
-    const updated = await window.sourcerer.setStalenessEnabled(enabled);
-    onUserUpdated(updated);
+    try {
+      const updated = await window.sourcerer.setStalenessEnabled(enabled);
+      onUserUpdated(updated);
+    } catch {
+      setStalenessEnabled(!enabled);
+    }
   }
 
   async function handleStalenessThresholdBlur() {
     const days = parseInt(stalenessThresholdInput, 10);
     if (!isNaN(days) && days > 0 && days !== stalenessThreshold) {
       setStalenessThreshold(days);
-      const updated = await window.sourcerer.setStalenessThreshold(days);
-      onUserUpdated(updated);
+      try {
+        const updated = await window.sourcerer.setStalenessThreshold(days);
+        onUserUpdated(updated);
+      } catch {
+        setStalenessThreshold(stalenessThreshold);
+        setStalenessThresholdInput(String(stalenessThreshold));
+      }
     } else {
       setStalenessThresholdInput(String(stalenessThreshold));
     }
@@ -278,20 +292,33 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
 
   async function handleAlertNotificationsToggle(enabled: boolean) {
     setAlertNotificationsEnabled(enabled);
-    const updated = await window.sourcerer.setAlertNotificationsEnabled(enabled);
-    onUserUpdated(updated);
+    try {
+      const updated = await window.sourcerer.setAlertNotificationsEnabled(enabled);
+      onUserUpdated(updated);
+    } catch {
+      setAlertNotificationsEnabled(!enabled);
+    }
   }
 
   async function handleRssPollIntervalChange(hours: number) {
+    const prev = rssPollIntervalHours;
     setRssPollIntervalHours(hours);
-    const updated = await window.sourcerer.setRssPollInterval(hours);
-    onUserUpdated(updated);
+    try {
+      const updated = await window.sourcerer.setRssPollInterval(hours);
+      onUserUpdated(updated);
+    } catch {
+      setRssPollIntervalHours(prev);
+    }
   }
 
   async function handleWaybackToggle(enabled: boolean) {
     setWaybackEnabled(enabled);
-    const updated = await window.sourcerer.setWaybackEnabled(enabled);
-    onUserUpdated(updated);
+    try {
+      const updated = await window.sourcerer.setWaybackEnabled(enabled);
+      onUserUpdated(updated);
+    } catch {
+      setWaybackEnabled(!enabled);
+    }
   }
 
   async function handleArchiveKeysSave() {
@@ -304,26 +331,43 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
 
   async function handleReminderNotificationsToggle(enabled: boolean) {
     setReminderNotificationsEnabled(enabled);
-    const updated = await window.sourcerer.setReminderNotificationsEnabled(enabled);
-    onUserUpdated(updated);
+    try {
+      const updated = await window.sourcerer.setReminderNotificationsEnabled(enabled);
+      onUserUpdated(updated);
+    } catch {
+      setReminderNotificationsEnabled(!enabled);
+    }
   }
 
   async function handleOutreachToggle(enabled: boolean) {
     setOutreachRemindersEnabled(enabled);
-    const updated = await window.sourcerer.setOutreachRemindersEnabled(enabled);
-    onUserUpdated(updated);
+    try {
+      const updated = await window.sourcerer.setOutreachRemindersEnabled(enabled);
+      onUserUpdated(updated);
+    } catch {
+      setOutreachRemindersEnabled(!enabled);
+    }
   }
 
   async function handleOutreachRequireInteractionToggle(required: boolean) {
     setOutreachRequireInteraction(required);
-    const updated = await window.sourcerer.setOutreachRequireInteraction(required);
-    onUserUpdated(updated);
+    try {
+      const updated = await window.sourcerer.setOutreachRequireInteraction(required);
+      onUserUpdated(updated);
+    } catch {
+      setOutreachRequireInteraction(!required);
+    }
   }
 
   async function handlePhoneCountryChange(country: string) {
+    const prev = phoneCountry;
     setPhoneCountry(country);
-    const updated = await window.sourcerer.setPhoneCountry(country);
-    onUserUpdated(updated);
+    try {
+      const updated = await window.sourcerer.setPhoneCountry(country);
+      onUserUpdated(updated);
+    } catch {
+      setPhoneCountry(prev);
+    }
   }
 
   async function handleChooseBackupFolder() {


### PR DESCRIPTION
Closes #304
Closes #275
Closes #198

## Changes

**SettingsView — optimistic revert on IPC failure**
All settings toggle/select handlers (`handleReminderNotificationsToggle`, `handleOutreachToggle`, `handleOutreachRequireInteractionToggle`, `handlePhoneCountryChange`, plus the previously-partial handlers) now revert local state if the IPC call throws, so the UI stays consistent with the database on failure.

**Bulk delete/remove — `Promise.allSettled` instead of `Promise.all`**
`AllContacts.handleBulkDelete`, `ProjectView.handleBulkDelete`, and `ProjectView.handleBulkRemove` previously used `Promise.all`, which meant any single failure would throw and leave the UI in a stale state (optimistic removes already applied). Now they use `Promise.allSettled` and only remove items whose individual call succeeded; failed items remain selected so the user can see something went wrong. (#304)

**ScratchpadSection — inline error on save failure**
`handleSave` now wraps the IPC call in try/catch and surfaces a `"Failed to save draft. Please try again."` message inline above the draft list instead of silently swallowing errors. (#275)

**QuickLogModal + QuickReminderModal — stable dropdown close**
Replaced the `onBlur + setTimeout(150ms)` hack for closing the contact-search dropdown with `useClickOutside` on the picker container. This is the same pattern used by `LogProjectPicker`, `AddContactModal`, and the reporter dropdown in `ProjectTab`. The `onMouseDown preventDefault` on individual items was already correct and remains. (#198)

## Test plan
- [x] Settings: toggle outreach reminders off/on, confirm toggle reverts if DB is unreachable
- [x] AllContacts: select 2+ contacts, bulk delete — confirm only successful deletes leave the list
- [x] ProjectView: same for remove-from-project and delete-contact bulk actions
- [x] ScratchpadSection: attempt save on a draft, confirm error shows on failure
- [x] QuickLogModal / QuickReminderModal: open, type in contact search, click an option — confirm dropdown closes without flicker; also confirm Escape closes the modal (not the dropdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)