### PR TITLE
Extract duplicated constants, validation hook, and reminder utils

### DIFF
--- a/src/renderer/src/contacts/AddContactModal.tsx
+++ b/src/renderer/src/contacts/AddContactModal.tsx
@@ -5,12 +5,12 @@ import Button from '../shell/Button';
 import DynamicList from './DynamicList';
 import { CalendarPicker } from '../views/CalendarPicker';
 import {
-  isValidEmail,
-  isValidUrl,
   hasDisallowedPhoneChars,
   normalizePhoneForComparison,
-  findDuplicates,
 } from './contactValidation';
+import { NON_OTHER_SOCIAL_TYPES, SOCIAL_META, localToday } from './contactConstants';
+import type { NonOtherSocialType } from './contactConstants';
+import { useContactFieldValidation } from './useContactFieldValidation';
 import Modal from '../shell/Modal';
 import './AddContactModal.css';
 
@@ -19,23 +19,8 @@ interface Props {
   onCancel: () => void;
 }
 
-const SOCIAL_TYPES = ['linkedin', 'x', 'instagram', 'facebook'] as const;
-type SocialType = (typeof SOCIAL_TYPES)[number];
-
-const SOCIAL_META: Record<SocialType, { label: string; placeholder: string }> = {
-  linkedin:  { label: 'LinkedIn',   placeholder: 'https://linkedin.com/in/…' },
-  x:         { label: 'X / Twitter', placeholder: 'https://x.com/…' },
-  instagram: { label: 'Instagram',  placeholder: 'https://instagram.com/…' },
-  facebook:  { label: 'Facebook',   placeholder: 'https://facebook.com/…' },
-};
-
 import { HANDLE_TYPES, HANDLE_META } from './handleMeta';
 import type { HandleType } from './handleMeta';
-
-function localToday(): string {
-  const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-}
 
 export default function AddContactModal({ onCreated, onCancel }: Props) {
   const [name, setName] = useState('');
@@ -45,7 +30,7 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
   const [emails, setEmails] = useState<Array<{ email: string; label: string }>>([{ email: '', label: '' }]);
   const [phones, setPhones] = useState<Array<{ phone: string; label: string }>>([{ phone: '', label: '' }]);
   const [websites, setWebsites] = useState<string[]>(['']);
-  const [socials, setSocials] = useState<Record<SocialType, string[]>>({
+  const [socials, setSocials] = useState<Record<NonOtherSocialType, string[]>>({
     linkedin: [''], x: [], instagram: [], facebook: [],
   });
   const [handles, setHandles] = useState<Array<{ type: HandleType; handle: string }>>([]);
@@ -53,27 +38,31 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
   const [expanded, setExpanded] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
-  const [emailCollisions, setEmailCollisions] = useState<Record<string, string>>({});
-  const [phoneCollisions, setPhoneCollisions] = useState<Record<string, string>>({});
-  const [emailFormatWarnings, setEmailFormatWarnings] = useState<Record<string, true>>({});
-  const [phoneFormatWarnings, setPhoneFormatWarnings] = useState<Record<string, true>>({});
-  const [urlFormatWarnings, setUrlFormatWarnings] = useState<Record<string, true>>({});
+  const mounted = useRef(true);
+  useEffect(() => { mounted.current = true; return () => { mounted.current = false; }; }, []);
 
-  // Computed within-form duplicate sets — derived from state, no extra state needed.
-  const emailDuplicates = useMemo(
-    () => findDuplicates(emails.map((e) => e.email.trim().toLowerCase())),
-    [emails],
-  );
-
-  const phoneDuplicates = useMemo(
-    () => findDuplicates(phones.map((p) => normalizePhoneForComparison(p.phone))),
-    [phones],
-  );
-
-  const urlDuplicates = useMemo(
-    () => findDuplicates([...websites, ...SOCIAL_TYPES.flatMap((t) => socials[t])].map((u) => u.trim())),
+  const urlValues = useMemo(
+    () => [...websites, ...NON_OTHER_SOCIAL_TYPES.flatMap((t) => socials[t])],
     [websites, socials],
   );
+
+  const {
+    emailCollisions,
+    phoneCollisions,
+    emailFormatWarnings,
+    phoneFormatWarnings,
+    urlFormatWarnings,
+    emailDuplicates,
+    phoneDuplicates,
+    urlDuplicates,
+    checkEmailBlur,
+    checkPhoneBlur,
+    clearEmailWarnings,
+    clearPhoneWarnings,
+    updatePhoneFormatWarning,
+    clearUrlWarning,
+    updateUrlFormatWarning,
+  } = useContactFieldValidation({ mounted, emails, phones, urlValues });
 
   const [projects, setProjects] = useState<Project[]>([]);
   const [selectedProjectIds, setSelectedProjectIds] = useState<Set<string>>(new Set());
@@ -82,8 +71,6 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
   const formRef = useRef<HTMLFormElement>(null);
   const projectInputRef = useRef<HTMLInputElement>(null);
   const projectWrapRef = useRef<HTMLDivElement>(null);
-  const mounted = useRef(true);
-  useEffect(() => { mounted.current = true; return () => { mounted.current = false; }; }, []);
 
   useEffect(() => {
     window.sourcerer.listProjects().then((p) => { if (mounted.current) setProjects(p); });
@@ -106,46 +93,7 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
     setSelectedProjectIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
   }
 
-  async function checkEmailBlur(value: string) {
-    if (!value) return;
-    const valid = isValidEmail(value);
-    setEmailFormatWarnings((prev) => {
-      const next = { ...prev };
-      if (!valid) next[value] = true; else delete next[value];
-      return next;
-    });
-    if (!valid) return;
-    const result = await window.sourcerer.checkCollision({ emails: [value], phones: [] });
-    if (!mounted.current) return;
-    setEmailCollisions((prev) => {
-      const next = { ...prev };
-      if (result.email[value]) next[value] = result.email[value];
-      else delete next[value];
-      return next;
-    });
-  }
-
-  async function checkPhoneBlur(value: string) {
-    if (!value) return;
-    const [isValid, collision] = await Promise.all([
-      window.sourcerer.validatePhone(value),
-      window.sourcerer.checkCollision({ emails: [], phones: [value] }),
-    ]);
-    if (!mounted.current) return;
-    setPhoneFormatWarnings((prev) => {
-      const next = { ...prev };
-      if (!isValid) next[value] = true; else delete next[value];
-      return next;
-    });
-    setPhoneCollisions((prev) => {
-      const next = { ...prev };
-      if (collision.phone[value]) next[value] = collision.phone[value];
-      else delete next[value];
-      return next;
-    });
-  }
-
-  function setSocial(type: SocialType, values: string[]) {
+  function setSocial(type: NonOtherSocialType, values: string[]) {
     setSocials((prev) => ({ ...prev, [type]: values }));
   }
 
@@ -160,7 +108,7 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
 
     const links = [
       ...websites.filter((u) => u.trim()).map((url) => ({ type: 'website' as const, url })),
-      ...SOCIAL_TYPES.flatMap((type) =>
+      ...NON_OTHER_SOCIAL_TYPES.flatMap((type) =>
         socials[type].filter((u) => u.trim()).map((url) => ({ type, url })),
       ),
     ];
@@ -273,10 +221,7 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
                     onChange={(e) => {
                       const prev = entry.email.trim();
                       setEmails(emails.map((em, j) => j === i ? { ...em, email: e.target.value } : em));
-                      if (prev) {
-                        setEmailFormatWarnings((w) => { if (!w[prev]) return w; const u = { ...w }; delete u[prev]; return u; });
-                        setEmailCollisions((c) => { if (!c[prev]) return c; const u = { ...c }; delete u[prev]; return u; });
-                      }
+                      if (prev) clearEmailWarnings(prev);
                     }}
                     onBlur={() => checkEmailBlur(entry.email.trim())}
                     disabled={submitting}
@@ -330,19 +275,8 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
                       const prev = entry.phone.trim();
                       const newVal = e.target.value.trim();
                       setPhones(phones.map((p, j) => j === i ? { ...p, phone: e.target.value } : p));
-                      if (prev && prev !== newVal) {
-                        setPhoneFormatWarnings((w) => { if (!w[prev]) return w; const u = { ...w }; delete u[prev]; return u; });
-                        setPhoneCollisions((c) => { if (!c[prev]) return c; const u = { ...c }; delete u[prev]; return u; });
-                      }
-                      if (newVal) {
-                        setPhoneFormatWarnings((w) => {
-                          const bad = hasDisallowedPhoneChars(newVal);
-                          if (bad === !!w[newVal]) return w;
-                          const u = { ...w };
-                          if (bad) u[newVal] = true; else delete u[newVal];
-                          return u;
-                        });
-                      }
+                      if (prev && prev !== newVal) clearPhoneWarnings(prev);
+                      if (newVal) updatePhoneFormatWarning(newVal);
                     }}
                     onBlur={() => checkPhoneBlur(entry.phone.trim())}
                     disabled={submitting}
@@ -432,18 +366,8 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
             values={websites}
             placeholder="https://example.com"
             onChange={setWebsites}
-            onChangeItem={(oldVal) => {
-              if (!oldVal) return;
-              setUrlFormatWarnings((w) => { if (!w[oldVal]) return w; const u = { ...w }; delete u[oldVal]; return u; });
-            }}
-            onBlurItem={(val) => {
-              if (!val) return;
-              setUrlFormatWarnings((prev) => {
-                const next = { ...prev };
-                if (!isValidUrl(val)) next[val] = true; else delete next[val];
-                return next;
-              });
-            }}
+            onChangeItem={(oldVal) => { if (oldVal) clearUrlWarning(oldVal); }}
+            onBlurItem={(val) => { if (val) updateUrlFormatWarning(val); }}
             warnings={Object.fromEntries(
               websites.map((v) => v.trim()).filter(Boolean).flatMap((v) => {
                 if (urlFormatWarnings[v]) return [[v, '⚠ Invalid URL']];
@@ -453,25 +377,15 @@ export default function AddContactModal({ onCreated, onCancel }: Props) {
             )}
           />
 
-          {SOCIAL_TYPES.map((type) => (
+          {NON_OTHER_SOCIAL_TYPES.map((type) => (
             <DynamicList
               key={type}
               label={SOCIAL_META[type].label}
               values={socials[type]}
               placeholder={SOCIAL_META[type].placeholder}
               onChange={(vals) => setSocial(type, vals)}
-              onChangeItem={(oldVal) => {
-                if (!oldVal) return;
-                setUrlFormatWarnings((w) => { if (!w[oldVal]) return w; const u = { ...w }; delete u[oldVal]; return u; });
-              }}
-              onBlurItem={(val) => {
-                if (!val) return;
-                setUrlFormatWarnings((prev) => {
-                  const next = { ...prev };
-                  if (!isValidUrl(val)) next[val] = true; else delete next[val];
-                  return next;
-                });
-              }}
+              onChangeItem={(oldVal) => { if (oldVal) clearUrlWarning(oldVal); }}
+              onBlurItem={(val) => { if (val) updateUrlFormatWarning(val); }}
               warnings={Object.fromEntries(
                 socials[type].map((v) => v.trim()).filter(Boolean).flatMap((v) => {
                   if (urlFormatWarnings[v]) return [[v, '⚠ Invalid URL']];

--- a/src/renderer/src/contacts/GlobalRemindersSection.tsx
+++ b/src/renderer/src/contacts/GlobalRemindersSection.tsx
@@ -140,7 +140,7 @@ export default function GlobalRemindersSection({ contact }: { contact: ContactDe
         return (
           <div key={r.id} className={`pt-reminder-row${overdue ? ' pt-reminder-row--overdue' : ''}${done ? ' pt-reminder-row--completing' : ''}`}>
             <div className={`pt-reminder-row-date${overdue && !done ? ' pt-reminder-row-date--overdue' : ''}`}>
-              {fmtReminderDate(r.due_date, overdue)}
+              {fmtReminderDate(r.due_date, overdue, now)}
             </div>
             <div className="pt-reminder-row-body">
               <span>{r.note || ''}</span>

--- a/src/renderer/src/contacts/GlobalRemindersSection.tsx
+++ b/src/renderer/src/contacts/GlobalRemindersSection.tsx
@@ -3,6 +3,7 @@ import type { ContactDetail as ContactDetailType, Reminder } from '@shared/types
 import Button from '../shell/Button';
 import { CalendarPicker } from '../views/CalendarPicker';
 import { dateStrToUnix } from '../utils/fmtDate';
+import { fmtReminderDate, sortReminders } from './logShared';
 import './ContactDetail.css';
 
 export default function GlobalRemindersSection({ contact }: { contact: ContactDetailType }) {
@@ -35,10 +36,6 @@ export default function GlobalRemindersSection({ contact }: { contact: ContactDe
     });
     return () => { cancelled = true; };
   }, [contact.id]);
-
-  function sortReminders(a: Reminder, b: Reminder) {
-    return b.is_auto_outreach - a.is_auto_outreach || a.due_date - b.due_date;
-  }
 
   function handleStartAdd() {
     const defaultProject = contact.default_membership_id
@@ -110,19 +107,6 @@ export default function GlobalRemindersSection({ contact }: { contact: ContactDe
   }
 
   const now = Math.floor(Date.now() / 1000);
-
-  function fmtReminderDate(ts: number, overdue: boolean): string {
-    const d = new Date(ts * 1000);
-    const mm = String(d.getMonth() + 1).padStart(2, '0');
-    const dd = String(d.getDate()).padStart(2, '0');
-    const dateStr = `${mm}.${dd}`;
-    const days = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
-    const dayName = days[d.getDay()];
-    const diffDays = Math.ceil((ts - now) / 86400);
-    if (overdue) return `WAS ${dayName} · ${dateStr}`;
-    if (diffDays <= 7) return `${dayName} · ${dateStr}`;
-    return dateStr;
-  }
 
   const manualReminders = reminders.filter((r) => r.is_auto_outreach === 0);
 

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -5,15 +5,15 @@ import GlobalLogSection from './GlobalLogSection';
 import GlobalRemindersSection from './GlobalRemindersSection';
 import DynamicList, { useDragReorder } from './DynamicList';
 import {
-  isValidEmail,
-  isValidUrl,
   isGoogleAlertUrl,
   hasDisallowedPhoneChars,
   normalizePhoneForComparison,
   sanitizeOtherLabel,
   OTHER_LABEL_MAX,
-  findDuplicates,
 } from './contactValidation';
+import { NON_OTHER_SOCIAL_TYPES, SOCIAL_TYPES, SOCIAL_META, localToday } from './contactConstants';
+import type { SocialType, NonOtherSocialType } from './contactConstants';
+import { useContactFieldValidation } from './useContactFieldValidation';
 import { CalendarPicker } from '../views/CalendarPicker';
 import RssAlertPanel from './RssAlertPanel';
 import ScreenshotPanel from './ScreenshotPanel';
@@ -31,22 +31,8 @@ interface Props {
   user?: User | null;
 }
 
-const SOCIAL_TYPES = ['linkedin', 'x', 'instagram', 'facebook', 'other'] as const;
-type SocialType = (typeof SOCIAL_TYPES)[number];
-
 import { HANDLE_TYPES, HANDLE_META } from './handleMeta';
 import type { HandleType } from './handleMeta';
-
-const NON_OTHER_SOCIAL_TYPES = ['linkedin', 'x', 'instagram', 'facebook'] as const;
-type NonOtherSocialType = (typeof NON_OTHER_SOCIAL_TYPES)[number];
-
-const SOCIAL_META: Record<SocialType, { label: string; placeholder: string }> = {
-  linkedin:  { label: 'LinkedIn',    placeholder: 'https://linkedin.com/in/…' },
-  x:         { label: 'X / Twitter', placeholder: 'https://x.com/…' },
-  instagram: { label: 'Instagram',   placeholder: 'https://instagram.com/…' },
-  facebook:  { label: 'Facebook',    placeholder: 'https://facebook.com/…' },
-  'other':  { label: 'Other social',    placeholder: 'https://…' },
-};
 
 const KNOWN_LINK_TYPES = new Set<string>([...SOCIAL_TYPES, 'website']);
 
@@ -113,31 +99,39 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
   const { getDragProps: otherSocialDragProps, handleProps: otherSocialHandleProps } = useDragReorder(editOtherSocials, setEditOtherSocials);
   const [editWebsites, setEditWebsites] = useState<string[]>([]);
   const [newRssUrl, setNewRssUrl] = useState('');
-  const [emailCollisions, setEmailCollisions] = useState<Record<string, string>>({});
-  const [phoneCollisions, setPhoneCollisions] = useState<Record<string, string>>({});
-  const [emailFormatWarnings, setEmailFormatWarnings] = useState<Record<string, true>>({});
-  const [phoneFormatWarnings, setPhoneFormatWarnings] = useState<Record<string, true>>({});
-  const [urlFormatWarnings, setUrlFormatWarnings] = useState<Record<string, true>>({});
-
-  // Computed within-form duplicate sets — derived from state, no extra state needed.
-  const emailDuplicates = useMemo(
-    () => findDuplicates(editEmails.map((e) => e.email.trim().toLowerCase())),
-    [editEmails],
-  );
-
-  const phoneDuplicates = useMemo(
-    () => findDuplicates(editPhones.map((p) => normalizePhoneForComparison(p.phone))),
-    [editPhones],
-  );
-
-  const urlDuplicates = useMemo(
-    () => findDuplicates([
+  const urlValues = useMemo(
+    () => [
       ...editWebsites,
       ...NON_OTHER_SOCIAL_TYPES.flatMap((t) => editSocials[t]),
       ...editOtherSocials.map((e) => e.url),
-    ].map((u) => u.trim())),
+    ],
     [editWebsites, editSocials, editOtherSocials],
   );
+
+  const {
+    emailCollisions,
+    phoneCollisions,
+    emailFormatWarnings,
+    phoneFormatWarnings,
+    urlFormatWarnings,
+    emailDuplicates,
+    phoneDuplicates,
+    urlDuplicates,
+    checkEmailBlur,
+    checkPhoneBlur,
+    clearEmailWarnings,
+    clearPhoneWarnings,
+    updatePhoneFormatWarning,
+    clearUrlWarning,
+    updateUrlFormatWarning,
+    resetAll,
+  } = useContactFieldValidation({
+    excludeId: contact.id,
+    mounted,
+    emails: editEmails,
+    phones: editPhones,
+    urlValues,
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -147,43 +141,6 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
     return () => { cancelled = true; };
   }, [contact.id]);
 
-
-  async function checkEmailBlur(value: string) {
-    if (!value) return;
-    const valid = isValidEmail(value);
-    setEmailFormatWarnings((prev) => {
-      const next = { ...prev };
-      if (!valid) next[value] = true; else delete next[value];
-      return next;
-    });
-    if (!valid) return;
-    const result = await window.sourcerer.checkCollision({ emails: [value], phones: [], excludeId: contact.id });
-    if (!mounted.current) return;
-    setEmailCollisions((prev) => {
-      const next = { ...prev };
-      if (result.email[value]) next[value] = result.email[value]; else delete next[value];
-      return next;
-    });
-  }
-
-  async function checkPhoneBlur(value: string) {
-    if (!value) return;
-    const [isValid, collision] = await Promise.all([
-      window.sourcerer.validatePhone(value),
-      window.sourcerer.checkCollision({ emails: [], phones: [value], excludeId: contact.id }),
-    ]);
-    if (!mounted.current) return;
-    setPhoneFormatWarnings((prev) => {
-      const next = { ...prev };
-      if (!isValid) next[value] = true; else delete next[value];
-      return next;
-    });
-    setPhoneCollisions((prev) => {
-      const next = { ...prev };
-      if (collision.phone[value]) next[value] = collision.phone[value]; else delete next[value];
-      return next;
-    });
-  }
 
   function setSocial(type: NonOtherSocialType, values: string[]) {
     setEditSocials((prev) => ({ ...prev, [type]: values }));
@@ -210,11 +167,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
     );
     setEditWebsites(contact.links.filter((l) => l.type === 'website').map((l) => l.url));
     setNewRssUrl('');
-    setEmailCollisions({});
-    setPhoneCollisions({});
-    setEmailFormatWarnings({});
-    setPhoneFormatWarnings({});
-    setUrlFormatWarnings({});
+    resetAll();
     setEditingAndNotify(true);
   }
 
@@ -362,20 +315,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                     const next = [...editEmails];
                     next[i] = { ...next[i], email: e.target.value };
                     setEditEmails(next);
-                    if (prev) {
-                      setEmailFormatWarnings((w) => {
-                        if (!w[prev]) return w;
-                        const updated = { ...w };
-                        delete updated[prev];
-                        return updated;
-                      });
-                      setEmailCollisions((c) => {
-                        if (!c[prev]) return c;
-                        const updated = { ...c };
-                        delete updated[prev];
-                        return updated;
-                      });
-                    }
+                    if (prev) clearEmailWarnings(prev);
                   }}
                   onBlur={() => checkEmailBlur(entry.email.trim())}
                 />
@@ -442,19 +382,8 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                     next[i] = { ...next[i], phone: e.target.value };
                     setEditPhones(next);
                     const newVal = e.target.value.trim();
-                    if (prev && prev !== newVal) {
-                      setPhoneFormatWarnings((w) => { if (!w[prev]) return w; const u = { ...w }; delete u[prev]; return u; });
-                      setPhoneCollisions((c) => { if (!c[prev]) return c; const u = { ...c }; delete u[prev]; return u; });
-                    }
-                    if (newVal) {
-                      setPhoneFormatWarnings((w) => {
-                        const bad = hasDisallowedPhoneChars(newVal);
-                        if (bad === !!w[newVal]) return w;
-                        const u = { ...w };
-                        if (bad) u[newVal] = true; else delete u[newVal];
-                        return u;
-                      });
-                    }
+                    if (prev && prev !== newVal) clearPhoneWarnings(prev);
+                    if (newVal) updatePhoneFormatWarning(newVal);
                   }}
                   onBlur={() => checkPhoneBlur(entry.phone.trim())}
                 />
@@ -556,18 +485,8 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
               values={editSocials[type]}
               placeholder={SOCIAL_META[type].placeholder}
               onChange={(vals) => setSocial(type, vals)}
-              onChangeItem={(oldVal) => {
-                if (!oldVal) return;
-                setUrlFormatWarnings((w) => { if (!w[oldVal]) return w; const u = { ...w }; delete u[oldVal]; return u; });
-              }}
-              onBlurItem={(val) => {
-                if (!val) return;
-                setUrlFormatWarnings((prev) => {
-                  const next = { ...prev };
-                  if (!isValidUrl(val)) next[val] = true; else delete next[val];
-                  return next;
-                });
-              }}
+              onChangeItem={(oldVal) => { if (oldVal) clearUrlWarning(oldVal); }}
+              onBlurItem={(val) => { if (val) updateUrlFormatWarning(val); }}
               warnings={Object.fromEntries(
                 editSocials[type]
                   .map((v) => v.trim())
@@ -616,18 +535,11 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
                     const next = [...editOtherSocials];
                     next[i] = { ...next[i], url: e.target.value };
                     setEditOtherSocials(next);
-                    if (prev) {
-                      setUrlFormatWarnings((w) => { if (!w[prev]) return w; const u = { ...w }; delete u[prev]; return u; });
-                    }
+                    if (prev) clearUrlWarning(prev);
                   }}
                   onBlur={() => {
                     const val = entry.url.trim();
-                    if (!val) return;
-                    setUrlFormatWarnings((prev) => {
-                      const next = { ...prev };
-                      if (!isValidUrl(val)) next[val] = true; else delete next[val];
-                      return next;
-                    });
+                    if (val) updateUrlFormatWarning(val);
                   }}
                 />
                 <button
@@ -662,18 +574,8 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
             values={editWebsites}
             placeholder="https://example.com"
             onChange={setEditWebsites}
-            onChangeItem={(oldVal) => {
-              if (!oldVal) return;
-              setUrlFormatWarnings((w) => { if (!w[oldVal]) return w; const u = { ...w }; delete u[oldVal]; return u; });
-            }}
-            onBlurItem={(val) => {
-              if (!val) return;
-              setUrlFormatWarnings((prev) => {
-                const next = { ...prev };
-                if (!isValidUrl(val)) next[val] = true; else delete next[val];
-                return next;
-              });
-            }}
+            onChangeItem={(oldVal) => { if (oldVal) clearUrlWarning(oldVal); }}
+            onBlurItem={(val) => { if (val) updateUrlFormatWarning(val); }}
             warnings={Object.fromEntries(
               editWebsites
                 .map((v) => v.trim())
@@ -725,11 +627,6 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
     const d = new Date(`${dob}T12:00:00`);
     if (isNaN(d.getTime())) return dob;
     return new Intl.DateTimeFormat('en-CA', { year: 'numeric', month: 'long', day: 'numeric' }).format(d);
-  }
-
-  function localToday(): string {
-    const d = new Date();
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
   }
 
   return (

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -3,7 +3,7 @@ import { fmtDateFull, dateStrToUnix } from '../utils/fmtDate';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { CalendarPicker } from '../views/CalendarPicker';
 import Button from '../shell/Button';
-import { LogRow, LogAllModal } from './logShared';
+import { LogRow, LogAllModal, fmtReminderDate, sortReminders } from './logShared';
 import LogProjectPicker from './LogProjectPicker';
 import './ContactDetail.css';
 import type {
@@ -374,10 +374,6 @@ function RemindersSection({
     return () => { cancelled = true; };
   }, [contactId, projectId, refreshToken]);
 
-  function sortReminders(a: Reminder, b: Reminder) {
-    return b.is_auto_outreach - a.is_auto_outreach || a.due_date - b.due_date;
-  }
-
   async function handleAdd() {
     if (!dueDate || !note.trim() || addingSaving) return;
     setAddingSaving(true);
@@ -450,19 +446,6 @@ function RemindersSection({
   }
 
   const now = Math.floor(Date.now() / 1000);
-
-  function fmtReminderDate(ts: number, overdue: boolean): string {
-    const d = new Date(ts * 1000);
-    const mm = String(d.getMonth() + 1).padStart(2, '0');
-    const dd = String(d.getDate()).padStart(2, '0');
-    const dateStr = `${mm}.${dd}`;
-    const days = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
-    const dayName = days[d.getDay()];
-    const diffDays = Math.ceil((ts - now) / 86400);
-    if (overdue) return `WAS ${dayName} · ${dateStr}`;
-    if (diffDays <= 7) return `${dayName} · ${dateStr}`;
-    return dateStr;
-  }
 
   return (
     <div className="pt-section">

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -507,7 +507,7 @@ function RemindersSection({
         return (
           <div key={r.id} className={`pt-reminder-row${overdue ? ' pt-reminder-row--overdue' : ''}${done ? ' pt-reminder-row--completing' : ''}`}>
             <div className={`pt-reminder-row-date${overdue && !done ? ' pt-reminder-row-date--overdue' : ''}`}>
-              {fmtReminderDate(r.due_date, overdue)}
+              {fmtReminderDate(r.due_date, overdue, now)}
             </div>
             <div className="pt-reminder-row-note">{r.note || ''}</div>
             {!done && (

--- a/src/renderer/src/contacts/contactConstants.ts
+++ b/src/renderer/src/contacts/contactConstants.ts
@@ -1,0 +1,18 @@
+export const NON_OTHER_SOCIAL_TYPES = ['linkedin', 'x', 'instagram', 'facebook'] as const;
+export type NonOtherSocialType = (typeof NON_OTHER_SOCIAL_TYPES)[number];
+
+export const SOCIAL_TYPES = [...NON_OTHER_SOCIAL_TYPES, 'other'] as const;
+export type SocialType = (typeof SOCIAL_TYPES)[number];
+
+export const SOCIAL_META: Record<SocialType, { label: string; placeholder: string }> = {
+  linkedin:  { label: 'LinkedIn',    placeholder: 'https://linkedin.com/in/…' },
+  x:         { label: 'X / Twitter', placeholder: 'https://x.com/…' },
+  instagram: { label: 'Instagram',   placeholder: 'https://instagram.com/…' },
+  facebook:  { label: 'Facebook',    placeholder: 'https://facebook.com/…' },
+  other:     { label: 'Other social', placeholder: 'https://…' },
+};
+
+export function localToday(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}

--- a/src/renderer/src/contacts/logShared.tsx
+++ b/src/renderer/src/contacts/logShared.tsx
@@ -9,8 +9,7 @@ export function sortReminders(a: Reminder, b: Reminder): number {
   return b.is_auto_outreach - a.is_auto_outreach || a.due_date - b.due_date;
 }
 
-export function fmtReminderDate(ts: number, overdue: boolean): string {
-  const now = Math.floor(Date.now() / 1000);
+export function fmtReminderDate(ts: number, overdue: boolean, now: number): string {
   const d = new Date(ts * 1000);
   const mm = String(d.getMonth() + 1).padStart(2, '0');
   const dd = String(d.getDate()).padStart(2, '0');

--- a/src/renderer/src/contacts/logShared.tsx
+++ b/src/renderer/src/contacts/logShared.tsx
@@ -1,9 +1,27 @@
 import { useState } from 'react';
-import type { InteractionLogEntry } from '@shared/types';
+import type { InteractionLogEntry, Reminder } from '@shared/types';
 import { linkifyText } from '../utils/linkify';
 import Modal from '../shell/Modal';
 import Button from '../shell/Button';
 import './ContactDetail.css';
+
+export function sortReminders(a: Reminder, b: Reminder): number {
+  return b.is_auto_outreach - a.is_auto_outreach || a.due_date - b.due_date;
+}
+
+export function fmtReminderDate(ts: number, overdue: boolean): string {
+  const now = Math.floor(Date.now() / 1000);
+  const d = new Date(ts * 1000);
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  const dateStr = `${mm}.${dd}`;
+  const days = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+  const dayName = days[d.getDay()];
+  const diffDays = Math.ceil((ts - now) / 86400);
+  if (overdue) return `WAS ${dayName} · ${dateStr}`;
+  if (diffDays <= 7) return `${dayName} · ${dateStr}`;
+  return dateStr;
+}
 
 function startOfDay(d: Date): number {
   return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();

--- a/src/renderer/src/contacts/useContactFieldValidation.ts
+++ b/src/renderer/src/contacts/useContactFieldValidation.ts
@@ -1,0 +1,148 @@
+import { useState, useMemo } from 'react';
+import type { MutableRefObject } from 'react';
+import {
+  isValidEmail,
+  isValidUrl,
+  hasDisallowedPhoneChars,
+  normalizePhoneForComparison,
+  findDuplicates,
+} from './contactValidation';
+
+export function useContactFieldValidation({
+  excludeId,
+  mounted,
+  emails,
+  phones,
+  urlValues,
+}: {
+  excludeId?: string;
+  mounted: MutableRefObject<boolean>;
+  emails: Array<{ email: string; label: string }>;
+  phones: Array<{ phone: string; label: string }>;
+  urlValues: string[];
+}) {
+  const [emailCollisions, setEmailCollisions] = useState<Record<string, string>>({});
+  const [phoneCollisions, setPhoneCollisions] = useState<Record<string, string>>({});
+  const [emailFormatWarnings, setEmailFormatWarnings] = useState<Record<string, true>>({});
+  const [phoneFormatWarnings, setPhoneFormatWarnings] = useState<Record<string, true>>({});
+  const [urlFormatWarnings, setUrlFormatWarnings] = useState<Record<string, true>>({});
+
+  const emailDuplicates = useMemo(
+    () => findDuplicates(emails.map((e) => e.email.trim().toLowerCase())),
+    [emails],
+  );
+
+  const phoneDuplicates = useMemo(
+    () => findDuplicates(phones.map((p) => normalizePhoneForComparison(p.phone))),
+    [phones],
+  );
+
+  const urlDuplicates = useMemo(
+    () => findDuplicates(urlValues.map((u) => u.trim())),
+    [urlValues],
+  );
+
+  async function checkEmailBlur(value: string) {
+    if (!value) return;
+    const valid = isValidEmail(value);
+    setEmailFormatWarnings((prev) => {
+      const next = { ...prev };
+      if (!valid) next[value] = true; else delete next[value];
+      return next;
+    });
+    if (!valid) return;
+    const result = await window.sourcerer.checkCollision({
+      emails: [value],
+      phones: [],
+      ...(excludeId ? { excludeId } : {}),
+    });
+    if (!mounted.current) return;
+    setEmailCollisions((prev) => {
+      const next = { ...prev };
+      if (result.email[value]) next[value] = result.email[value]; else delete next[value];
+      return next;
+    });
+  }
+
+  async function checkPhoneBlur(value: string) {
+    if (!value) return;
+    const [isValid, collision] = await Promise.all([
+      window.sourcerer.validatePhone(value),
+      window.sourcerer.checkCollision({
+        emails: [],
+        phones: [value],
+        ...(excludeId ? { excludeId } : {}),
+      }),
+    ]);
+    if (!mounted.current) return;
+    setPhoneFormatWarnings((prev) => {
+      const next = { ...prev };
+      if (!isValid) next[value] = true; else delete next[value];
+      return next;
+    });
+    setPhoneCollisions((prev) => {
+      const next = { ...prev };
+      if (collision.phone[value]) next[value] = collision.phone[value]; else delete next[value];
+      return next;
+    });
+  }
+
+  function clearEmailWarnings(prev: string) {
+    setEmailFormatWarnings((w) => { if (!w[prev]) return w; const u = { ...w }; delete u[prev]; return u; });
+    setEmailCollisions((c) => { if (!c[prev]) return c; const u = { ...c }; delete u[prev]; return u; });
+  }
+
+  function clearPhoneWarnings(prev: string) {
+    setPhoneFormatWarnings((w) => { if (!w[prev]) return w; const u = { ...w }; delete u[prev]; return u; });
+    setPhoneCollisions((c) => { if (!c[prev]) return c; const u = { ...c }; delete u[prev]; return u; });
+  }
+
+  function updatePhoneFormatWarning(newVal: string) {
+    setPhoneFormatWarnings((w) => {
+      const bad = hasDisallowedPhoneChars(newVal);
+      if (bad === !!w[newVal]) return w;
+      const u = { ...w };
+      if (bad) u[newVal] = true; else delete u[newVal];
+      return u;
+    });
+  }
+
+  function clearUrlWarning(prev: string) {
+    setUrlFormatWarnings((w) => { if (!w[prev]) return w; const u = { ...w }; delete u[prev]; return u; });
+  }
+
+  function updateUrlFormatWarning(val: string) {
+    setUrlFormatWarnings((prev) => {
+      const next = { ...prev };
+      if (!isValidUrl(val)) next[val] = true; else delete next[val];
+      return next;
+    });
+  }
+
+  function resetAll() {
+    setEmailCollisions({});
+    setPhoneCollisions({});
+    setEmailFormatWarnings({});
+    setPhoneFormatWarnings({});
+    setUrlFormatWarnings({});
+  }
+
+  return {
+    emailCollisions,
+    phoneCollisions,
+    emailFormatWarnings,
+    phoneFormatWarnings,
+    urlFormatWarnings,
+    emailDuplicates,
+    phoneDuplicates,
+    urlDuplicates,
+    checkEmailBlur,
+    checkPhoneBlur,
+    clearEmailWarnings,
+    clearPhoneWarnings,
+    updatePhoneFormatWarning,
+    clearUrlWarning,
+    updateUrlFormatWarning,
+    resetAll,
+  };
+}


### PR DESCRIPTION
## Summary

- **#285** — Extracts `SOCIAL_TYPES`, `NON_OTHER_SOCIAL_TYPES`, `SOCIAL_META`, and `localToday()` to a new `contactConstants.ts` module; both `AddContactModal` and `GlobalTab` now import from the shared source instead of each maintaining their own copies
- **#230** — Extracts all duplicated field-validation logic into a `useContactFieldValidation` hook: the 5 warning/collision state variables, `checkEmailBlur`, `checkPhoneBlur`, duplicate-detection `useMemo`s, and helper functions for clearing/updating warnings inline. `GlobalTab` passes `excludeId` to scope collision checks to the contact being edited
- **#234** — Exports `fmtReminderDate` and `sortReminders` from `logShared.tsx` (which already hosts shared log utilities); removes the byte-for-byte duplicate definitions in `GlobalRemindersSection` and `ProjectTab.RemindersSection`

Net result: −302 / +264 lines across 7 files, with no behaviour change.

Closes #230
Closes #285
Closes #234