### PR TITLE
Replace inline styles with CSS custom properties; extract dateStrToUnix utility

### DIFF
--- a/src/renderer/src/contacts/GlobalRemindersSection.tsx
+++ b/src/renderer/src/contacts/GlobalRemindersSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import type { ContactDetail as ContactDetailType, Reminder } from '@shared/types';
 import Button from '../shell/Button';
 import { CalendarPicker } from '../views/CalendarPicker';
+import { dateStrToUnix } from '../utils/fmtDate';
 import './ContactDetail.css';
 
 export default function GlobalRemindersSection({ contact }: { contact: ContactDetailType }) {
@@ -54,7 +55,7 @@ export default function GlobalRemindersSection({ contact }: { contact: ContactDe
     if (!dueDate || !note.trim() || addingSaving) return;
     setAddingSaving(true);
     try {
-      const ts = Math.floor(new Date(`${dueDate}T09:00:00`).getTime() / 1000);
+      const ts = dateStrToUnix(dueDate);
       const r = await window.sourcerer.createReminder({
         contactId: contact.id,
         projectId: selectedProjectId ?? undefined,
@@ -81,7 +82,7 @@ export default function GlobalRemindersSection({ contact }: { contact: ContactDe
 
   async function handleSaveEdit(id: string) {
     if (!editDueDate || !editNote.trim()) return;
-    const ts = Math.floor(new Date(`${editDueDate}T09:00:00`).getTime() / 1000);
+    const ts = dateStrToUnix(editDueDate);
     try {
       const updated = await window.sourcerer.updateReminder({ id, dueDate: ts, note: editNote.trim() });
       setReminders((prev) => prev.map((r) => (r.id === id ? updated : r)).sort(sortReminders));

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { fmtDateFull } from '../utils/fmtDate';
+import { fmtDateFull, dateStrToUnix } from '../utils/fmtDate';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { CalendarPicker } from '../views/CalendarPicker';
 import Button from '../shell/Button';
@@ -382,7 +382,7 @@ function RemindersSection({
     if (!dueDate || !note.trim() || addingSaving) return;
     setAddingSaving(true);
     try {
-      const ts = Math.floor(new Date(`${dueDate}T09:00:00`).getTime() / 1000);
+      const ts = dateStrToUnix(dueDate);
       const r = await window.sourcerer.createReminder({
         contactId,
         projectId,
@@ -411,7 +411,7 @@ function RemindersSection({
 
   async function handleSaveEdit(id: string) {
     if (!editDueDate || !editNote.trim()) return;
-    const ts = Math.floor(new Date(`${editDueDate}T09:00:00`).getTime() / 1000);
+    const ts = dateStrToUnix(editDueDate);
     try {
       const updated = await window.sourcerer.updateReminder({ id, dueDate: ts, note: editNote.trim() });
       setReminders((prev) => prev.map((r) => (r.id === id ? updated : r)).sort(sortReminders));

--- a/src/renderer/src/contacts/QuickReminderModal.tsx
+++ b/src/renderer/src/contacts/QuickReminderModal.tsx
@@ -4,6 +4,7 @@ import Modal from '../shell/Modal';
 import Button from '../shell/Button';
 import { CalendarPicker } from '../views/CalendarPicker';
 import { useClickOutside } from '../hooks/useClickOutside';
+import { dateStrToUnix } from '../utils/fmtDate';
 import './QuickLogModal.css';
 
 interface Props {
@@ -70,7 +71,7 @@ export default function QuickReminderModal({ contacts, onClose, onSaved }: Props
     if (!selectedContactId || !date) return;
     setSaving(true);
     try {
-      const ts = Math.floor(new Date(`${date}T09:00:00`).getTime() / 1000);
+      const ts = dateStrToUnix(date);
       await window.sourcerer.createReminder({
         contactId: selectedContactId,
         projectId: selectedProjectId ?? undefined,

--- a/src/renderer/src/utils/fmtDate.ts
+++ b/src/renderer/src/utils/fmtDate.ts
@@ -42,6 +42,11 @@ export function fmtDateRelative(ts: number | null, fetched: number): string {
   return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
+/** Convert a YYYY-MM-DD date string to a Unix timestamp (seconds) at 09:00 local time. */
+export function dateStrToUnix(dateStr: string): number {
+  return Math.floor(new Date(`${dateStr}T09:00:00`).getTime() / 1000);
+}
+
 /**
  * Format a Unix timestamp (seconds) as a full date always including the year.
  * Returns '—' when ts is null.

--- a/src/renderer/src/views/AllContacts.css
+++ b/src/renderer/src/views/AllContacts.css
@@ -27,6 +27,7 @@
 
 .virt-spacer {
   padding: 0;
+  height: var(--spacer-height, 0);
 }
 
 .contacts-table {

--- a/src/renderer/src/views/ColumnHeader.css
+++ b/src/renderer/src/views/ColumnHeader.css
@@ -84,6 +84,8 @@
 
 .col-filter-dropdown {
   position: fixed;
+  top: var(--dropdown-top);
+  left: var(--dropdown-left);
   min-width: 190px;
   background: var(--color-surface);
   border: 1px solid var(--color-border);

--- a/src/renderer/src/views/ColumnHeader.tsx
+++ b/src/renderer/src/views/ColumnHeader.tsx
@@ -72,7 +72,7 @@ export default function ColumnHeader({
             <div className="col-filter-overlay" aria-hidden="true" onClick={() => onFilterToggle?.()} />
             <div
               className="col-filter-dropdown"
-              style={{ top: dropdownPos.top, left: dropdownPos.left }}
+              style={{ '--dropdown-top': `${dropdownPos.top}px`, '--dropdown-left': `${dropdownPos.left}px` } as React.CSSProperties}
               onClick={(e) => e.stopPropagation()}
             >
               {filterContent}

--- a/src/renderer/src/views/ContactsTable.tsx
+++ b/src/renderer/src/views/ContactsTable.tsx
@@ -608,8 +608,7 @@ export default function ContactsTable(props: ContactsTableProps) {
           <>
             {paddingTop > 0 && (
               <tr aria-hidden="true">
-                {/* eslint-disable-next-line react/forbid-dom-props */}
-                <td colSpan={colSpan} className="virt-spacer" style={{ height: paddingTop }} />
+                <td colSpan={colSpan} className="virt-spacer" style={{ '--spacer-height': `${paddingTop}px` } as React.CSSProperties} />
               </tr>
             )}
             {rowsToRender.map((row) => {
@@ -724,8 +723,7 @@ export default function ContactsTable(props: ContactsTableProps) {
             })}
             {paddingBottom > 0 && (
               <tr aria-hidden="true">
-                {/* eslint-disable-next-line react/forbid-dom-props */}
-                <td colSpan={colSpan} className="virt-spacer" style={{ height: paddingBottom }} />
+                <td colSpan={colSpan} className="virt-spacer" style={{ '--spacer-height': `${paddingBottom}px` } as React.CSSProperties} />
               </tr>
             )}
           </>


### PR DESCRIPTION
## Summary

- **#298** `ContactsTable`: virtual scroll spacer rows now pass height via `--spacer-height` CSS custom property instead of inline `style={{ height }}`, removing the `eslint-disable react/forbid-dom-props` comments
- **#295** `ColumnHeader`: filter dropdown position now uses `--dropdown-top` / `--dropdown-left` CSS variables instead of inline `top`/`left` pixel values; corresponding `top`/`left` declarations moved to `ColumnHeader.css`
- **#270** Extract `dateStrToUnix(dateStr: string): number` into `src/renderer/src/utils/fmtDate.ts`; replaces five identical inline `Math.floor(new Date(\`${date}T09:00:00\`).getTime() / 1000)` expressions in `GlobalRemindersSection`, `ProjectTab`, and `QuickReminderModal`

## Test plan

- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Virtual scroll in All Contacts and project contact tables renders without blank gaps
- [ ] Column filter dropdowns open at the correct position
- [ ] Reminders created and edited from contact detail, project tab, and quick reminder modal save with correct due dates

Closes #298
Closes #295
Closes #270