### PR TITLE
Fix DB/IPC correctness: contacts read-back, merge validation, key-compare, cipher pragmas

### DIFF
--- a/src/main/database/shared-db.ts
+++ b/src/main/database/shared-db.ts
@@ -26,6 +26,10 @@ const connections = new Map<string, Database.Database>();
 function openRaw(filePath: string, keyHex: string): Database.Database {
   const db = new Database(filePath);
   db.pragma(`cipher='sqlcipher'`);
+  db.pragma('cipher_page_size=4096');
+  db.pragma('kdf_iter=256000');
+  db.pragma('cipher_hmac_algorithm=HMAC_SHA512');
+  db.pragma('cipher_kdf_algorithm=PBKDF2_HMAC_SHA512');
   db.pragma(`key="x'${keyHex}'"`);
   try {
     db.pragma('user_version');
@@ -105,6 +109,10 @@ export function createSharedDb(
   const db = new Database(filePath);
   try {
     db.pragma(`cipher='sqlcipher'`);
+    db.pragma('cipher_page_size=4096');
+    db.pragma('kdf_iter=256000');
+    db.pragma('cipher_hmac_algorithm=HMAC_SHA512');
+    db.pragma('cipher_kdf_algorithm=PBKDF2_HMAC_SHA512');
     db.pragma(`key="x'${keyHex}'"`);
     db.pragma('foreign_keys = ON');
     db.pragma('busy_timeout = 5000');

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -275,15 +275,12 @@ export function registerContactHandlers(): void {
     const now = Math.floor(Date.now() / 1000);
     const { phone_country, wayback_enabled } = db.prepare('SELECT phone_country, wayback_enabled FROM users WHERE id = 1').get() as { phone_country: string; wayback_enabled: number };
 
-    let emails: { email: string; label: string | null }[] = [];
-    let phones: { phone: string; label: string | null }[] = [];
-
     const insert = db.transaction(() => {
       db.prepare(
         'INSERT INTO contacts (id, name, organization, title, dob, notes, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
       ).run(id, data.name.trim(), data.organization?.trim() || null, data.title?.trim() || null, /^\d{4}-\d{2}-\d{2}$/.test(data.dob?.trim() ?? '') ? data.dob!.trim() : null, data.notes?.trim() || null, now, now);
 
-      emails = (data.emails ?? [])
+      const emails = (data.emails ?? [])
         .map((e) => ({ email: normalizeEmail(e.email), label: e.label?.trim() || null }))
         .filter((e) => e.email && validateEmail(e.email));
       emails.forEach((e, i) => {
@@ -292,7 +289,7 @@ export function registerContactHandlers(): void {
         ).run(uuidv4(), id, e.email, e.label, i, now);
       });
 
-      phones = (data.phones ?? [])
+      const phones = (data.phones ?? [])
         .filter((p) => p.phone.trim())
         .map((p) => ({ phone: normalizePhone(p.phone, phone_country), label: p.label?.trim() || null }))
         .filter((p): p is { phone: string; label: string | null } => p.phone !== null);
@@ -326,20 +323,16 @@ export function registerContactHandlers(): void {
         triggerWaybackSave(id, link.url.trim()).catch(() => {});
       }
     }
-    return {
-      id,
-      name: data.name.trim(),
-      organization: data.organization?.trim() || null,
-      notes: data.notes?.trim() || null,
-      created_at: now,
-      has_email: emails.length > 0 ? 1 : 0,
-      has_phone: phones.length > 0 ? 1 : 0,
-      date_first_contacted: null,
-      date_last_contacted: null,
-      emails_raw: emails.map((e) => e.email).join(' ') || null,
-      phones_raw: phones.length > 0 ? phones.map((p) => p.phone).join(' ') : null,
-      projects: [],
-    };
+
+    const row = db.prepare(
+      `SELECT c.id, c.name, c.organization, c.notes, c.created_at,
+              EXISTS(SELECT 1 FROM contact_emails WHERE contact_id = c.id) AS has_email,
+              EXISTS(SELECT 1 FROM contact_phones WHERE contact_id = c.id) AS has_phone,
+              (SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contact_id = c.id) AS emails_raw,
+              (SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contact_id = c.id) AS phones_raw
+       FROM contacts c WHERE c.id = ?`,
+    ).get(id) as { id: string; name: string; organization: string | null; notes: string | null; created_at: number; has_email: 0|1; has_phone: 0|1; emails_raw: string|null; phones_raw: string|null };
+    return { ...row, date_first_contacted: null, date_last_contacted: null, projects: [] };
   });
 
   ipcMain.handle('contacts:delete', (_, id: string): void => {
@@ -888,7 +881,12 @@ export function registerContactHandlers(): void {
   ipcMain.handle(
     'contacts:merge',
     (_, { winnerId, loserId, strategy }: { winnerId: string; loserId: string; strategy: 'keep' | 'merge' | 'skip' }): void => {
+      if (winnerId === loserId) throw new Error('winnerId and loserId must be different');
+      if (!['keep', 'merge', 'skip'].includes(strategy)) throw new Error('Invalid strategy');
       const db = getDatabase();
+      const winnerExists = db.prepare('SELECT 1 FROM contacts WHERE id = ?').get(winnerId);
+      const loserExists = db.prepare('SELECT 1 FROM contacts WHERE id = ?').get(loserId);
+      if (!winnerExists || !loserExists) throw new Error('Contact not found');
       if (strategy === 'skip') {
         dismissPair(db, winnerId, loserId);
       } else {

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import crypto from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
 import Database from 'better-sqlite3-multiple-ciphers';
-import { getDatabase, closeDatabase, updateActiveKeyHex, setActivePassword } from '../database';
+import { getDatabase, closeDatabase, getKeyHex, updateActiveKeyHex, setActivePassword } from '../database';
 import { getPaths, deriveKey, getVaultBundlePath, writeVaultConfig, clearVaultConfig, detectSyncProvider } from '../utils';
 import { autoLock } from '../auto-lock';
 import { setRssPollIntervalHours } from '../sync/poller';
@@ -157,28 +157,14 @@ export function registerSettingsHandlers(): void {
   ipcMain.handle(
     'settings:change-password',
     async (_, { currentPassword, newPassword }: { currentPassword: string; newPassword: string }): Promise<{ success: boolean; error?: string }> => {
-      const { dbPath, saltPath } = getPaths();
+      const { saltPath } = getPaths();
       try {
-        // Verify the current password against the existing salt
+        // Verify the current password by comparing derived key against the active in-memory key
         const salt = await fs.readFile(saltPath);
         const currentKeyHex = await deriveKey(currentPassword, salt);
-
-        const testDb = new Database(dbPath);
-        testDb.pragma(`cipher='sqlcipher'`);
-        testDb.pragma('cipher_page_size=4096');
-        testDb.pragma('kdf_iter=256000');
-        testDb.pragma('cipher_hmac_algorithm=HMAC_SHA512');
-        testDb.pragma('cipher_kdf_algorithm=PBKDF2_HMAC_SHA512');
-        testDb.pragma(`key="x'${currentKeyHex}'"`);
-        try {
-          // pragma('user_version') doesn't force a page decrypt; an actual
-          // table read is required to reliably detect a wrong key.
-          testDb.prepare('SELECT id FROM users WHERE id = 1').get();
-        } catch {
-          testDb.close();
+        if (currentKeyHex !== getKeyHex()) {
           return { success: false, error: 'Current password is incorrect.' };
         }
-        testDb.close();
 
         // Derive new key with a fresh salt
         const newSalt = crypto.randomBytes(32);

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -162,7 +162,7 @@ export function registerSettingsHandlers(): void {
         // Verify the current password by comparing derived key against the active in-memory key
         const salt = await fs.readFile(saltPath);
         const currentKeyHex = await deriveKey(currentPassword, salt);
-        if (currentKeyHex !== getKeyHex()) {
+        if (!crypto.timingSafeEqual(Buffer.from(currentKeyHex, 'hex'), Buffer.from(getKeyHex(), 'hex'))) {
           return { success: false, error: 'Current password is incorrect.' };
         }
 

--- a/src/test/contacts.test.ts
+++ b/src/test/contacts.test.ts
@@ -243,3 +243,36 @@ describe('contacts:get', () => {
     expect(() => handlers.get('contacts:get')!({}, 'non-existent-id')).toThrow();
   });
 });
+
+// ---------------------------------------------------------------------------
+// contacts:merge validation (#285)
+// ---------------------------------------------------------------------------
+
+describe('contacts:merge validation', () => {
+  it('throws when winnerId and loserId are the same', () => {
+    const id = insertContact(testDb, 'Alice');
+    expect(() => handlers.get('contacts:merge')!({}, { winnerId: id, loserId: id, strategy: 'keep' }))
+      .toThrow('winnerId and loserId must be different');
+  });
+
+  it('throws on an invalid strategy', () => {
+    const a = insertContact(testDb, 'Alice');
+    const b = insertContact(testDb, 'Bob');
+    expect(() => handlers.get('contacts:merge')!({}, { winnerId: a, loserId: b, strategy: 'bad' }))
+      .toThrow('Invalid strategy');
+  });
+
+  it('throws when winner does not exist and leaves loser unchanged', () => {
+    const b = insertContact(testDb, 'Bob');
+    expect(() => handlers.get('contacts:merge')!({}, { winnerId: 'no-such-id', loserId: b, strategy: 'keep' }))
+      .toThrow('Contact not found');
+    expect(testDb.prepare('SELECT id FROM contacts WHERE id = ?').get(b)).toBeDefined();
+  });
+
+  it('throws when loser does not exist and leaves winner unchanged', () => {
+    const a = insertContact(testDb, 'Alice');
+    expect(() => handlers.get('contacts:merge')!({}, { winnerId: a, loserId: 'no-such-id', strategy: 'keep' }))
+      .toThrow('Contact not found');
+    expect(testDb.prepare('SELECT id FROM contacts WHERE id = ?').get(a)).toBeDefined();
+  });
+});

--- a/src/test/shared-db.test.ts
+++ b/src/test/shared-db.test.ts
@@ -1,15 +1,20 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { randomBytes } from 'crypto';
 import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import Database from 'better-sqlite3-multiple-ciphers';
 import { SHARED_SCHEMA_SQL } from '../main/database/shared-schema';
-import { rekeySharedDb, getSharedDb } from '../main/database/shared-db';
+import { createSharedDb, openSharedDb, closeSharedDb, rekeySharedDb, getSharedDb, closeAllSharedDbs } from '../main/database/shared-db';
+
+vi.mock('electron', () => ({
+  app: { getVersion: vi.fn(() => '0.0.0-test') },
+}));
 
 const tmpDirs: string[] = [];
 
 afterEach(() => {
+  closeAllSharedDbs();
   tmpDirs.forEach((d) => rmSync(d, { recursive: true, force: true }));
   tmpDirs.length = 0;
 });
@@ -59,5 +64,39 @@ describe('rekeySharedDb', () => {
     rekeySharedDb('proj-2', filePath, oldKeyHex, newKeyHex);
 
     expect(getSharedDb('proj-2')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSharedDb / openSharedDb round-trip with pinned SQLCipher pragmas
+// ---------------------------------------------------------------------------
+
+describe('createSharedDb / openSharedDb', () => {
+  function makeTempPath(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'sourcerer-shared-'));
+    tmpDirs.push(dir);
+    return join(dir, 'shared.sourcerer');
+  }
+
+  it('file created by createSharedDb can be re-opened by openSharedDb', () => {
+    const keyHex = randomBytes(32).toString('hex');
+    const filePath = makeTempPath();
+
+    createSharedDb(filePath, keyHex, 'rt-1');
+    closeSharedDb('rt-1');
+
+    const db = openSharedDb(filePath, keyHex, 'rt-1');
+    expect(() => db.pragma('user_version')).not.toThrow();
+  });
+
+  it('openSharedDb rejects a wrong key on a pinned-pragma DB', () => {
+    const keyHex = randomBytes(32).toString('hex');
+    const wrongKeyHex = randomBytes(32).toString('hex');
+    const filePath = makeTempPath();
+
+    createSharedDb(filePath, keyHex, 'rt-2');
+    closeSharedDb('rt-2');
+
+    expect(() => openSharedDb(filePath, wrongKeyHex, 'rt-3')).toThrow();
   });
 });


### PR DESCRIPTION
Closes #303
Closes #259
Closes #238
Closes #175

## Changes

**`contacts:create` — DB read-back instead of synthesized return (#303)**
The handler was constructing its `ContactListItem` return value from input parameters (normalized by the application layer) rather than from a post-insert `SELECT`. Any future DB-level coercion or trigger would silently diverge from what the renderer caches. After the transaction, the handler now does a targeted read of the new row and returns the actual stored data.

**`contacts:merge` — input validation (#259)**
Merge is irreversible; an accidental call with `winnerId === loserId` or a non-existent ID could corrupt or silently delete contact data. The handler now validates: (1) `winnerId !== loserId`, (2) both contacts exist in the DB, and (3) `strategy` is one of the three expected string values (TypeScript guarantee is stripped at runtime).

**`settings:change-password` — eliminate second DB connection (#238)**
The handler opened a second `Database` connection to verify the current password against the live file. This connection could fail with `SQLITE_BUSY` if the main write connection held a lock during an RSS poll or sync, returning a misleading "Current password is incorrect" error. The fix: derive the candidate key from the supplied password + salt, then compare it against `getKeyHex()` (the in-memory active key). If they match, the password is correct — no second connection needed.

**`shared-db.ts` — pin SQLCipher 4 parameters (#175)**
Both `openRaw()` and `createSharedDb()` were missing the four explicit cipher-pinning pragmas (`cipher_page_size`, `kdf_iter`, `cipher_hmac_algorithm`, `cipher_kdf_algorithm`) that the local DB's `openRaw()` sets. Without them, shared DBs silently depend on compiled library defaults — which could differ between library versions or build configurations, making shared project files unreadable after an app update. Both functions now set the full pragma sequence matching the local DB.

## Test plan
- [ ] Create a contact with trimmed whitespace fields — confirm the returned `ContactListItem` reflects what the DB actually stored
- [ ] Attempt to merge a contact with itself — confirm an error is thrown, no data changed
- [ ] Change password: confirm wrong current password is rejected cleanly; correct password succeeds
- [ ] Create a new shared project, then open it from the same vault — confirm it opens cleanly with the pinned cipher params

🤖 Generated with [Claude Code](https://claude.com/claude-code)