### PR TITLE
docs: document one-Closes-per-issue rule in PR guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ npm run db:export     # prompts for app password, writes sourcerer-plain.db
 - Branch naming: `feature/`, `fix/`, `dev/` prefixes
 - Always push to a feature branch and open a PR via `gh pr create`
 - CI runs a `test` status check — PRs won't merge until it passes
+- To auto-close issues on merge, use one `Closes #N` line per issue — **not** `Closes #1, #2, #3` (GitHub only closes the first number in a comma-separated list)
 
 ## Cutting a release
 


### PR DESCRIPTION
GitHub's auto-close parser requires each issue number to be directly preceded by a closing keyword. A line like `Closes #1, #2, #3` only auto-closes `#1`; the others need their own `Closes #N` line.

Adds a one-liner to the Git / PR rules section of CLAUDE.md so this is enforced going forward rather than caught after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)