### PR TITLE
Eliminate redundant IPC calls and lazy-load expensive renderer data

### DIFF
--- a/src/renderer/src/contacts/ContactDetail.tsx
+++ b/src/renderer/src/contacts/ContactDetail.tsx
@@ -95,16 +95,18 @@ export default function ContactDetail({ contactId, onClose, onDeleted, onUpdated
 
   useEffect(() => {
     if (!contact) return;
-    let cancelled = false;
-    Promise.all(
-      contact.projects.map((p) =>
-        window.sourcerer.listInteractionLog(p.membership_id).then((entries) => ({
-          projectName: p.name,
-          entries,
-        }))
-      )
-    ).then((logs) => { if (!cancelled) setPrintLogs(logs); });
-    return () => { cancelled = true; };
+    function handleBeforePrint() {
+      Promise.all(
+        contact!.projects.map((p) =>
+          window.sourcerer.listInteractionLog(p.membership_id).then((entries) => ({
+            projectName: p.name,
+            entries,
+          }))
+        )
+      ).then(setPrintLogs);
+    }
+    window.addEventListener('beforeprint', handleBeforePrint);
+    return () => window.removeEventListener('beforeprint', handleBeforePrint);
   }, [contact]);
 
   function handleMembershipChanged() {

--- a/src/renderer/src/contacts/ContactDetail.tsx
+++ b/src/renderer/src/contacts/ContactDetail.tsx
@@ -106,6 +106,8 @@ export default function ContactDetail({ contactId, onClose, onDeleted, onUpdated
         )
       ).then((logs) => {
         if (!cancelled) setPrintLogs(logs);
+      }).catch(() => {
+        if (!cancelled) setPrintLogs([]);
       });
     }
     window.addEventListener('beforeprint', handleBeforePrint);

--- a/src/renderer/src/contacts/ContactDetail.tsx
+++ b/src/renderer/src/contacts/ContactDetail.tsx
@@ -95,6 +95,7 @@ export default function ContactDetail({ contactId, onClose, onDeleted, onUpdated
 
   useEffect(() => {
     if (!contact) return;
+    let cancelled = false;
     function handleBeforePrint() {
       Promise.all(
         contact!.projects.map((p) =>
@@ -103,10 +104,15 @@ export default function ContactDetail({ contactId, onClose, onDeleted, onUpdated
             entries,
           }))
         )
-      ).then(setPrintLogs);
+      ).then((logs) => {
+        if (!cancelled) setPrintLogs(logs);
+      });
     }
     window.addEventListener('beforeprint', handleBeforePrint);
-    return () => window.removeEventListener('beforeprint', handleBeforePrint);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('beforeprint', handleBeforePrint);
+    };
   }, [contact]);
 
   function handleMembershipChanged() {

--- a/src/renderer/src/contacts/QuickLogModal.tsx
+++ b/src/renderer/src/contacts/QuickLogModal.tsx
@@ -12,12 +12,12 @@ function todayISO(): string {
 }
 
 interface Props {
+  contacts: ContactListItem[];
   onClose: () => void;
   onSaved: () => void;
 }
 
-export default function QuickLogModal({ onClose, onSaved }: Props) {
-  const [contacts, setContacts] = useState<ContactListItem[]>([]);
+export default function QuickLogModal({ contacts, onClose, onSaved }: Props) {
   const [query, setQuery] = useState('');
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [selectedContactId, setSelectedContactId] = useState<string | null>(null);
@@ -28,10 +28,6 @@ export default function QuickLogModal({ onClose, onSaved }: Props) {
   const [body, setBody] = useState('');
   const [saving, setSaving] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    window.sourcerer.listContacts().then(setContacts);
-  }, []);
 
   useEffect(() => {
     if (!selectedContactId) {

--- a/src/renderer/src/contacts/QuickReminderModal.tsx
+++ b/src/renderer/src/contacts/QuickReminderModal.tsx
@@ -6,12 +6,12 @@ import { CalendarPicker } from '../views/CalendarPicker';
 import './QuickLogModal.css';
 
 interface Props {
+  contacts: ContactListItem[];
   onClose: () => void;
   onSaved: () => void;
 }
 
-export default function QuickReminderModal({ onClose, onSaved }: Props) {
-  const [contacts, setContacts] = useState<ContactListItem[]>([]);
+export default function QuickReminderModal({ contacts, onClose, onSaved }: Props) {
   const [query, setQuery] = useState('');
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [selectedContactId, setSelectedContactId] = useState<string | null>(null);
@@ -26,10 +26,6 @@ export default function QuickReminderModal({ onClose, onSaved }: Props) {
   const [note, setNote] = useState('');
   const [saving, setSaving] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    window.sourcerer.listContacts().then(setContacts);
-  }, []);
 
   useEffect(() => {
     if (!selectedContactId) {

--- a/src/renderer/src/contacts/ScreenshotPanel.tsx
+++ b/src/renderer/src/contacts/ScreenshotPanel.tsx
@@ -38,31 +38,6 @@ export default function ScreenshotPanel({ contactId }: Props) {
   }, [contactId]);
 
   useEffect(() => {
-    let cancelled = false;
-
-    async function loadAll() {
-      for (const s of screenshots) {
-        if (cancelled) return;
-        if (screenshotImagesRef.current[s.id]) continue;
-        const result = await window.sourcerer.loadScreenshot(s.id);
-        if (cancelled) return;
-        if ('data' in result) {
-          setScreenshotImages((prev) => ({ ...prev, [s.id]: result.data }));
-        } else {
-          console.error('[screenshot] load failed for', s.id, '—', result.error);
-          setScreenshotImages((prev) => ({ ...prev, [s.id]: `error:${result.error}` }));
-        }
-      }
-    }
-
-    loadAll().catch(console.error);
-
-    return () => {
-      cancelled = true;
-    };
-  }, [screenshots]);
-
-  useEffect(() => {
     if (viewingScreenshot) {
       viewerRef.current?.focus();
       setZoomMode('fit');

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -65,7 +65,6 @@ export default function AppShell() {
 
   useEffect(() => {
     window.sourcerer.getUser().then(setUser);
-    window.sourcerer.listContacts().then(setContacts);
     window.sourcerer.listProjects().then(setProjects);
     window.sourcerer.getUnseenMentionCount().then(setUnseenMentions);
     window.sourcerer.getContactCount().then(setTotalContacts);
@@ -285,8 +284,8 @@ export default function AppShell() {
         onProjectDeleted={handleProjectDeleted}
         onAddContact={() => setShowAddContact(true)}
         onImportCsv={() => setShowImportCsv(true)}
-        onQuickLog={() => setShowQuickLog(true)}
-        onQuickReminder={() => setShowQuickReminder(true)}
+        onQuickLog={() => { window.sourcerer.listContacts().then(setContacts); setShowQuickLog(true); }}
+        onQuickReminder={() => { window.sourcerer.listContacts().then(setContacts); setShowQuickReminder(true); }}
       />
       <main className="app-content">
         {nav.view === 'all-contacts' && (

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { ImportResult, Project, User } from '@shared/types';
+import type { ContactListItem, ImportResult, Project, User } from '@shared/types';
 import Sidebar from './Sidebar';
 import SearchModal from './SearchModal';
 import SetupPayloadModal from './SetupPayloadModal';
@@ -28,6 +28,7 @@ export type NavTarget =
 
 export default function AppShell() {
   const [user, setUser] = useState<User | null>(null);
+  const [contacts, setContacts] = useState<ContactListItem[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
   const [nav, setNav] = useState<NavTarget>({ view: 'all-contacts' });
   const [pendingPayload, setPendingPayload] = useState<{
@@ -64,6 +65,7 @@ export default function AppShell() {
 
   useEffect(() => {
     window.sourcerer.getUser().then(setUser);
+    window.sourcerer.listContacts().then(setContacts);
     window.sourcerer.listProjects().then(setProjects);
     window.sourcerer.getUnseenMentionCount().then(setUnseenMentions);
     window.sourcerer.getContactCount().then(setTotalContacts);
@@ -105,6 +107,7 @@ export default function AppShell() {
 
   useEffect(() => {
     return window.sourcerer.onContactsChanged(() => {
+      window.sourcerer.listContacts().then(setContacts);
       window.sourcerer.getContactCount().then(setTotalContacts);
       refreshOverdue();
     });
@@ -384,6 +387,7 @@ export default function AppShell() {
 
       {showQuickLog && (
         <QuickLogModal
+          contacts={contacts}
           onClose={() => setShowQuickLog(false)}
           onSaved={() => {
             setShowQuickLog(false);
@@ -395,6 +399,7 @@ export default function AppShell() {
 
       {showQuickReminder && (
         <QuickReminderModal
+          contacts={contacts}
           onClose={() => setShowQuickReminder(false)}
           onSaved={() => {
             setShowQuickReminder(false);

--- a/src/renderer/src/views/AllContacts.tsx
+++ b/src/renderer/src/views/AllContacts.tsx
@@ -56,14 +56,11 @@ export default function AllContacts({ projects, user, openContactId, onOpenConta
   }, [openContactId, onOpenContactIdConsumed]);
 
   useEffect(() => {
-    refresh();
-  }, [refresh]);
-
-  useEffect(() => {
     if (refreshTrigger) refresh();
   }, [refreshTrigger, refresh]);
 
   useEffect(() => {
+    refresh();
     return window.sourcerer.onContactsChanged(refresh);
   }, [refresh]);
 

--- a/src/renderer/src/views/ProjectView.tsx
+++ b/src/renderer/src/views/ProjectView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Project, ProjectContactRow, StatusOption, PriorityOption, ImportResult, User } from '@shared/types';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { useSortFilter } from '../hooks/useSortFilter';
@@ -365,110 +365,112 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
     setOpenFilter((prev) => (prev === col ? null : col));
   }
 
-  // Build sort-order lookup maps for status/priority (used in sort logic below)
-  const statusOrderMap = buildOrderMap(statusOptions);
-  const priorityOrderMap = buildOrderMap(priorityOptions);
+  const displayed = useMemo(() => {
+    const statusOrderMap = buildOrderMap(statusOptions);
+    const priorityOrderMap = buildOrderMap(priorityOptions);
+    const now = Math.floor(Date.now() / 1000);
+    let result = rows;
 
-  const now = Math.floor(Date.now() / 1000);
-  let displayed = rows;
+    if (filters.name) {
+      const q = filters.name.toLowerCase();
+      result = result.filter((r) => r.name.toLowerCase().includes(q));
+    }
+    if (filters.organization) {
+      const q = filters.organization.toLowerCase();
+      result = result.filter((r) => (r.organization ?? '').toLowerCase().includes(q));
+    }
+    if (filters.theme) {
+      const q = filters.theme.toLowerCase();
+      result = result.filter((r) => (r.theme ?? '').toLowerCase().includes(q));
+    }
+    if (filters.notes) {
+      const q = filters.notes.toLowerCase();
+      result = result.filter((r) => (r.notes ?? '').toLowerCase().includes(q));
+    }
+    if (filters.email) {
+      const q = filters.email.toLowerCase();
+      result = result.filter((r) => (r.emails_raw ?? '').toLowerCase().includes(q));
+    }
+    if (filters.phone) {
+      const q = filters.phone.toLowerCase();
+      result = result.filter((r) => (r.phones_raw ?? '').toLowerCase().includes(q));
+    }
+    if (filters.hasEmail !== null) {
+      result = result.filter((r) => (filters.hasEmail ? r.has_email === 1 : r.has_email === 0));
+    }
+    if (filters.hasPhone !== null) {
+      result = result.filter((r) => (filters.hasPhone ? r.has_phone === 1 : r.has_phone === 0));
+    }
+    if (filters.dateLastContacted === 'never') {
+      result = result.filter((r) => r.date_last_contacted === null);
+    } else if (filters.dateLastContacted === 'contacted') {
+      result = result.filter((r) => r.date_last_contacted !== null);
+    } else if (filters.dateLastContacted === 'not_30') {
+      result = result.filter(
+        (r) => r.date_last_contacted === null || r.date_last_contacted < now - 30 * 86400,
+      );
+    } else if (filters.dateLastContacted === 'not_90') {
+      result = result.filter(
+        (r) => r.date_last_contacted === null || r.date_last_contacted < now - 90 * 86400,
+      );
+    }
+    if (filters.dateAddedFrom) {
+      const from = Math.floor(new Date(filters.dateAddedFrom).getTime() / 1000);
+      result = result.filter((r) => r.membership_created_at >= from);
+    }
+    if (filters.dateAddedTo) {
+      const to = Math.floor(new Date(filters.dateAddedTo).getTime() / 1000) + 86399;
+      result = result.filter((r) => r.membership_created_at <= to);
+    }
+    if (filters.status.length > 0) {
+      result = result.filter((r) => filters.status.includes(r.status ?? ''));
+    }
+    if (filters.priority.length > 0) {
+      result = result.filter((r) => filters.priority.includes(r.priority ?? ''));
+    }
+    if (filters.reporter.length > 0) {
+      result = result.filter((r) => filters.reporter.includes(r.reporter_name));
+    }
 
-  if (filters.name) {
-    const q = filters.name.toLowerCase();
-    displayed = displayed.filter((r) => r.name.toLowerCase().includes(q));
-  }
-  if (filters.organization) {
-    const q = filters.organization.toLowerCase();
-    displayed = displayed.filter((r) => (r.organization ?? '').toLowerCase().includes(q));
-  }
-  if (filters.theme) {
-    const q = filters.theme.toLowerCase();
-    displayed = displayed.filter((r) => (r.theme ?? '').toLowerCase().includes(q));
-  }
-  if (filters.notes) {
-    const q = filters.notes.toLowerCase();
-    displayed = displayed.filter((r) => (r.notes ?? '').toLowerCase().includes(q));
-  }
-  if (filters.email) {
-    const q = filters.email.toLowerCase();
-    displayed = displayed.filter((r) => (r.emails_raw ?? '').toLowerCase().includes(q));
-  }
-  if (filters.phone) {
-    const q = filters.phone.toLowerCase();
-    displayed = displayed.filter((r) => (r.phones_raw ?? '').toLowerCase().includes(q));
-  }
-  if (filters.hasEmail !== null) {
-    displayed = displayed.filter((r) => (filters.hasEmail ? r.has_email === 1 : r.has_email === 0));
-  }
-  if (filters.hasPhone !== null) {
-    displayed = displayed.filter((r) => (filters.hasPhone ? r.has_phone === 1 : r.has_phone === 0));
-  }
-  if (filters.dateLastContacted === 'never') {
-    displayed = displayed.filter((r) => r.date_last_contacted === null);
-  } else if (filters.dateLastContacted === 'contacted') {
-    displayed = displayed.filter((r) => r.date_last_contacted !== null);
-  } else if (filters.dateLastContacted === 'not_30') {
-    displayed = displayed.filter(
-      (r) => r.date_last_contacted === null || r.date_last_contacted < now - 30 * 86400,
-    );
-  } else if (filters.dateLastContacted === 'not_90') {
-    displayed = displayed.filter(
-      (r) => r.date_last_contacted === null || r.date_last_contacted < now - 90 * 86400,
-    );
-  }
-  if (filters.dateAddedFrom) {
-    const from = Math.floor(new Date(filters.dateAddedFrom).getTime() / 1000);
-    displayed = displayed.filter((r) => r.membership_created_at >= from);
-  }
-  if (filters.dateAddedTo) {
-    const to = Math.floor(new Date(filters.dateAddedTo).getTime() / 1000) + 86399;
-    displayed = displayed.filter((r) => r.membership_created_at <= to);
-  }
-  if (filters.status.length > 0) {
-    displayed = displayed.filter((r) => filters.status.includes(r.status ?? ''));
-  }
-  if (filters.priority.length > 0) {
-    displayed = displayed.filter((r) => filters.priority.includes(r.priority ?? ''));
-  }
-  if (filters.reporter.length > 0) {
-    displayed = displayed.filter((r) => filters.reporter.includes(r.reporter_name));
-  }
+    if (sort.key) {
+      const dir = sort.dir === 'asc' ? 1 : -1;
+      result = [...result].sort((a, b) => {
+        let cmp = 0;
+        if (sort.key === 'name') {
+          cmp = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+        } else if (sort.key === 'organization') {
+          cmp = (a.organization ?? '').localeCompare(b.organization ?? '', undefined, {
+            sensitivity: 'base',
+          });
+        } else if (sort.key === 'theme') {
+          cmp = (a.theme ?? '').localeCompare(b.theme ?? '', undefined, { sensitivity: 'base' });
+        } else if (sort.key === 'status') {
+          const si = (s: string | null) => statusOrderMap.get(s ?? '') ?? 9999;
+          cmp = si(a.status) - si(b.status);
+        } else if (sort.key === 'priority') {
+          const pi = (p: string | null) => priorityOrderMap.get(p ?? '') ?? 9999;
+          cmp = pi(a.priority) - pi(b.priority);
+        } else if (sort.key === 'reporter') {
+          cmp = a.reporter_name.localeCompare(b.reporter_name, undefined, { sensitivity: 'base' });
+        } else if (sort.key === 'date_first_contacted') {
+          if (a.date_first_contacted === null && b.date_first_contacted === null) cmp = 0;
+          else if (a.date_first_contacted === null) cmp = 1;
+          else if (b.date_first_contacted === null) cmp = -1;
+          else cmp = a.date_first_contacted - b.date_first_contacted;
+        } else if (sort.key === 'date_last_contacted') {
+          if (a.date_last_contacted === null && b.date_last_contacted === null) cmp = 0;
+          else if (a.date_last_contacted === null) cmp = 1;
+          else if (b.date_last_contacted === null) cmp = -1;
+          else cmp = a.date_last_contacted - b.date_last_contacted;
+        } else if (sort.key === 'membership_created_at') {
+          cmp = a.membership_created_at - b.membership_created_at;
+        }
+        return cmp * dir;
+      });
+    }
 
-  if (sort.key) {
-    const dir = sort.dir === 'asc' ? 1 : -1;
-    displayed = [...displayed].sort((a, b) => {
-      let cmp = 0;
-      if (sort.key === 'name') {
-        cmp = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
-      } else if (sort.key === 'organization') {
-        cmp = (a.organization ?? '').localeCompare(b.organization ?? '', undefined, {
-          sensitivity: 'base',
-        });
-      } else if (sort.key === 'theme') {
-        cmp = (a.theme ?? '').localeCompare(b.theme ?? '', undefined, { sensitivity: 'base' });
-      } else if (sort.key === 'status') {
-        const si = (s: string | null) => statusOrderMap.get(s ?? '') ?? 9999;
-        cmp = si(a.status) - si(b.status);
-      } else if (sort.key === 'priority') {
-        const pi = (p: string | null) => priorityOrderMap.get(p ?? '') ?? 9999;
-        cmp = pi(a.priority) - pi(b.priority);
-      } else if (sort.key === 'reporter') {
-        cmp = a.reporter_name.localeCompare(b.reporter_name, undefined, { sensitivity: 'base' });
-      } else if (sort.key === 'date_first_contacted') {
-        if (a.date_first_contacted === null && b.date_first_contacted === null) cmp = 0;
-        else if (a.date_first_contacted === null) cmp = 1;
-        else if (b.date_first_contacted === null) cmp = -1;
-        else cmp = a.date_first_contacted - b.date_first_contacted;
-      } else if (sort.key === 'date_last_contacted') {
-        if (a.date_last_contacted === null && b.date_last_contacted === null) cmp = 0;
-        else if (a.date_last_contacted === null) cmp = 1;
-        else if (b.date_last_contacted === null) cmp = -1;
-        else cmp = a.date_last_contacted - b.date_last_contacted;
-      } else if (sort.key === 'membership_created_at') {
-        cmp = a.membership_created_at - b.membership_created_at;
-      }
-      return cmp * dir;
-    });
-  }
+    return result;
+  }, [rows, filters, sort, statusOptions, priorityOptions]);
 
   const allChecked = displayed.length > 0 && displayed.every((r) => checkedIds.has(r.id));
   const someChecked = !allChecked && displayed.some((r) => checkedIds.has(r.id));


### PR DESCRIPTION
Closes #326
Closes #244
Closes #239
Closes #223
Closes #261

## Summary

- **#326 (AllContacts):** combine initial load and `onContactsChanged` into a single effect to eliminate the duplicate `listContacts` call on mount.
- **#244 (ScreenshotPanel):** remove bulk image preload on mount. Images now load on hover or click, matching the existing lazy `loadScreenshotImage` path.
- **#239 (ContactDetail):** fetch print logs in a `beforeprint` handler instead of on every contact load. Eliminates N `listInteractionLog` IPC calls per contact view for users who never print.
- **#223 (ProjectView):** wrap filter+sort computation in `useMemo` so it only reruns when rows, filters, sort, or status/priority options change — not on every render triggered by unrelated state.
- **#261 (QuickLogModal / QuickReminderModal):** accept contacts as a prop from `AppShell` rather than fetching independently on each open. `AppShell` already holds the list and passes it down, eliminating the per-open `listContacts` IPC call.

## Test plan
- [ ] All Contacts view loads without a double fetch on mount
- [ ] Screenshot thumbnails show placeholder until hovered/clicked, then load
- [ ] Print contact sheet still populates correctly on Cmd+P
- [ ] ProjectView filter/sort still works; no regressions on sort/filter interactions
- [ ] Quick log and quick reminder modals still populate contact list correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)