### PR TITLE
Fix keyboard accessibility across sidebar, dropdowns, and calendar

### DIFF
--- a/src/renderer/src/contacts/AddContactModal.css
+++ b/src/renderer/src/contacts/AddContactModal.css
@@ -286,6 +286,7 @@
   letter-spacing: normal;
 }
 
-.ac-project-option:hover {
+.ac-project-option:hover,
+.ac-project-option--active {
   background: var(--color-surface-2);
 }

--- a/src/renderer/src/contacts/AddContactModal.tsx
+++ b/src/renderer/src/contacts/AddContactModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useMemo, useRef, type FormEvent } from 'react';
+import { useListboxKeyboard } from '../hooks/useListboxKeyboard';
 import type { ContactListItem, CreateContactInput, Project } from '@shared/types';
 import { useClickOutside } from '../hooks/useClickOutside';
 import Button from '../shell/Button';
@@ -101,6 +102,14 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
     setProjectQuery('');
     projectInputRef.current?.focus();
   }
+
+  const listboxAcm = useListboxKeyboard({
+    isOpen: projectDropdownOpen,
+    optionCount: filteredProjects.length,
+    onSelect: (i) => selectProject(filteredProjects[i].id),
+    onClose: () => setProjectDropdownOpen(false),
+    onOpen: () => setProjectDropdownOpen(true),
+  });
 
   function removeProject(id: string) {
     setSelectedProjectIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
@@ -506,21 +515,30 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
                     ref={projectInputRef}
                     className="ac-project-search"
                     type="text"
+                    role="combobox"
+                    aria-expanded={projectDropdownOpen}
+                    aria-controls={listboxAcm.listboxId}
+                    aria-activedescendant={listboxAcm.activeIndex >= 0 ? listboxAcm.getOptionId(listboxAcm.activeIndex) : undefined}
                     value={projectQuery}
                     onChange={(e) => { setProjectQuery(e.target.value); setProjectDropdownOpen(true); }}
                     onFocus={() => setProjectDropdownOpen(true)}
+                    onKeyDown={listboxAcm.handleInputKeyDown}
                     placeholder={selectedProjectIds.size === 0 ? 'Search projects…' : ''}
                     disabled={submitting}
                   />
                 </div>
                 {projectDropdownOpen && filteredProjects.length > 0 && (
-                  <div className="ac-project-dropdown">
-                    {filteredProjects.map((p) => (
+                  <div id={listboxAcm.listboxId} className="ac-project-dropdown" role="listbox">
+                    {filteredProjects.map((p, i) => (
                       <button
                         key={p.id}
+                        id={listboxAcm.getOptionId(i)}
                         type="button"
-                        className="ac-project-option"
+                        role="option"
+                        aria-selected={listboxAcm.activeIndex === i}
+                        className={`ac-project-option${listboxAcm.activeIndex === i ? ' ac-project-option--active' : ''}`}
                         onMouseDown={(e) => { e.preventDefault(); selectProject(p.id); }}
+                        onMouseEnter={() => listboxAcm.setActiveIndex(i)}
                       >
                         {p.name}
                       </button>

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -606,7 +606,7 @@
 
 .pt-reporter-option:hover,
 .pt-reporter-option--active {
-  background: var(--color-surface);
+  background: var(--color-surface-2);
 }
 
 /* Interaction log */

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -604,7 +604,8 @@
   border-bottom: none;
 }
 
-.pt-reporter-option:hover {
+.pt-reporter-option:hover,
+.pt-reporter-option--active {
   background: var(--color-surface);
 }
 

--- a/src/renderer/src/contacts/LogProjectPicker.css
+++ b/src/renderer/src/contacts/LogProjectPicker.css
@@ -83,6 +83,7 @@
   cursor: pointer;
 }
 
-.lpp-option:hover {
+.lpp-option:hover,
+.lpp-option--active {
   background: var(--color-surface);
 }

--- a/src/renderer/src/contacts/LogProjectPicker.tsx
+++ b/src/renderer/src/contacts/LogProjectPicker.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import type { ContactProject } from '@shared/types';
 import { useClickOutside } from '../hooks/useClickOutside';
+import { useListboxKeyboard } from '../hooks/useListboxKeyboard';
 import './LogProjectPicker.css';
 
 interface Props {
@@ -15,8 +16,6 @@ export default function LogProjectPicker({ projects, selectedIds, onChange, lock
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  useClickOutside(containerRef, () => { setOpen(false); setQuery(''); }, { isOpen: open, escapeKey: false });
-
   const selected = projects.filter((p) => selectedIds.includes(p.membership_id));
   const available = projects.filter(
     (p) => !selectedIds.includes(p.membership_id) &&
@@ -26,11 +25,22 @@ export default function LogProjectPicker({ projects, selectedIds, onChange, lock
   function add(mid: string) {
     onChange([...selectedIds, mid]);
     setQuery('');
+    listbox.resetActiveIndex();
   }
 
   function remove(mid: string) {
     onChange(selectedIds.filter((id) => id !== mid));
   }
+
+  const listbox = useListboxKeyboard({
+    isOpen: open,
+    optionCount: available.length,
+    onSelect: (i) => add(available[i].membership_id),
+    onClose: () => { setOpen(false); setQuery(''); },
+    onOpen: () => setOpen(true),
+  });
+
+  useClickOutside(containerRef, () => { setOpen(false); setQuery(''); }, { isOpen: open, escapeKey: false });
 
   return (
     <div className="lpp-root" ref={containerRef}>
@@ -42,6 +52,7 @@ export default function LogProjectPicker({ projects, selectedIds, onChange, lock
               <button
                 type="button"
                 className="lpp-tag-remove"
+                aria-label={`Remove ${p.name}`}
                 onMouseDown={(e) => { e.stopPropagation(); remove(p.membership_id); }}
               >×</button>
             )}
@@ -49,19 +60,28 @@ export default function LogProjectPicker({ projects, selectedIds, onChange, lock
         ))}
         <input
           className="lpp-input"
+          role="combobox"
+          aria-expanded={open}
+          aria-controls={listbox.listboxId}
+          aria-activedescendant={listbox.activeIndex >= 0 ? listbox.getOptionId(listbox.activeIndex) : undefined}
           placeholder={selected.length === 0 ? 'Add projects…' : ''}
           value={query}
           onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
           onFocus={() => setOpen(true)}
+          onKeyDown={listbox.handleInputKeyDown}
         />
       </div>
       {open && available.length > 0 && (
-        <div className="lpp-dropdown">
-          {available.map((p) => (
+        <div id={listbox.listboxId} className="lpp-dropdown" role="listbox">
+          {available.map((p, i) => (
             <div
               key={p.membership_id}
-              className="lpp-option"
+              id={listbox.getOptionId(i)}
+              role="option"
+              aria-selected={listbox.activeIndex === i}
+              className={`lpp-option${listbox.activeIndex === i ? ' lpp-option--active' : ''}`}
               onMouseDown={(e) => { e.preventDefault(); add(p.membership_id); }}
+              onMouseEnter={() => listbox.setActiveIndex(i)}
             >
               {p.name}
             </div>

--- a/src/renderer/src/contacts/LogProjectPicker.tsx
+++ b/src/renderer/src/contacts/LogProjectPicker.tsx
@@ -53,7 +53,8 @@ export default function LogProjectPicker({ projects, selectedIds, onChange, lock
                 type="button"
                 className="lpp-tag-remove"
                 aria-label={`Remove ${p.name}`}
-                onMouseDown={(e) => { e.stopPropagation(); remove(p.membership_id); }}
+                onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                onClick={(e) => { e.stopPropagation(); remove(p.membership_id); }}
               >×</button>
             )}
           </span>
@@ -68,7 +69,14 @@ export default function LogProjectPicker({ projects, selectedIds, onChange, lock
           value={query}
           onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
           onFocus={() => setOpen(true)}
-          onKeyDown={listbox.handleInputKeyDown}
+          onKeyDown={(e) => {
+            if (e.key === 'Backspace' && query === '' && selected.length > 0) {
+              e.preventDefault();
+              remove(selected[selected.length - 1].membership_id);
+              return;
+            }
+            listbox.handleInputKeyDown(e);
+          }}
         />
       </div>
       {open && available.length > 0 && (

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -802,7 +802,9 @@ export default function ProjectTab({ contact, statusOptions, priorityOptions, on
                   {r.name}
                   <button
                     className="pt-reporter-chip-remove"
-                    onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); removeReporter(r.email); }}
+                    aria-label={`Remove ${r.name}`}
+                    onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                    onClick={(e) => { e.stopPropagation(); removeReporter(r.email); }}
                   >×</button>
                 </span>
               ))}

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -689,6 +689,7 @@ export default function ProjectTab({ contact, statusOptions, priorityOptions, on
     const next = [...localReporters, r];
     setLocalReporters(next);
     setReporterQuery('');
+    listboxPt.resetActiveIndex();
     await window.sourcerer.setMembershipReporters(membership.membership_id, next);
     onMembershipUpdated();
   }

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useListboxKeyboard } from '../hooks/useListboxKeyboard';
 import { fmtDateFull } from '../utils/fmtDate';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { CalendarPicker } from '../views/CalendarPicker';
@@ -705,6 +706,14 @@ export default function ProjectTab({ contact, statusOptions, priorityOptions, on
       r.name.toLowerCase().includes(reporterQuery.toLowerCase()),
   );
 
+  const listboxPt = useListboxKeyboard({
+    isOpen: reporterDropdownOpen,
+    optionCount: filteredReporterOptions.length,
+    onSelect: (i) => addReporter(filteredReporterOptions[i]),
+    onClose: () => { setReporterDropdownOpen(false); setReporterQuery(''); },
+    onOpen: () => setReporterDropdownOpen(true),
+  });
+
   async function handleDismissConflict() {
     await window.sourcerer.updateMembership({
       membershipId: membership.membership_id,
@@ -799,24 +808,34 @@ export default function ProjectTab({ contact, statusOptions, priorityOptions, on
               ))}
               <input
                 className="pt-reporter-search"
+                role="combobox"
+                aria-expanded={reporterDropdownOpen}
+                aria-controls={listboxPt.listboxId}
+                aria-activedescendant={listboxPt.activeIndex >= 0 ? listboxPt.getOptionId(listboxPt.activeIndex) : undefined}
                 value={reporterQuery}
                 onChange={(e) => { setReporterQuery(e.target.value); setReporterDropdownOpen(true); }}
                 onFocus={() => setReporterDropdownOpen(true)}
                 onKeyDown={(e) => {
                   if (e.key === 'Backspace' && reporterQuery === '' && localReporters.length > 0) {
                     removeReporter(localReporters[localReporters.length - 1].email);
+                    return;
                   }
+                  listboxPt.handleInputKeyDown(e);
                 }}
                 placeholder={localReporters.length === 0 ? 'Assign reporters…' : ''}
               />
             </div>
             {reporterDropdownOpen && filteredReporterOptions.length > 0 && (
-              <div className="pt-reporter-dropdown">
-                {filteredReporterOptions.map((r) => (
+              <div id={listboxPt.listboxId} className="pt-reporter-dropdown" role="listbox">
+                {filteredReporterOptions.map((r, i) => (
                   <button
                     key={r.email}
-                    className="pt-reporter-option"
+                    id={listboxPt.getOptionId(i)}
+                    role="option"
+                    aria-selected={listboxPt.activeIndex === i}
+                    className={`pt-reporter-option${listboxPt.activeIndex === i ? ' pt-reporter-option--active' : ''}`}
                     onMouseDown={(e) => { e.preventDefault(); addReporter(r); }}
+                    onMouseEnter={() => listboxPt.setActiveIndex(i)}
                   >
                     {r.name}
                   </button>

--- a/src/renderer/src/hooks/useListboxKeyboard.ts
+++ b/src/renderer/src/hooks/useListboxKeyboard.ts
@@ -61,6 +61,7 @@ export function useListboxKeyboard({
       } else if (e.key === 'Escape') {
         if (isOpen) {
           e.preventDefault();
+          e.stopPropagation();
           onClose();
         }
       }

--- a/src/renderer/src/hooks/useListboxKeyboard.ts
+++ b/src/renderer/src/hooks/useListboxKeyboard.ts
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseListboxKeyboardOptions {
+  isOpen: boolean;
+  optionCount: number;
+  onSelect: (index: number) => void;
+  onClose: () => void;
+  onOpen?: () => void;
+}
+
+interface UseListboxKeyboardResult {
+  activeIndex: number;
+  setActiveIndex: (i: number) => void;
+  resetActiveIndex: () => void;
+  handleInputKeyDown: (e: React.KeyboardEvent) => void;
+  listboxId: string;
+  getOptionId: (index: number) => string;
+}
+
+let idCounter = 0;
+
+export function useListboxKeyboard({
+  isOpen,
+  optionCount,
+  onSelect,
+  onClose,
+  onOpen,
+}: UseListboxKeyboardOptions): UseListboxKeyboardResult {
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const idRef = useRef(`listbox-${++idCounter}`);
+
+  const resetActiveIndex = useCallback(() => setActiveIndex(-1), []);
+
+  useEffect(() => {
+    if (!isOpen) setActiveIndex(-1);
+  }, [isOpen]);
+
+  const handleInputKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        if (!isOpen) {
+          onOpen?.();
+          setActiveIndex(0);
+        } else {
+          setActiveIndex((i) => (i + 1) % optionCount);
+        }
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        if (!isOpen) {
+          onOpen?.();
+          setActiveIndex(optionCount - 1);
+        } else {
+          setActiveIndex((i) => (i <= 0 ? optionCount - 1 : i - 1));
+        }
+      } else if (e.key === 'Enter') {
+        if (isOpen && activeIndex >= 0) {
+          e.preventDefault();
+          onSelect(activeIndex);
+        }
+      } else if (e.key === 'Escape') {
+        if (isOpen) {
+          e.preventDefault();
+          onClose();
+        }
+      }
+    },
+    [isOpen, optionCount, activeIndex, onSelect, onClose, onOpen],
+  );
+
+  const getOptionId = useCallback(
+    (index: number) => `${idRef.current}-option-${index}`,
+    [],
+  );
+
+  return {
+    activeIndex,
+    setActiveIndex,
+    resetActiveIndex,
+    handleInputKeyDown,
+    listboxId: idRef.current,
+    getOptionId,
+  };
+}

--- a/src/renderer/src/hooks/useListboxKeyboard.ts
+++ b/src/renderer/src/hooks/useListboxKeyboard.ts
@@ -54,7 +54,7 @@ export function useListboxKeyboard({
           setActiveIndex((i) => (i <= 0 ? optionCount - 1 : i - 1));
         }
       } else if (e.key === 'Enter') {
-        if (isOpen && activeIndex >= 0) {
+        if (isOpen && activeIndex >= 0 && activeIndex < optionCount) {
           e.preventDefault();
           onSelect(activeIndex);
         }

--- a/src/renderer/src/shell/Sidebar.tsx
+++ b/src/renderer/src/shell/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, type KeyboardEvent } from 'react';
+import { useState, useRef, useEffect, type KeyboardEvent } from 'react';
 
 function hashColour(id: string, colours: string[]): string {
   let h = 0;
@@ -66,6 +66,13 @@ export default function Sidebar({
   const [renameValue, setRenameValue] = useState('');
   const renameInputRef = useRef<HTMLInputElement>(null);
   const renameCancelledRef = useRef(false);
+  const deleteCancelRefs = useRef<Map<string, HTMLButtonElement | null>>(new Map());
+
+  useEffect(() => {
+    if (deletingId) {
+      deleteCancelRefs.current.get(deletingId)?.focus();
+    }
+  }, [deletingId]);
 
   function startRename(project: Project) {
     setRenamingId(project.id);
@@ -235,7 +242,11 @@ export default function Sidebar({
                     <span className="sidebar-delete-label">Delete "{project.name}"?</span>
                     <div className="sidebar-delete-actions">
                       <button className="sidebar-delete-yes" onClick={() => confirmDelete(project.id)}>Delete</button>
-                      <button className="sidebar-delete-no" onClick={() => setDeletingId(null)}>Cancel</button>
+                      <button
+                        className="sidebar-delete-no"
+                        ref={(el) => { deleteCancelRefs.current.set(project.id, el); }}
+                        onClick={() => setDeletingId(null)}
+                      >Cancel</button>
                     </div>
                   </div>
                 ) : (

--- a/src/renderer/src/views/CalendarPicker.tsx
+++ b/src/renderer/src/views/CalendarPicker.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useClickOutside } from '../hooks/useClickOutside';
 import './CalendarPicker.css';
 
@@ -84,9 +84,49 @@ export function CalendarPicker({
   const [viewYear, setViewYear] = useState(() => new Date().getFullYear());
   const [viewMonth, setViewMonth] = useState(() => new Date().getMonth() + 1);
   const [yearPageOffset, setYearPageOffset] = useState(0);
+  const [focusedDayIndex, setFocusedDayIndex] = useState<number | null>(null);
+  const [focusedMonthIndex, setFocusedMonthIndex] = useState<number | null>(null);
+  const [focusedYearIndex, setFocusedYearIndex] = useState<number | null>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dayGridRef = useRef<HTMLDivElement>(null);
+  const monthGridRef = useRef<HTMLDivElement>(null);
+  const yearGridRef = useRef<HTMLDivElement>(null);
 
   useClickOutside(wrapRef, () => { setOpen(false); setMode('days'); }, { isOpen: open });
+
+  const moveFocusAfterNavRef = useRef(false);
+
+  useEffect(() => {
+    if (!open) return;
+    if (mode === 'days') {
+      const dayCells = dayGridRef.current?.querySelectorAll<HTMLButtonElement>('.cal-day:not(.cal-day--disabled)');
+      if (!dayCells || !dayCells.length) return;
+      if (focusedDayIndex === null || moveFocusAfterNavRef.current) {
+        moveFocusAfterNavRef.current = false;
+        const selectedBtn = dayGridRef.current?.querySelector<HTMLButtonElement>('.cal-day--selected');
+        const defaultIdx = selectedBtn ? Array.from(dayCells).indexOf(selectedBtn) : 0;
+        const idx = Math.max(0, defaultIdx);
+        setFocusedDayIndex(idx);
+        dayCells[idx]?.focus();
+      }
+    } else if (mode === 'months') {
+      const monthCells = monthGridRef.current?.querySelectorAll<HTMLButtonElement>('.cal-month-cell:not(:disabled)');
+      if (!monthCells || !monthCells.length) return;
+      moveFocusAfterNavRef.current = false;
+      const idx = focusedMonthIndex ?? (viewMonth - 1);
+      setFocusedMonthIndex(idx);
+      monthCells[idx]?.focus();
+    } else if (mode === 'years') {
+      const yearCells = yearGridRef.current?.querySelectorAll<HTMLButtonElement>('.cal-year-cell:not(:disabled)');
+      if (!yearCells || !yearCells.length) return;
+      moveFocusAfterNavRef.current = false;
+      const idx = focusedYearIndex ?? Math.floor(YEAR_WINDOW / 2);
+      setFocusedYearIndex(idx);
+      yearCells[idx]?.focus();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, mode, viewYear, viewMonth, yearPageOffset]);
 
   function openCalendar() {
     if (value) {
@@ -100,6 +140,9 @@ export function CalendarPicker({
     }
     setMode('days');
     setYearPageOffset(0);
+    setFocusedDayIndex(null);
+    setFocusedMonthIndex(null);
+    setFocusedYearIndex(null);
     setOpen((v) => !v);
   }
 
@@ -118,15 +161,18 @@ export function CalendarPicker({
     onChange(iso);
     setOpen(false);
     setMode('days');
+    triggerRef.current?.focus();
   }
 
   function selectYear(y: number) {
     setViewYear(y);
+    setFocusedMonthIndex(null);
     setMode('months');
   }
 
   function selectMonth(m: number) {
     setViewMonth(m);
+    setFocusedDayIndex(null);
     setMode('days');
   }
 
@@ -135,6 +181,132 @@ export function CalendarPicker({
     onChange('');
     setOpen(false);
     setMode('days');
+  }
+
+  function handleDayGridKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    const buttons = Array.from(
+      dayGridRef.current?.querySelectorAll<HTMLButtonElement>('.cal-day:not(.cal-day--disabled)') ?? [],
+    );
+    if (!buttons.length) return;
+    const current = document.activeElement as HTMLButtonElement | null;
+    const idx = current ? buttons.indexOf(current) : -1;
+
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      const next = idx + 1 < buttons.length ? idx + 1 : 0;
+      buttons[next].focus();
+      setFocusedDayIndex(next);
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const prev = idx - 1 >= 0 ? idx - 1 : buttons.length - 1;
+      buttons[prev].focus();
+      setFocusedDayIndex(prev);
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = idx + 7 < buttons.length ? idx + 7 : idx;
+      buttons[next].focus();
+      setFocusedDayIndex(next);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prev = idx - 7 >= 0 ? idx - 7 : idx;
+      buttons[prev].focus();
+      setFocusedDayIndex(prev);
+    } else if (e.key === 'PageDown') {
+      e.preventDefault();
+      moveFocusAfterNavRef.current = true;
+      setFocusedDayIndex(null);
+      nextMonth();
+    } else if (e.key === 'PageUp') {
+      e.preventDefault();
+      moveFocusAfterNavRef.current = true;
+      setFocusedDayIndex(null);
+      prevMonth();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setOpen(false);
+      setMode('days');
+      triggerRef.current?.focus();
+    }
+  }
+
+  function handleMonthGridKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    const buttons = Array.from(
+      monthGridRef.current?.querySelectorAll<HTMLButtonElement>('.cal-month-cell:not(:disabled)') ?? [],
+    );
+    if (!buttons.length) return;
+    const current = document.activeElement as HTMLButtonElement | null;
+    const idx = current ? buttons.indexOf(current) : -1;
+
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      const next = idx + 1 < buttons.length ? idx + 1 : 0;
+      buttons[next].focus();
+      setFocusedMonthIndex(next);
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const prev = idx - 1 >= 0 ? idx - 1 : buttons.length - 1;
+      buttons[prev].focus();
+      setFocusedMonthIndex(prev);
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = idx + 3 < buttons.length ? idx + 3 : idx;
+      buttons[next].focus();
+      setFocusedMonthIndex(next);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prev = idx - 3 >= 0 ? idx - 3 : idx;
+      buttons[prev].focus();
+      setFocusedMonthIndex(prev);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setMode('days');
+      setFocusedDayIndex(null);
+    }
+  }
+
+  function handleYearGridKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    const buttons = Array.from(
+      yearGridRef.current?.querySelectorAll<HTMLButtonElement>('.cal-year-cell:not(:disabled)') ?? [],
+    );
+    if (!buttons.length) return;
+    const current = document.activeElement as HTMLButtonElement | null;
+    const idx = current ? buttons.indexOf(current) : -1;
+
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      const next = idx + 1 < buttons.length ? idx + 1 : 0;
+      buttons[next].focus();
+      setFocusedYearIndex(next);
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const prev = idx - 1 >= 0 ? idx - 1 : buttons.length - 1;
+      buttons[prev].focus();
+      setFocusedYearIndex(prev);
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = idx + 3 < buttons.length ? idx + 3 : idx;
+      buttons[next].focus();
+      setFocusedYearIndex(next);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prev = idx - 3 >= 0 ? idx - 3 : idx;
+      buttons[prev].focus();
+      setFocusedYearIndex(prev);
+    } else if (e.key === 'PageDown') {
+      e.preventDefault();
+      moveFocusAfterNavRef.current = true;
+      setFocusedYearIndex(null);
+      setYearPageOffset((o) => o + 1);
+    } else if (e.key === 'PageUp') {
+      e.preventDefault();
+      moveFocusAfterNavRef.current = true;
+      setFocusedYearIndex(null);
+      setYearPageOffset((o) => o - 1);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setMode('days');
+      setFocusedDayIndex(null);
+    }
   }
 
   const cells = buildCells(viewYear, viewMonth);
@@ -149,6 +321,7 @@ export function CalendarPicker({
   return (
     <div ref={wrapRef} className="cal-wrap">
       <button
+        ref={triggerRef}
         type="button"
         className={`project-meta-action-btn${value ? ' project-meta-action-btn--active' : ''}`}
         onClick={openCalendar}
@@ -198,13 +371,17 @@ export function CalendarPicker({
           </div>
 
           {mode === 'years' ? (
-            <div className="cal-year-grid">
+            <div ref={yearGridRef} className="cal-year-grid" onKeyDown={handleYearGridKeyDown}>
               {yearRange.map((y) => {
                 const yearDisabled = maxY !== undefined && y > maxY;
+                const enabledButtons = yearRange.filter((yr) => !(maxY !== undefined && yr > maxY));
+                const enabledIdx = enabledButtons.indexOf(y);
+                const isFocused = !yearDisabled && enabledIdx === focusedYearIndex;
                 return (
                   <button
                     type="button"
                     key={y}
+                    tabIndex={isFocused ? 0 : -1}
                     className={[
                       'cal-year-cell',
                       y === viewYear ? 'cal-year-cell--selected' : '',
@@ -220,14 +397,21 @@ export function CalendarPicker({
               })}
             </div>
           ) : mode === 'months' ? (
-            <div className="cal-month-grid">
+            <div ref={monthGridRef} className="cal-month-grid" onKeyDown={handleMonthGridKeyDown}>
               {MONTHS_SHORT.map((name, i) => {
                 const monthDisabled = maxY !== undefined && maxM !== undefined &&
                   (viewYear > maxY || (viewYear === maxY && i + 1 > maxM));
+                const enabledMonths = MONTHS_SHORT.map((_, mi) => mi).filter((mi) => {
+                  if (maxY === undefined || maxM === undefined) return true;
+                  return !(viewYear > maxY || (viewYear === maxY && mi + 1 > maxM));
+                });
+                const enabledIdx = enabledMonths.indexOf(i);
+                const isFocused = !monthDisabled && enabledIdx === focusedMonthIndex;
                 return (
                 <button
                   type="button"
                   key={name}
+                  tabIndex={isFocused ? 0 : -1}
                   className={[
                     'cal-month-cell',
                     i + 1 === viewMonth ? 'cal-month-cell--selected' : '',
@@ -243,7 +427,7 @@ export function CalendarPicker({
               })}
             </div>
           ) : (
-            <div className="cal-grid">
+            <div ref={dayGridRef} className="cal-grid" onKeyDown={handleDayGridKeyDown}>
               {DAY_NAMES.map((n) => (
                 <div key={n} className="cal-day-name">{n}</div>
               ))}
@@ -252,10 +436,17 @@ export function CalendarPicker({
                 const isSelected = iso === value;
                 const isToday = iso === todayStr && !isSelected;
                 const isDisabled = !!maxDate && iso > maxDate;
+                const enabledCells = cells.filter((_, ci) => {
+                  const ciso = `${cells[ci].y}-${String(cells[ci].m).padStart(2, '0')}-${String(cells[ci].d).padStart(2, '0')}`;
+                  return !(!!maxDate && ciso > maxDate);
+                });
+                const enabledIdx = !isDisabled ? enabledCells.indexOf(cell) : -1;
+                const isFocused = !isDisabled && enabledIdx === focusedDayIndex;
                 return (
                   <button
                     type="button"
                     key={i}
+                    tabIndex={isFocused ? 0 : -1}
                     className={[
                       'cal-day',
                       cell.overflow ? 'cal-day--overflow' : '',

--- a/src/renderer/src/views/Timeline.css
+++ b/src/renderer/src/views/Timeline.css
@@ -247,7 +247,8 @@
   border-bottom: none;
 }
 
-.ptl-ms-option:hover {
+.ptl-ms-option:hover,
+.ptl-ms-option--active {
   background: var(--color-bg);
 }
 

--- a/src/renderer/src/views/Timeline.tsx
+++ b/src/renderer/src/views/Timeline.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useListboxKeyboard } from '../hooks/useListboxKeyboard';
 import { createPortal } from 'react-dom';
 import type { TimelineEntry, User } from '@shared/types';
 import { useClickOutside } from '../hooks/useClickOutside';
@@ -125,12 +126,20 @@ function MultiSelect({
   const [query, setQuery] = useState('');
   const ref = useRef<HTMLDivElement>(null);
 
-  const close = () => { setOpen(false); setQuery(''); };
-  useClickOutside(ref, close, { isOpen: open, escapeKey: false });
-
   const filtered = options.filter(
     (o) => !selected.includes(o) && o.toLowerCase().includes(query.toLowerCase()),
   );
+
+  const listbox = useListboxKeyboard({
+    isOpen: open,
+    optionCount: filtered.length,
+    onSelect: (i) => { onChange([...selected, filtered[i]]); setQuery(''); },
+    onClose: () => { setOpen(false); setQuery(''); },
+    onOpen: () => setOpen(true),
+  });
+
+  const close = () => { setOpen(false); setQuery(''); };
+  useClickOutside(ref, close, { isOpen: open, escapeKey: false });
 
   return (
     <div ref={ref} className="ptl-ms">
@@ -140,6 +149,8 @@ function MultiSelect({
             {s}
             <button
               className="ptl-ms-chip-remove"
+              aria-label={`Remove ${s}`}
+              tabIndex={0}
               onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); onChange(selected.filter((x) => x !== s)); }}
             >
               ×
@@ -148,24 +159,34 @@ function MultiSelect({
         ))}
         <input
           className="ptl-ms-input"
+          role="combobox"
+          aria-expanded={open}
+          aria-controls={listbox.listboxId}
+          aria-activedescendant={listbox.activeIndex >= 0 ? listbox.getOptionId(listbox.activeIndex) : undefined}
           value={query}
           onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
           onFocus={() => setOpen(true)}
           onKeyDown={(e) => {
             if (e.key === 'Backspace' && query === '' && selected.length > 0) {
               onChange(selected.slice(0, -1));
+              return;
             }
+            listbox.handleInputKeyDown(e);
           }}
           placeholder={selected.length === 0 ? placeholder : ''}
         />
       </div>
       {open && filtered.length > 0 && (
-        <div className="ptl-ms-dropdown">
-          {filtered.map((opt) => (
+        <div id={listbox.listboxId} className="ptl-ms-dropdown" role="listbox">
+          {filtered.map((opt, i) => (
             <button
               key={opt}
-              className="ptl-ms-option"
+              id={listbox.getOptionId(i)}
+              role="option"
+              aria-selected={listbox.activeIndex === i}
+              className={`ptl-ms-option${listbox.activeIndex === i ? ' ptl-ms-option--active' : ''}`}
               onMouseDown={(e) => { e.preventDefault(); onChange([...selected, opt]); setQuery(''); }}
+              onMouseEnter={() => listbox.setActiveIndex(i)}
             >
               {opt}
             </button>


### PR DESCRIPTION
## Summary

- **#327 — Sidebar delete confirmation focus:** When a delete confirmation appears for a project, focus now moves automatically to the Cancel button via a `useEffect` + per-project ref map. The safe default (Cancel) receives focus so keyboard/screen-reader users can immediately act.

- **#264 — Dropdown pickers keyboard nav:** Added a shared `useListboxKeyboard` hook (`src/renderer/src/hooks/useListboxKeyboard.ts`) providing `role="combobox"` on inputs, `role="listbox"` on dropdowns, `role="option"` + `aria-selected` on items, and ArrowUp/Down/Enter/Escape keyboard navigation. Wired into all three pickers: AddContactModal "Add to projects", ProjectTab "Reporters", and LogProjectPicker. Active option highlighted via `--active` CSS modifier.

- **#323 — Timeline MultiSelect keyboard nav:** Wired the same `useListboxKeyboard` hook into the `MultiSelect` component. Added `aria-label="Remove {chip}"` to chip remove buttons (which are already `<button>` elements and naturally tab-reachable).

- **#237 — CalendarPicker arrow key navigation:** Added `onKeyDown` handlers to day/month/year grid containers. Arrow keys navigate cells within the grid, PageUp/PageDown navigate months (day view) or year pages (year view), Enter/Space select via the existing button click, Escape closes and returns focus to the trigger. Uses roving tabindex: the focused cell has `tabIndex={0}`, all others `tabIndex={-1}`. A ref flag (`moveFocusAfterNavRef`) ensures focus follows keyboard-driven month changes but not click-based nav-button presses.

## Test plan

- [x] Sidebar: click the "…" menu on a project → Delete → confirm the Cancel button receives focus automatically
- [ ] AddContactModal "Add to projects": Tab into the input, ArrowDown opens dropdown and highlights first option, ArrowUp wraps, Enter selects, Escape closes
- [ ] ProjectTab "Reporters": same keyboard behaviour as above
- [ ] LogProjectPicker: same keyboard behaviour as above; chip × buttons have aria-label
- [x] Timeline MultiSelect (Reporter/Project/Priority filters): ArrowDown/Up navigates options, Enter selects, Escape closes; chip × buttons focusable by Tab
- [x] CalendarPicker: open → arrow keys move between days, PageUp/Down change months, Enter selects, Escape returns focus to trigger button; click year → arrow keys, Escape returns to day view

Closes #327
Closes #264
Closes #323
Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)