### PR TITLE
Three trivial fixes: ContactHandleType, ContactListItem title, btn--full alignment

### DIFF
--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -159,7 +159,7 @@ export function registerContactHandlers(): void {
   ipcMain.handle('contacts:list', (): ContactListItem[] => {
     const db = getDatabase();
     const rows = stmt(db,
-        `SELECT c.id, c.name, c.organization, c.notes, c.created_at,
+        `SELECT c.id, c.name, c.organization, c.title, c.notes, c.created_at,
                 EXISTS(SELECT 1 FROM contact_emails WHERE contact_id = c.id) AS has_email,
                 EXISTS(SELECT 1 FROM contact_phones WHERE contact_id = c.id) AS has_phone,
                 (SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contact_id = c.id) AS emails_raw,
@@ -182,6 +182,7 @@ export function registerContactHandlers(): void {
       id: string;
       name: string;
       organization: string | null;
+      title: string | null;
       notes: string | null;
       created_at: number;
       has_email: 0 | 1;
@@ -197,6 +198,7 @@ export function registerContactHandlers(): void {
       id: row.id,
       name: row.name,
       organization: row.organization,
+      title: row.title,
       notes: row.notes,
       created_at: row.created_at,
       has_email: row.has_email,
@@ -324,13 +326,13 @@ export function registerContactHandlers(): void {
     }
 
     const row = db.prepare(
-      `SELECT c.id, c.name, c.organization, c.notes, c.created_at,
+      `SELECT c.id, c.name, c.organization, c.title, c.notes, c.created_at,
               EXISTS(SELECT 1 FROM contact_emails WHERE contact_id = c.id) AS has_email,
               EXISTS(SELECT 1 FROM contact_phones WHERE contact_id = c.id) AS has_phone,
               (SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contact_id = c.id) AS emails_raw,
               (SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contact_id = c.id) AS phones_raw
        FROM contacts c WHERE c.id = ?`,
-    ).get(id) as { id: string; name: string; organization: string | null; notes: string | null; created_at: number; has_email: 0|1; has_phone: 0|1; emails_raw: string|null; phones_raw: string|null };
+    ).get(id) as { id: string; name: string; organization: string | null; title: string | null; notes: string | null; created_at: number; has_email: 0|1; has_phone: 0|1; emails_raw: string|null; phones_raw: string|null };
     return { ...row, date_first_contacted: null, date_last_contacted: null, projects: [] };
   });
 

--- a/src/main/ipc/import.ts
+++ b/src/main/ipc/import.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import type Database from 'better-sqlite3-multiple-ciphers';
 import { getDatabase } from '../database';
 import { normalizeEmail, normalizePhone, validateEmail, validateUrl } from '../sanitize';
-import type { User, ImportResult } from '@shared/types';
+import type { User, ImportResult, ContactHandleType } from '@shared/types';
 
 const SAMPLE_HEADERS =
   'Name,Organization,Title,DOB,Notes,Email,Phone,LinkedIn,X,Website,Theme,Status,Priority\n';
@@ -74,7 +74,7 @@ export interface VcfContact {
   emails: string[];
   phones: string[];
   urls: string[];
-  handles: Array<{ type: string; handle: string }>;
+  handles: Array<{ type: ContactHandleType; handle: string }>;
 }
 
 function parseBday(value: string): string | null {
@@ -159,7 +159,7 @@ export function parseVcf(text: string): VcfContact[] {
         let handle = '';
         try { handle = decodeURIComponent(value.slice(schemeColon + 1)).trim(); } catch { handle = value.slice(schemeColon + 1).trim(); }
         if (!handle) break;
-        const typeMap: Record<string, string> = { signal: 'signal', whatsapp: 'whatsapp', telegram: 'telegram' };
+        const typeMap: Record<string, ContactHandleType> = { signal: 'signal', whatsapp: 'whatsapp', telegram: 'telegram' };
         cur.handles.push({ type: typeMap[scheme] ?? 'other', handle });
         break;
       }

--- a/src/renderer/src/contacts/AddContactModal.tsx
+++ b/src/renderer/src/contacts/AddContactModal.tsx
@@ -48,7 +48,7 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
   const [socials, setSocials] = useState<Record<SocialType, string[]>>({
     linkedin: [''], x: [], instagram: [], facebook: [],
   });
-  const [handles, setHandles] = useState<Array<{ type: string; handle: string }>>([]);
+  const [handles, setHandles] = useState<Array<{ type: HandleType; handle: string }>>([]);
   const [notes, setNotes] = useState('');
   const [expanded, setExpanded] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -396,7 +396,7 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
                 <select
                   className="form-input ac-handle-type"
                   value={HANDLE_TYPES.includes(entry.type as HandleType) ? entry.type : 'other'}
-                  onChange={(e) => setHandles(handles.map((h, j) => j === i ? { ...h, type: e.target.value } : h))}
+                  onChange={(e) => setHandles(handles.map((h, j) => j === i ? { ...h, type: e.target.value as HandleType } : h))}
                   disabled={submitting}
                 >
                   {HANDLE_TYPES.map((t) => (

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -101,7 +101,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
   const [editTitle, setEditTitle] = useState('');
   const [editDob, setEditDob] = useState('');
   const [editNotes, setEditNotes] = useState('');
-  const [editHandles, setEditHandles] = useState<Array<{ type: string; handle: string }>>([]);
+  const [editHandles, setEditHandles] = useState<Array<{ type: HandleType; handle: string }>>([]);
   const [editEmails, setEditEmails] = useState<Array<{ email: string; label: string }>>([]);
   const [editPhones, setEditPhones] = useState<Array<{ phone: string; label: string }>>([]);
   const [editSocials, setEditSocials] = useState<Record<NonOtherSocialType, string[]>>({
@@ -512,7 +512,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                 value={HANDLE_TYPES.includes(entry.type as HandleType) ? entry.type : 'other'}
                 onChange={(e) => {
                   const next = [...editHandles];
-                  next[i] = { ...next[i], type: e.target.value };
+                  next[i] = { ...next[i], type: e.target.value as HandleType };
                   setEditHandles(next);
                 }}
               >

--- a/src/renderer/src/screens/Setup.css
+++ b/src/renderer/src/screens/Setup.css
@@ -123,7 +123,6 @@
 
 .setup-card .btn {
   height: 40px;
-  justify-content: center;
 }
 
 .setup-vault-hint {

--- a/src/renderer/src/screens/Unlock.css
+++ b/src/renderer/src/screens/Unlock.css
@@ -89,5 +89,4 @@
 
 .unlock-card .btn {
   height: 40px;
-  justify-content: center;
 }

--- a/src/renderer/src/shell/Button.css
+++ b/src/renderer/src/shell/Button.css
@@ -35,7 +35,6 @@
 
 .btn--full {
   width: 100%;
-  justify-content: flex-start;
 }
 
 /* ── Variants ── */

--- a/src/renderer/src/shell/Sidebar.css
+++ b/src/renderer/src/shell/Sidebar.css
@@ -60,6 +60,7 @@
 
 .sidebar-action-btns .btn {
   height: 26px;
+  justify-content: flex-start;
 }
 
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -76,6 +76,7 @@ export interface ContactListItem {
   id: string;
   name: string;
   organization: string | null;
+  title: string | null;
   notes: string | null;
   created_at: number;
   has_email: 0 | 1;
@@ -110,15 +111,17 @@ export interface ContactLink {
   sort_order: number;
 }
 
+export type ContactHandleType = 'signal' | 'whatsapp' | 'telegram' | 'other';
+
 export interface ContactHandle {
   id: string;
-  type: 'signal' | 'whatsapp' | 'telegram' | 'other';
+  type: ContactHandleType;
   handle: string;
   sort_order: number;
 }
 
 export interface ContactHandleInput {
-  type: string;
+  type: ContactHandleType;
   handle: string;
 }
 


### PR DESCRIPTION
## Summary

- **#254** Extract `ContactHandleType = 'signal' | 'whatsapp' | 'telegram' | 'other'` from `types.ts`; apply it to `ContactHandleInput.type` (previously `string`), the local parse type in `import.ts`, and the `editHandles` / `handles` state in `GlobalTab` and `AddContactModal`. The `select` `onChange` handlers cast `e.target.value as HandleType` since DOM events always return `string`.
- **#320** Add `title: string | null` to `ContactListItem`; add `c.title` to the `contacts:list` SELECT and row mapping; add `c.title` to the `contacts:create` post-insert SELECT and its return type.
- **#324** Remove `justify-content: flex-start` from `.btn--full` so full-width buttons default to centered (matching every use case except the sidebar). Move `justify-content: flex-start` into `.sidebar-action-btns .btn`. Drop the now-redundant `justify-content: center` overrides from `Setup.css` and `Unlock.css`.

## Test plan

- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Tests pass (`npm test`)
- [ ] Sidebar action buttons still left-align
- [ ] Setup and Unlock full-width buttons still center their text
- [ ] New contact appears in list with correct `title` field after create

Closes #254
Closes #320
Closes #324