### PR TITLE
Split three oversized components into focused units

### DIFF
--- a/src/main/ipc/backup.ts
+++ b/src/main/ipc/backup.ts
@@ -5,7 +5,7 @@ import os from 'os';
 import crypto from 'crypto';
 import Database from 'better-sqlite3-multiple-ciphers';
 import { getPaths, deriveKey, filenameDateStamp } from '../utils';
-import { closeDatabase, getDatabase, getKeyHex, applyCipherPragmas } from '../database';
+import { closeDatabase, getKeyHex, applyCipherPragmas } from '../database';
 import { stopPoller } from '../sync/poller';
 import { clearExtensionSession } from '../http-server';
 import { writeBackupFile, readBackupFile, createBackupEntries, MAX_BACKUP_BYTES } from './backup-format';
@@ -17,7 +17,7 @@ export function registerBackupHandlers(): void {
   ipcMain.handle(
     'backup:export',
     async (_, { password }: { password: string }): Promise<{ success: boolean; error?: string }> => {
-      const { saltPath, screenshotsPath } = getPaths();
+      const { dbPath, saltPath, screenshotsPath } = getPaths();
 
       const dbSalt = await fs.readFile(saltPath);
       const verifyKeyHex = await deriveKey(password, dbSalt);
@@ -37,7 +37,7 @@ export function registerBackupHandlers(): void {
       const tmpSnapPath = path.join(tmpSnapDir, 'snapshot.db');
       const tmpOutPath = path.join(path.dirname(filePath), `.sourcerer-backup-${crypto.randomBytes(8).toString('hex')}.tmp`);
       try {
-        await getDatabase().backup(tmpSnapPath);
+        await fs.copyFile(dbPath, tmpSnapPath);
         await writeBackupFile(createBackupEntries(tmpSnapPath, saltPath, screenshotsPath), tmpOutPath, password);
         await fs.unlink(filePath).catch(() => {}); // pre-remove so rename works on Windows
         await fs.rename(tmpOutPath, filePath);

--- a/src/renderer/src/contacts/ContactEditForm.tsx
+++ b/src/renderer/src/contacts/ContactEditForm.tsx
@@ -1,0 +1,602 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { ContactDetail as ContactDetailType, ContactAlertRss, User } from '@shared/types';
+import Button from '../shell/Button';
+import DynamicList, { useDragReorder } from './DynamicList';
+import {
+  isValidEmail,
+  isValidUrl,
+  isGoogleAlertUrl,
+  hasDisallowedPhoneChars,
+  normalizePhoneForComparison,
+  sanitizeOtherLabel,
+  OTHER_LABEL_MAX,
+  findDuplicates,
+} from './contactValidation';
+import { CalendarPicker } from '../views/CalendarPicker';
+import RssAlertPanel from './RssAlertPanel';
+import { HANDLE_TYPES, HANDLE_META } from './handleMeta';
+import type { HandleType } from './handleMeta';
+import { SOCIAL_TYPES, NON_OTHER_SOCIAL_TYPES, SOCIAL_META, localToday } from './contactConstants';
+import type { NonOtherSocialType } from './contactConstants';
+import './AddContactModal.css';
+import './ContactDetail.css';
+
+export { SOCIAL_TYPES, SOCIAL_META } from './contactConstants';
+export type { SocialType } from './contactConstants';
+
+export const KNOWN_LINK_TYPES = new Set<string>([...SOCIAL_TYPES, 'website']);
+
+interface Props {
+  contact: ContactDetailType;
+  user?: User | null;
+  alertRssList: ContactAlertRss[];
+  newRssUrl: string;
+  onNewRssUrlChange: (url: string) => void;
+  onAddRss: () => Promise<void>;
+  onRemoveRss: (id: string) => Promise<void>;
+  onSaved: () => void;
+  onCancel: () => void;
+}
+
+export default function ContactEditForm({
+  contact,
+  user,
+  alertRssList,
+  newRssUrl,
+  onNewRssUrlChange,
+  onAddRss,
+  onRemoveRss,
+  onSaved,
+  onCancel,
+}: Props) {
+  const [saving, setSaving] = useState(false);
+  const formRef = useRef<HTMLDivElement>(null);
+  const mounted = useRef(true);
+  useEffect(() => { mounted.current = true; return () => { mounted.current = false; }; }, []);
+
+  const [editName, setEditName] = useState(contact.name);
+  const [editOrg, setEditOrg] = useState(contact.organization ?? '');
+  const [editTitle, setEditTitle] = useState(contact.title ?? '');
+  const [editDob, setEditDob] = useState(contact.dob ?? '');
+  const [editNotes, setEditNotes] = useState(contact.notes ?? '');
+  const [editHandles, setEditHandles] = useState(() =>
+    contact.handles.map((h) => ({ type: h.type, handle: h.handle })),
+  );
+  const [editEmails, setEditEmails] = useState(() =>
+    contact.emails.map((e) => ({ email: e.email, label: e.label ?? '' })),
+  );
+  const [editPhones, setEditPhones] = useState(() =>
+    contact.phones.map((p) => ({ phone: p.phone, label: p.label ?? '' })),
+  );
+  const [editSocials, setEditSocials] = useState<Record<NonOtherSocialType, string[]>>(() => {
+    return Object.fromEntries(
+      NON_OTHER_SOCIAL_TYPES.map((type) => [
+        type,
+        contact.links.filter((l) => l.type === type).map((l) => l.url),
+      ]),
+    ) as Record<NonOtherSocialType, string[]>;
+  });
+  const [editOtherSocials, setEditOtherSocials] = useState(() =>
+    contact.links.filter((l) => l.type === 'other').map((l) => ({ url: l.url, label: l.label ?? '' })),
+  );
+  const [editWebsites, setEditWebsites] = useState(() =>
+    contact.links.filter((l) => l.type === 'website').map((l) => l.url),
+  );
+
+  const { getDragProps: emailDragProps, handleProps: emailHandleProps } = useDragReorder(editEmails, setEditEmails);
+  const { getDragProps: phoneDragProps, handleProps: phoneHandleProps } = useDragReorder(editPhones, setEditPhones);
+  const { getDragProps: otherSocialDragProps, handleProps: otherSocialHandleProps } = useDragReorder(editOtherSocials, setEditOtherSocials);
+
+  const [emailCollisions, setEmailCollisions] = useState<Record<string, string>>({});
+  const [phoneCollisions, setPhoneCollisions] = useState<Record<string, string>>({});
+  const [emailFormatWarnings, setEmailFormatWarnings] = useState<Record<string, true>>({});
+  const [phoneFormatWarnings, setPhoneFormatWarnings] = useState<Record<string, true>>({});
+  const [urlFormatWarnings, setUrlFormatWarnings] = useState<Record<string, true>>({});
+
+  const emailDuplicates = useMemo(
+    () => findDuplicates(editEmails.map((e) => e.email.trim().toLowerCase())),
+    [editEmails],
+  );
+
+  const phoneDuplicates = useMemo(
+    () => findDuplicates(editPhones.map((p) => normalizePhoneForComparison(p.phone))),
+    [editPhones],
+  );
+
+  const urlDuplicates = useMemo(
+    () => findDuplicates([
+      ...editWebsites,
+      ...NON_OTHER_SOCIAL_TYPES.flatMap((t) => editSocials[t]),
+      ...editOtherSocials.map((e) => e.url),
+    ].map((u) => u.trim())),
+    [editWebsites, editSocials, editOtherSocials],
+  );
+
+  async function checkEmailBlur(value: string) {
+    if (!value) return;
+    const valid = isValidEmail(value);
+    setEmailFormatWarnings((prev) => {
+      const next = { ...prev };
+      if (!valid) next[value] = true; else delete next[value];
+      return next;
+    });
+    if (!valid) return;
+    const result = await window.sourcerer.checkCollision({ emails: [value], phones: [], excludeId: contact.id });
+    if (!mounted.current) return;
+    setEmailCollisions((prev) => {
+      const next = { ...prev };
+      if (result.email[value]) next[value] = result.email[value]; else delete next[value];
+      return next;
+    });
+  }
+
+  async function checkPhoneBlur(value: string) {
+    if (!value) return;
+    const [isValid, collision] = await Promise.all([
+      window.sourcerer.validatePhone(value),
+      window.sourcerer.checkCollision({ emails: [], phones: [value], excludeId: contact.id }),
+    ]);
+    if (!mounted.current) return;
+    setPhoneFormatWarnings((prev) => {
+      const next = { ...prev };
+      if (!isValid) next[value] = true; else delete next[value];
+      return next;
+    });
+    setPhoneCollisions((prev) => {
+      const next = { ...prev };
+      if (collision.phone[value]) next[value] = collision.phone[value]; else delete next[value];
+      return next;
+    });
+  }
+
+  function setSocial(type: NonOtherSocialType, values: string[]) {
+    setEditSocials((prev) => ({ ...prev, [type]: values }));
+  }
+
+  async function handleSave() {
+    if (!editName.trim()) return;
+    if (emailDuplicates.size > 0 || phoneDuplicates.size > 0 || urlDuplicates.size > 0) {
+      formRef.current?.querySelector<HTMLElement>('.ac-collision-warn')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      return;
+    }
+    setSaving(true);
+    try {
+      const links = [
+        ...NON_OTHER_SOCIAL_TYPES.flatMap((type) =>
+          editSocials[type].filter((u) => u.trim()).map((url) => ({ type, url })),
+        ),
+        ...editOtherSocials
+          .filter((e) => e.url.trim())
+          .map((e) => {
+            const label = sanitizeOtherLabel(e.label);
+            return { type: 'other' as const, url: e.url, ...(label ? { label } : {}) };
+          }),
+        ...editWebsites.filter((u) => u.trim()).map((url) => ({ type: 'website' as const, url })),
+      ];
+      await window.sourcerer.updateContact({
+        id: contact.id,
+        name: editName,
+        organization: editOrg,
+        title: editTitle,
+        dob: editDob || undefined,
+        notes: editNotes,
+        emails: editEmails.filter((e) => e.email.trim()).map((e) => ({ email: e.email, label: e.label.trim() || undefined })),
+        phones: editPhones.filter((p) => p.phone?.trim()).map((p) => ({ phone: p.phone, label: p.label.trim() || undefined })),
+        links,
+        handles: editHandles.filter((h) => h.handle.trim() && h.type.trim()),
+      });
+      const pendingRss = newRssUrl.trim();
+      if (pendingRss && isGoogleAlertUrl(pendingRss) && !alertRssList.some((f) => f.rss_url === pendingRss)) {
+        await window.sourcerer.addAlertRss(contact.id, pendingRss);
+      }
+      onSaved();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="detail-body" ref={formRef}>
+      <div className="form-field">
+        <label className="form-label">Name <span className="form-required">*</span></label>
+        <input className="form-input" value={editName} onChange={(e) => setEditName(e.target.value)} autoFocus />
+      </div>
+
+      <div className="form-field">
+        <label className="form-label">Organization</label>
+        <input className="form-input" value={editOrg} onChange={(e) => setEditOrg(e.target.value)} />
+      </div>
+
+      <div className="form-field">
+        <label className="form-label">Title / Role</label>
+        <input className="form-input" value={editTitle} onChange={(e) => setEditTitle(e.target.value)} placeholder="e.g. Senior Editor" />
+      </div>
+
+      <div className="form-field">
+        <label className="form-label">Date of birth</label>
+        <CalendarPicker
+          label="Select date"
+          value={editDob}
+          onChange={setEditDob}
+          showYear
+          maxDate={localToday()}
+        />
+      </div>
+
+      <div className="form-field">
+        <label className="form-label">Email</label>
+        {editEmails.map((entry, i) => (
+          <div
+            key={i}
+            {...emailDragProps(i)}
+          >
+            <div className="ac-phone-row">
+              <span className="ac-drag-handle" {...emailHandleProps}>⠿</span>
+              <input
+                className="form-input"
+                value={entry.email}
+                placeholder="email@example.com"
+                disabled={saving}
+                onChange={(e) => {
+                  const prev = entry.email.trim();
+                  const next = [...editEmails];
+                  next[i] = { ...next[i], email: e.target.value };
+                  setEditEmails(next);
+                  if (prev) {
+                    setEmailFormatWarnings((w) => {
+                      if (!w[prev]) return w;
+                      const updated = { ...w };
+                      delete updated[prev];
+                      return updated;
+                    });
+                    setEmailCollisions((c) => {
+                      if (!c[prev]) return c;
+                      const updated = { ...c };
+                      delete updated[prev];
+                      return updated;
+                    });
+                  }
+                }}
+                onBlur={() => checkEmailBlur(entry.email.trim())}
+              />
+              <input
+                className="form-input"
+                value={entry.label}
+                placeholder="label"
+                disabled={saving}
+                onChange={(e) => {
+                  const next = [...editEmails];
+                  next[i] = { ...next[i], label: e.target.value };
+                  setEditEmails(next);
+                }}
+              />
+              <button
+                className="ac-remove"
+                type="button"
+                onClick={() => setEditEmails(editEmails.filter((_, j) => j !== i))}
+              ></button>
+            </div>
+            {entry.email.trim() && emailFormatWarnings[entry.email.trim()] && (
+              <div className="ac-collision-warn">
+                ⚠ Invalid email address
+              </div>
+            )}
+            {entry.email.trim() && !emailFormatWarnings[entry.email.trim()] && emailDuplicates.has(entry.email.trim().toLowerCase()) && (
+              <div className="ac-collision-warn">⚠ Already added</div>
+            )}
+            {entry.email.trim() && !emailFormatWarnings[entry.email.trim()] && !emailDuplicates.has(entry.email.trim().toLowerCase()) && emailCollisions[entry.email.trim()] && (
+              <div className="ac-collision-warn">
+                Already on: <span>{emailCollisions[entry.email.trim()]}</span>
+              </div>
+            )}
+          </div>
+        ))}
+        <div>
+          <Button
+            variant="ghost"
+            type="button"
+            onClick={() => setEditEmails([...editEmails, { email: '', label: '' }])}
+          >
+            + Add
+          </Button>
+        </div>
+      </div>
+
+      <div className="form-field">
+        <label className="form-label">Phone</label>
+        {editPhones.map((entry, i) => (
+          <div
+            key={i}
+            {...phoneDragProps(i)}
+          >
+            <div className="ac-phone-row">
+              <span className="ac-drag-handle" {...phoneHandleProps}>⠿</span>
+              <input
+                className="form-input"
+                value={entry.phone}
+                placeholder="+1 555 000 0000"
+                disabled={saving}
+                onChange={(e) => {
+                  const prev = entry.phone.trim();
+                  const next = [...editPhones];
+                  next[i] = { ...next[i], phone: e.target.value };
+                  setEditPhones(next);
+                  const newVal = e.target.value.trim();
+                  if (prev && prev !== newVal) {
+                    setPhoneFormatWarnings((w) => { if (!w[prev]) return w; const u = { ...w }; delete u[prev]; return u; });
+                    setPhoneCollisions((c) => { if (!c[prev]) return c; const u = { ...c }; delete u[prev]; return u; });
+                  }
+                  if (newVal) {
+                    setPhoneFormatWarnings((w) => {
+                      const bad = hasDisallowedPhoneChars(newVal);
+                      if (bad === !!w[newVal]) return w;
+                      const u = { ...w };
+                      if (bad) u[newVal] = true; else delete u[newVal];
+                      return u;
+                    });
+                  }
+                }}
+                onBlur={() => checkPhoneBlur(entry.phone.trim())}
+              />
+              <input
+                className="form-input"
+                value={entry.label}
+                placeholder="label"
+                disabled={saving}
+                onChange={(e) => {
+                  const next = [...editPhones];
+                  next[i] = { ...next[i], label: e.target.value };
+                  setEditPhones(next);
+                }}
+              />
+              <button
+                className="ac-remove"
+                type="button"
+                onClick={() => setEditPhones(editPhones.filter((_, j) => j !== i))}
+              ></button>
+            </div>
+            {entry.phone.trim() && phoneFormatWarnings[entry.phone.trim()] && (
+              <div className="ac-collision-warn">
+                {hasDisallowedPhoneChars(entry.phone.trim())
+                  ? '⚠ Phone contains invalid characters'
+                  : '⚠ Invalid phone number'}
+              </div>
+            )}
+            {entry.phone.trim() && !phoneFormatWarnings[entry.phone.trim()] && phoneDuplicates.has(normalizePhoneForComparison(entry.phone)) && (
+              <div className="ac-collision-warn">⚠ Already added</div>
+            )}
+            {entry.phone.trim() && !phoneFormatWarnings[entry.phone.trim()] && !phoneDuplicates.has(normalizePhoneForComparison(entry.phone)) && phoneCollisions[entry.phone.trim()] && (
+              <div className="ac-collision-warn">
+                Already on: <span>{phoneCollisions[entry.phone.trim()]}</span>
+              </div>
+            )}
+          </div>
+        ))}
+        <div>
+          <Button
+            variant="ghost"
+            type="button"
+            onClick={() => setEditPhones([...editPhones, { phone: '', label: '' }])}
+          >
+            + Add
+          </Button>
+        </div>
+      </div>
+
+      <div className="form-field">
+        <label className="form-label">Messaging</label>
+        {editHandles.map((entry, i) => (
+          <div key={i} className="ac-phone-row">
+            <select
+              className="form-input ac-handle-type"
+              value={HANDLE_TYPES.includes(entry.type as HandleType) ? entry.type : 'other'}
+              onChange={(e) => {
+                const next = [...editHandles];
+                next[i] = { ...next[i], type: e.target.value as HandleType };
+                setEditHandles(next);
+              }}
+            >
+              {HANDLE_TYPES.map((t) => (
+                <option key={t} value={t}>{HANDLE_META[t].label}</option>
+              ))}
+            </select>
+            <input
+              className="form-input"
+              value={entry.handle}
+              placeholder={HANDLE_META[(HANDLE_TYPES.includes(entry.type as HandleType) ? entry.type : 'other') as HandleType].placeholder}
+              onChange={(e) => {
+                const next = [...editHandles];
+                next[i] = { ...next[i], handle: e.target.value };
+                setEditHandles(next);
+              }}
+            />
+            <button
+              className="ac-remove"
+              type="button"
+              onClick={() => setEditHandles(editHandles.filter((_, j) => j !== i))}
+            ></button>
+          </div>
+        ))}
+        <div>
+          <Button
+            variant="ghost"
+            type="button"
+            onClick={() => setEditHandles([...editHandles, { type: 'signal', handle: '' }])}
+          >
+            + Add
+          </Button>
+        </div>
+      </div>
+
+      {NON_OTHER_SOCIAL_TYPES.map((type) => (
+        <div key={type} className="form-field">
+          <label className="form-label">{SOCIAL_META[type].label}</label>
+          <DynamicList
+            enableDragReorder
+            values={editSocials[type]}
+            placeholder={SOCIAL_META[type].placeholder}
+            onChange={(vals) => setSocial(type, vals)}
+            onChangeItem={(oldVal) => {
+              if (!oldVal) return;
+              setUrlFormatWarnings((w) => { if (!w[oldVal]) return w; const u = { ...w }; delete u[oldVal]; return u; });
+            }}
+            onBlurItem={(val) => {
+              if (!val) return;
+              setUrlFormatWarnings((prev) => {
+                const next = { ...prev };
+                if (!isValidUrl(val)) next[val] = true; else delete next[val];
+                return next;
+              });
+            }}
+            warnings={Object.fromEntries(
+              editSocials[type]
+                .map((v) => v.trim())
+                .filter(Boolean)
+                .flatMap((v) => {
+                  if (urlFormatWarnings[v]) return [[v, '⚠ Invalid URL']];
+                  if (urlDuplicates.has(v)) return [[v, '⚠ Already added']];
+                  return [];
+                })
+            )}
+          />
+        </div>
+      ))}
+
+      <div className="form-field">
+        <label className="form-label">Other social</label>
+        {editOtherSocials.map((entry, i) => (
+          <div
+            key={i}
+            {...otherSocialDragProps(i)}
+          >
+            <div className="ac-other-social-row">
+              <span className="ac-drag-handle" {...otherSocialHandleProps}>⠿</span>
+              <input
+                className="form-input"
+                value={entry.label}
+                placeholder="Platform (e.g. TikTok)"
+                maxLength={OTHER_LABEL_MAX}
+                onChange={(e) => {
+                  const next = [...editOtherSocials];
+                  next[i] = { ...next[i], label: e.target.value };
+                  setEditOtherSocials(next);
+                }}
+                onBlur={(e) => {
+                  const next = [...editOtherSocials];
+                  next[i] = { ...next[i], label: sanitizeOtherLabel(e.target.value) };
+                  setEditOtherSocials(next);
+                }}
+              />
+              <input
+                className="form-input"
+                value={entry.url}
+                placeholder="https://…"
+                onChange={(e) => {
+                  const prev = entry.url.trim();
+                  const next = [...editOtherSocials];
+                  next[i] = { ...next[i], url: e.target.value };
+                  setEditOtherSocials(next);
+                  if (prev) {
+                    setUrlFormatWarnings((w) => { if (!w[prev]) return w; const u = { ...w }; delete u[prev]; return u; });
+                  }
+                }}
+                onBlur={() => {
+                  const val = entry.url.trim();
+                  if (!val) return;
+                  setUrlFormatWarnings((prev) => {
+                    const next = { ...prev };
+                    if (!isValidUrl(val)) next[val] = true; else delete next[val];
+                    return next;
+                  });
+                }}
+              />
+              <button
+                className="ac-remove"
+                type="button"
+                onClick={() => setEditOtherSocials(editOtherSocials.filter((_, j) => j !== i))}
+              ></button>
+            </div>
+            {entry.url.trim() && urlFormatWarnings[entry.url.trim()] && (
+              <div className="ac-collision-warn">⚠ Invalid URL</div>
+            )}
+            {entry.url.trim() && !urlFormatWarnings[entry.url.trim()] && urlDuplicates.has(entry.url.trim()) && (
+              <div className="ac-collision-warn">⚠ Already added</div>
+            )}
+          </div>
+        ))}
+        <div>
+          <Button
+            variant="ghost"
+            type="button"
+            onClick={() => setEditOtherSocials([...editOtherSocials, { url: '', label: '' }])}
+          >
+            + Add
+          </Button>
+        </div>
+      </div>
+
+      <div className="form-field">
+        <label className="form-label">Website</label>
+        <DynamicList
+          enableDragReorder
+          values={editWebsites}
+          placeholder="https://example.com"
+          onChange={setEditWebsites}
+          onChangeItem={(oldVal) => {
+            if (!oldVal) return;
+            setUrlFormatWarnings((w) => { if (!w[oldVal]) return w; const u = { ...w }; delete u[oldVal]; return u; });
+          }}
+          onBlurItem={(val) => {
+            if (!val) return;
+            setUrlFormatWarnings((prev) => {
+              const next = { ...prev };
+              if (!isValidUrl(val)) next[val] = true; else delete next[val];
+              return next;
+            });
+          }}
+          warnings={Object.fromEntries(
+            editWebsites
+              .map((v) => v.trim())
+              .filter(Boolean)
+              .flatMap((v) => {
+                if (urlFormatWarnings[v]) return [[v, '⚠ Invalid URL']];
+                if (urlDuplicates.has(v)) return [[v, '⚠ Already added']];
+                return [];
+              })
+          )}
+        />
+        {user?.wayback_enabled !== 0 && user?.wayback_keys_configured !== 0 && (
+          <p className="form-field-hint">Wayback Machine archiving is enabled.</p>
+        )}
+      </div>
+
+      <div className="form-field">
+        <label className="form-label">Notes</label>
+        <textarea
+          className="form-textarea"
+          value={editNotes}
+          onChange={(e) => setEditNotes(e.target.value)}
+          rows={4}
+        />
+      </div>
+
+      <RssAlertPanel
+        editing
+        alertRssList={alertRssList}
+        newRssUrl={newRssUrl}
+        onNewRssUrlChange={onNewRssUrlChange}
+        onAddRss={onAddRss}
+        onRemoveRss={onRemoveRss}
+      />
+
+      <div className="detail-edit-actions-bottom">
+        <Button variant="primary" size="sm" onClick={handleSave} disabled={saving || !editName.trim() || Object.keys(emailFormatWarnings).length > 0 || Object.keys(phoneFormatWarnings).length > 0 || Object.keys(urlFormatWarnings).length > 0 || (!!newRssUrl.trim() && !isGoogleAlertUrl(newRssUrl.trim())) || (!!newRssUrl.trim() && alertRssList.some((f) => f.rss_url === newRssUrl.trim()))}>
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+        <Button variant="secondary" size="sm" onClick={onCancel} disabled={saving}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -1,23 +1,15 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ContactDetail as ContactDetailType, ContactAlertRss, Project, User } from '@shared/types';
 import Button from '../shell/Button';
 import GlobalLogSection from './GlobalLogSection';
 import GlobalRemindersSection from './GlobalRemindersSection';
-import DynamicList, { useDragReorder } from './DynamicList';
-import {
-  isGoogleAlertUrl,
-  hasDisallowedPhoneChars,
-  normalizePhoneForComparison,
-  sanitizeOtherLabel,
-  OTHER_LABEL_MAX,
-} from './contactValidation';
-import { NON_OTHER_SOCIAL_TYPES, SOCIAL_TYPES, SOCIAL_META, localToday } from './contactConstants';
-import type { SocialType, NonOtherSocialType } from './contactConstants';
-import { useContactFieldValidation } from './useContactFieldValidation';
-import { CalendarPicker } from '../views/CalendarPicker';
+import ContactEditForm, { SOCIAL_TYPES, SOCIAL_META, KNOWN_LINK_TYPES } from './ContactEditForm';
+import { isGoogleAlertUrl } from './contactValidation';
 import RssAlertPanel from './RssAlertPanel';
 import ScreenshotPanel from './ScreenshotPanel';
 import { linkifyText } from '../utils/linkify';
+import { HANDLE_TYPES, HANDLE_META } from './handleMeta';
+import type { HandleType } from './handleMeta';
 import './AddContactModal.css';
 import './ContactDetail.css';
 
@@ -31,12 +23,6 @@ interface Props {
   user?: User | null;
 }
 
-import { HANDLE_TYPES, HANDLE_META } from './handleMeta';
-import type { HandleType } from './handleMeta';
-
-const KNOWN_LINK_TYPES = new Set<string>([...SOCIAL_TYPES, 'website']);
-
-
 export default function GlobalTab({ contact, allProjects, onRefresh, onMembershipChanged, onDeleted, onEditingChange, user }: Props) {
   const [editing, setEditing] = useState(false);
 
@@ -44,15 +30,13 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
     setEditing(value);
     onEditingChange?.(value);
   }
-  const [saving, setSaving] = useState(false);
+
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [addingToProject, setAddingToProject] = useState('');
   const [confirmRemoveProjectId, setConfirmRemoveProjectId] = useState<string | null>(null);
   const [alertRssList, setAlertRssList] = useState<ContactAlertRss[]>([]);
   const [waybackStatus, setWaybackStatus] = useState<Map<string, 'pending' | 'failed'>>(new Map());
-  const formRef = useRef<HTMLDivElement>(null);
-  const mounted = useRef(true);
-  useEffect(() => { mounted.current = true; return () => { mounted.current = false; }; }, []);
+  const [newRssUrl, setNewRssUrl] = useState('');
 
   useEffect(() => {
     return window.sourcerer.onWaybackStatus(({ contactId, url, status }) => {
@@ -69,7 +53,6 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
     });
   }, [contact.id]);
 
-  // Clear pending status when contact reloads with a wayback_url
   useEffect(() => {
     const archivedUrls = new Set(contact.links.filter((l) => l.wayback_url).map((l) => l.url));
     if (archivedUrls.size === 0) return;
@@ -81,58 +64,6 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
     });
   }, [contact.links]);
 
-  // Edit form state
-  const [editName, setEditName] = useState('');
-  const [editOrg, setEditOrg] = useState('');
-  const [editTitle, setEditTitle] = useState('');
-  const [editDob, setEditDob] = useState('');
-  const [editNotes, setEditNotes] = useState('');
-  const [editHandles, setEditHandles] = useState<Array<{ type: HandleType; handle: string }>>([]);
-  const [editEmails, setEditEmails] = useState<Array<{ email: string; label: string }>>([]);
-  const [editPhones, setEditPhones] = useState<Array<{ phone: string; label: string }>>([]);
-  const [editSocials, setEditSocials] = useState<Record<NonOtherSocialType, string[]>>({
-    linkedin: [], x: [], instagram: [], facebook: [],
-  });
-  const [editOtherSocials, setEditOtherSocials] = useState<Array<{ url: string; label: string }>>([]);
-  const { getDragProps: emailDragProps, handleProps: emailHandleProps } = useDragReorder(editEmails, setEditEmails);
-  const { getDragProps: phoneDragProps, handleProps: phoneHandleProps } = useDragReorder(editPhones, setEditPhones);
-  const { getDragProps: otherSocialDragProps, handleProps: otherSocialHandleProps } = useDragReorder(editOtherSocials, setEditOtherSocials);
-  const [editWebsites, setEditWebsites] = useState<string[]>([]);
-  const [newRssUrl, setNewRssUrl] = useState('');
-  const urlValues = useMemo(
-    () => [
-      ...editWebsites,
-      ...NON_OTHER_SOCIAL_TYPES.flatMap((t) => editSocials[t]),
-      ...editOtherSocials.map((e) => e.url),
-    ],
-    [editWebsites, editSocials, editOtherSocials],
-  );
-
-  const {
-    emailCollisions,
-    phoneCollisions,
-    emailFormatWarnings,
-    phoneFormatWarnings,
-    urlFormatWarnings,
-    emailDuplicates,
-    phoneDuplicates,
-    urlDuplicates,
-    checkEmailBlur,
-    checkPhoneBlur,
-    clearEmailWarnings,
-    clearPhoneWarnings,
-    updatePhoneFormatWarning,
-    clearUrlWarning,
-    updateUrlFormatWarning,
-    resetAll,
-  } = useContactFieldValidation({
-    excludeId: contact.id,
-    mounted,
-    emails: editEmails,
-    phones: editPhones,
-    urlValues,
-  });
-
   useEffect(() => {
     let cancelled = false;
     window.sourcerer.listAlertRss(contact.id).then((list) => {
@@ -141,78 +72,11 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
     return () => { cancelled = true; };
   }, [contact.id]);
 
-
-  function setSocial(type: NonOtherSocialType, values: string[]) {
-    setEditSocials((prev) => ({ ...prev, [type]: values }));
-  }
-
-  function startEdit() {
-    setEditName(contact.name);
-    setEditOrg(contact.organization ?? '');
-    setEditTitle(contact.title ?? '');
-    setEditDob(contact.dob ?? '');
-    setEditNotes(contact.notes ?? '');
-    setEditHandles(contact.handles.map((h) => ({ type: h.type, handle: h.handle })));
-    setEditEmails(contact.emails.map((e) => ({ email: e.email, label: e.label ?? '' })));
-    setEditPhones(contact.phones.map((p) => ({ phone: p.phone, label: p.label ?? '' })));
-    const socialsByType = Object.fromEntries(
-      NON_OTHER_SOCIAL_TYPES.map((type) => [
-        type,
-        contact.links.filter((l) => l.type === type).map((l) => l.url),
-      ]),
-    ) as Record<NonOtherSocialType, string[]>;
-    setEditSocials(socialsByType);
-    setEditOtherSocials(
-      contact.links.filter((l) => l.type === 'other').map((l) => ({ url: l.url, label: l.label ?? '' })),
-    );
-    setEditWebsites(contact.links.filter((l) => l.type === 'website').map((l) => l.url));
+  // Reset edit mode when contact changes
+  useEffect(() => {
+    setEditingAndNotify(false);
     setNewRssUrl('');
-    resetAll();
-    setEditingAndNotify(true);
-  }
-
-  async function handleSave() {
-    if (!editName.trim()) return;
-    if (emailDuplicates.size > 0 || phoneDuplicates.size > 0 || urlDuplicates.size > 0) {
-      formRef.current?.querySelector<HTMLElement>('.ac-collision-warn')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      return;
-    }
-    setSaving(true);
-    try {
-      const links = [
-        ...NON_OTHER_SOCIAL_TYPES.flatMap((type) =>
-          editSocials[type].filter((u) => u.trim()).map((url) => ({ type, url })),
-        ),
-        ...editOtherSocials
-          .filter((e) => e.url.trim())
-          .map((e) => {
-            const label = sanitizeOtherLabel(e.label);
-            return { type: 'other' as const, url: e.url, ...(label ? { label } : {}) };
-          }),
-        ...editWebsites.filter((u) => u.trim()).map((url) => ({ type: 'website' as const, url })),
-      ];
-      await window.sourcerer.updateContact({
-        id: contact.id,
-        name: editName,
-        organization: editOrg,
-        title: editTitle,
-        dob: editDob || undefined,
-        notes: editNotes,
-        emails: editEmails.filter((e) => e.email.trim()).map((e) => ({ email: e.email, label: e.label.trim() || undefined })),
-        phones: editPhones.filter((p) => p.phone?.trim()).map((p) => ({ phone: p.phone, label: p.label.trim() || undefined })),
-        links,
-        handles: editHandles.filter((h) => h.handle.trim() && h.type.trim()),
-      });
-      const pendingRss = newRssUrl.trim();
-      if (pendingRss && isGoogleAlertUrl(pendingRss) && !alertRssList.some((f) => f.rss_url === pendingRss)) {
-        await window.sourcerer.addAlertRss(contact.id, pendingRss);
-      }
-      onRefresh();
-      setEditingAndNotify(false);
-    } finally {
-      setSaving(false);
-    }
-  }
+  }, [contact.id]);
 
   async function handleAddToProject() {
     if (!addingToProject) return;
@@ -257,11 +121,9 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
     } catch { /* item stays in list */ }
   }
 
-
-  // View mode: group links by type
   const socialLinks = Object.fromEntries(
     SOCIAL_TYPES.map((type) => [type, contact.links.filter((l) => l.type === type)]),
-  ) as Record<SocialType, typeof contact.links>;
+  ) as Record<typeof SOCIAL_TYPES[number], typeof contact.links>;
   const websiteLinks = contact.links.filter((l) => l.type === 'website');
   const otherLinks = contact.links.filter((l) => !KNOWN_LINK_TYPES.has(l.type));
   const contactProjectIds = new Set(contact.projects.map((p) => p.id));
@@ -269,357 +131,17 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
 
   if (editing) {
     return (
-      <div className="detail-body" ref={formRef}>
-        <div className="form-field">
-          <label className="form-label">Name <span className="form-required">*</span></label>
-          <input className="form-input" value={editName} onChange={(e) => setEditName(e.target.value)} autoFocus />
-        </div>
-
-        <div className="form-field">
-          <label className="form-label">Organization</label>
-          <input className="form-input" value={editOrg} onChange={(e) => setEditOrg(e.target.value)} />
-        </div>
-
-        <div className="form-field">
-          <label className="form-label">Title / Role</label>
-          <input className="form-input" value={editTitle} onChange={(e) => setEditTitle(e.target.value)} placeholder="e.g. Senior Editor" />
-        </div>
-
-        <div className="form-field">
-          <label className="form-label">Date of birth</label>
-          <CalendarPicker
-            label="Select date"
-            value={editDob}
-            onChange={setEditDob}
-            showYear
-            maxDate={localToday()}
-          />
-        </div>
-
-        <div className="form-field">
-          <label className="form-label">Email</label>
-          {editEmails.map((entry, i) => (
-            <div
-              key={i}
-              {...emailDragProps(i)}
-            >
-              <div className="ac-phone-row">
-                <span className="ac-drag-handle" {...emailHandleProps}>⠿</span>
-                <input
-                  className="form-input"
-                  value={entry.email}
-                  placeholder="email@example.com"
-                  disabled={saving}
-                  onChange={(e) => {
-                    const prev = entry.email.trim();
-                    const next = [...editEmails];
-                    next[i] = { ...next[i], email: e.target.value };
-                    setEditEmails(next);
-                    if (prev) clearEmailWarnings(prev);
-                  }}
-                  onBlur={() => checkEmailBlur(entry.email.trim())}
-                />
-                <input
-                  className="form-input"
-                  value={entry.label}
-                  placeholder="label"
-                  disabled={saving}
-                  onChange={(e) => {
-                    const next = [...editEmails];
-                    next[i] = { ...next[i], label: e.target.value };
-                    setEditEmails(next);
-                  }}
-                />
-                <button
-                  className="ac-remove"
-                  type="button"
-                  onClick={() => setEditEmails(editEmails.filter((_, j) => j !== i))}
-                ></button>
-              </div>
-              {entry.email.trim() && emailFormatWarnings[entry.email.trim()] && (
-                <div className="ac-collision-warn">
-                  ⚠ Invalid email address
-                </div>
-              )}
-              {entry.email.trim() && !emailFormatWarnings[entry.email.trim()] && emailDuplicates.has(entry.email.trim().toLowerCase()) && (
-                <div className="ac-collision-warn">⚠ Already added</div>
-              )}
-              {entry.email.trim() && !emailFormatWarnings[entry.email.trim()] && !emailDuplicates.has(entry.email.trim().toLowerCase()) && emailCollisions[entry.email.trim()] && (
-                <div className="ac-collision-warn">
-                  Already on: <span>{emailCollisions[entry.email.trim()]}</span>
-                </div>
-              )}
-            </div>
-          ))}
-          <div>
-            <Button
-              variant="ghost"
-              type="button"
-              onClick={() => setEditEmails([...editEmails, { email: '', label: '' }])}
-            >
-              + Add
-            </Button>
-          </div>
-        </div>
-
-        <div className="form-field">
-          <label className="form-label">Phone</label>
-          {editPhones.map((entry, i) => (
-            <div
-              key={i}
-              {...phoneDragProps(i)}
-            >
-              <div className="ac-phone-row">
-                <span className="ac-drag-handle" {...phoneHandleProps}>⠿</span>
-                <input
-                  className="form-input"
-                  value={entry.phone}
-                  placeholder="+1 555 000 0000"
-                  disabled={saving}
-                  onChange={(e) => {
-                    const prev = entry.phone.trim();
-                    const next = [...editPhones];
-                    next[i] = { ...next[i], phone: e.target.value };
-                    setEditPhones(next);
-                    const newVal = e.target.value.trim();
-                    if (prev && prev !== newVal) clearPhoneWarnings(prev);
-                    if (newVal) updatePhoneFormatWarning(newVal);
-                  }}
-                  onBlur={() => checkPhoneBlur(entry.phone.trim())}
-                />
-                <input
-                  className="form-input"
-                  value={entry.label}
-                  placeholder="label"
-                  disabled={saving}
-                  onChange={(e) => {
-                    const next = [...editPhones];
-                    next[i] = { ...next[i], label: e.target.value };
-                    setEditPhones(next);
-                  }}
-                />
-                <button
-                  className="ac-remove"
-                  type="button"
-                  onClick={() => setEditPhones(editPhones.filter((_, j) => j !== i))}
-                ></button>
-              </div>
-              {entry.phone.trim() && phoneFormatWarnings[entry.phone.trim()] && (
-                <div className="ac-collision-warn">
-                  {hasDisallowedPhoneChars(entry.phone.trim())
-                    ? '⚠ Phone contains invalid characters'
-                    : '⚠ Invalid phone number'}
-                </div>
-              )}
-              {entry.phone.trim() && !phoneFormatWarnings[entry.phone.trim()] && phoneDuplicates.has(normalizePhoneForComparison(entry.phone)) && (
-                <div className="ac-collision-warn">⚠ Already added</div>
-              )}
-              {entry.phone.trim() && !phoneFormatWarnings[entry.phone.trim()] && !phoneDuplicates.has(normalizePhoneForComparison(entry.phone)) && phoneCollisions[entry.phone.trim()] && (
-                <div className="ac-collision-warn">
-                  Already on: <span>{phoneCollisions[entry.phone.trim()]}</span>
-                </div>
-              )}
-            </div>
-          ))}
-          <div>
-            <Button
-              variant="ghost"
-              type="button"
-              onClick={() => setEditPhones([...editPhones, { phone: '', label: '' }])}
-            >
-              + Add
-            </Button>
-          </div>
-        </div>
-
-        <div className="form-field">
-          <label className="form-label">Messaging</label>
-          {editHandles.map((entry, i) => (
-            <div key={i} className="ac-phone-row">
-              <select
-                className="form-input ac-handle-type"
-                value={HANDLE_TYPES.includes(entry.type as HandleType) ? entry.type : 'other'}
-                onChange={(e) => {
-                  const next = [...editHandles];
-                  next[i] = { ...next[i], type: e.target.value as HandleType };
-                  setEditHandles(next);
-                }}
-              >
-                {HANDLE_TYPES.map((t) => (
-                  <option key={t} value={t}>{HANDLE_META[t].label}</option>
-                ))}
-              </select>
-              <input
-                className="form-input"
-                value={entry.handle}
-                placeholder={HANDLE_META[(HANDLE_TYPES.includes(entry.type as HandleType) ? entry.type : 'other') as HandleType].placeholder}
-                onChange={(e) => {
-                  const next = [...editHandles];
-                  next[i] = { ...next[i], handle: e.target.value };
-                  setEditHandles(next);
-                }}
-              />
-              <button
-                className="ac-remove"
-                type="button"
-                onClick={() => setEditHandles(editHandles.filter((_, j) => j !== i))}
-              ></button>
-            </div>
-          ))}
-          <div>
-            <Button
-              variant="ghost"
-              type="button"
-              onClick={() => setEditHandles([...editHandles, { type: 'signal', handle: '' }])}
-            >
-              + Add
-            </Button>
-          </div>
-        </div>
-
-        {NON_OTHER_SOCIAL_TYPES.map((type) => (
-          <div key={type} className="form-field">
-            <label className="form-label">{SOCIAL_META[type].label}</label>
-            <DynamicList
-              enableDragReorder
-              values={editSocials[type]}
-              placeholder={SOCIAL_META[type].placeholder}
-              onChange={(vals) => setSocial(type, vals)}
-              onChangeItem={(oldVal) => { if (oldVal) clearUrlWarning(oldVal); }}
-              onBlurItem={(val) => { if (val) updateUrlFormatWarning(val); }}
-              warnings={Object.fromEntries(
-                editSocials[type]
-                  .map((v) => v.trim())
-                  .filter(Boolean)
-                  .flatMap((v) => {
-                    if (urlFormatWarnings[v]) return [[v, '⚠ Invalid URL']];
-                    if (urlDuplicates.has(v)) return [[v, '⚠ Already added']];
-                    return [];
-                  })
-              )}
-            />
-          </div>
-        ))}
-
-        <div className="form-field">
-          <label className="form-label">Other social</label>
-          {editOtherSocials.map((entry, i) => (
-            <div
-              key={i}
-              {...otherSocialDragProps(i)}
-            >
-              <div className="ac-other-social-row">
-                <span className="ac-drag-handle" {...otherSocialHandleProps}>⠿</span>
-                <input
-                  className="form-input"
-                  value={entry.label}
-                  placeholder="Platform (e.g. TikTok)"
-                  maxLength={OTHER_LABEL_MAX}
-                  onChange={(e) => {
-                    const next = [...editOtherSocials];
-                    next[i] = { ...next[i], label: e.target.value };
-                    setEditOtherSocials(next);
-                  }}
-                  onBlur={(e) => {
-                    const next = [...editOtherSocials];
-                    next[i] = { ...next[i], label: sanitizeOtherLabel(e.target.value) };
-                    setEditOtherSocials(next);
-                  }}
-                />
-                <input
-                  className="form-input"
-                  value={entry.url}
-                  placeholder="https://…"
-                  onChange={(e) => {
-                    const prev = entry.url.trim();
-                    const next = [...editOtherSocials];
-                    next[i] = { ...next[i], url: e.target.value };
-                    setEditOtherSocials(next);
-                    if (prev) clearUrlWarning(prev);
-                  }}
-                  onBlur={() => {
-                    const val = entry.url.trim();
-                    if (val) updateUrlFormatWarning(val);
-                  }}
-                />
-                <button
-                  className="ac-remove"
-                  type="button"
-                  onClick={() => setEditOtherSocials(editOtherSocials.filter((_, j) => j !== i))}
-                ></button>
-              </div>
-              {entry.url.trim() && urlFormatWarnings[entry.url.trim()] && (
-                <div className="ac-collision-warn">⚠ Invalid URL</div>
-              )}
-              {entry.url.trim() && !urlFormatWarnings[entry.url.trim()] && urlDuplicates.has(entry.url.trim()) && (
-                <div className="ac-collision-warn">⚠ Already added</div>
-              )}
-            </div>
-          ))}
-          <div>
-            <Button
-              variant="ghost"
-              type="button"
-              onClick={() => setEditOtherSocials([...editOtherSocials, { url: '', label: '' }])}
-            >
-              + Add
-            </Button>
-          </div>
-        </div>
-
-        <div className="form-field">
-          <label className="form-label">Website</label>
-          <DynamicList
-            enableDragReorder
-            values={editWebsites}
-            placeholder="https://example.com"
-            onChange={setEditWebsites}
-            onChangeItem={(oldVal) => { if (oldVal) clearUrlWarning(oldVal); }}
-            onBlurItem={(val) => { if (val) updateUrlFormatWarning(val); }}
-            warnings={Object.fromEntries(
-              editWebsites
-                .map((v) => v.trim())
-                .filter(Boolean)
-                .flatMap((v) => {
-                  if (urlFormatWarnings[v]) return [[v, '⚠ Invalid URL']];
-                  if (urlDuplicates.has(v)) return [[v, '⚠ Already added']];
-                  return [];
-                })
-            )}
-          />
-          {user?.wayback_enabled !== 0 && user?.wayback_keys_configured !== 0 && (
-            <p className="form-field-hint">Wayback Machine archiving is enabled.</p>
-          )}
-        </div>
-
-        <div className="form-field">
-          <label className="form-label">Notes</label>
-          <textarea
-            className="form-textarea"
-            value={editNotes}
-            onChange={(e) => setEditNotes(e.target.value)}
-            rows={4}
-          />
-        </div>
-
-        <RssAlertPanel
-          editing
-          alertRssList={alertRssList}
-          newRssUrl={newRssUrl}
-          onNewRssUrlChange={setNewRssUrl}
-          onAddRss={handleAddRss}
-          onRemoveRss={handleRemoveRss}
-        />
-
-        <div className="detail-edit-actions-bottom">
-          <Button variant="primary" size="sm" onClick={handleSave} disabled={saving || !editName.trim() || Object.keys(emailFormatWarnings).length > 0 || Object.keys(phoneFormatWarnings).length > 0 || Object.keys(urlFormatWarnings).length > 0 || (!!newRssUrl.trim() && !isGoogleAlertUrl(newRssUrl.trim())) || (!!newRssUrl.trim() && alertRssList.some((f) => f.rss_url === newRssUrl.trim()))}>
-            {saving ? 'Saving…' : 'Save'}
-          </Button>
-          <Button variant="secondary" size="sm" onClick={() => setEditingAndNotify(false)} disabled={saving}>
-            Cancel
-          </Button>
-        </div>
-      </div>
+      <ContactEditForm
+        contact={contact}
+        user={user}
+        alertRssList={alertRssList}
+        newRssUrl={newRssUrl}
+        onNewRssUrlChange={setNewRssUrl}
+        onAddRss={handleAddRss}
+        onRemoveRss={handleRemoveRss}
+        onSaved={() => { onRefresh(); setEditingAndNotify(false); }}
+        onCancel={() => setEditingAndNotify(false)}
+      />
     );
   }
 
@@ -836,7 +358,7 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
               >
                 ↓ vCard
               </Button>
-              <Button variant="secondary" size="sm" onClick={startEdit}>Edit</Button>
+              <Button variant="secondary" size="sm" onClick={() => setEditingAndNotify(true)}>Edit</Button>
             </div>
             <Button variant="danger-outline" size="sm" onClick={() => setConfirmDelete(true)}>
               Delete contact

--- a/src/renderer/src/hooks/useProjectContacts.ts
+++ b/src/renderer/src/hooks/useProjectContacts.ts
@@ -1,0 +1,131 @@
+import { useMemo } from 'react';
+import type { ProjectContactRow, StatusOption, PriorityOption } from '@shared/types';
+import type { ProjectFilters as Filters } from '../views/ContactsTable';
+import { buildOrderMap } from '../views/ContactsTable';
+import type { SortState } from './useSortFilter';
+
+type SortKey =
+  | 'name'
+  | 'organization'
+  | 'theme'
+  | 'status'
+  | 'priority'
+  | 'reporter'
+  | 'date_first_contacted'
+  | 'date_last_contacted'
+  | 'membership_created_at';
+
+export function useProjectContacts(
+  rows: ProjectContactRow[],
+  filters: Filters,
+  sort: SortState<SortKey>,
+  statusOptions: StatusOption[],
+  priorityOptions: PriorityOption[],
+): ProjectContactRow[] {
+  return useMemo(() => {
+    const statusOrderMap = buildOrderMap(statusOptions);
+    const priorityOrderMap = buildOrderMap(priorityOptions);
+    const now = Math.floor(Date.now() / 1000);
+    let result = rows;
+
+    if (filters.name) {
+      const q = filters.name.toLowerCase();
+      result = result.filter((r) => r.name.toLowerCase().includes(q));
+    }
+    if (filters.organization) {
+      const q = filters.organization.toLowerCase();
+      result = result.filter((r) => (r.organization ?? '').toLowerCase().includes(q));
+    }
+    if (filters.theme) {
+      const q = filters.theme.toLowerCase();
+      result = result.filter((r) => (r.theme ?? '').toLowerCase().includes(q));
+    }
+    if (filters.notes) {
+      const q = filters.notes.toLowerCase();
+      result = result.filter((r) => (r.notes ?? '').toLowerCase().includes(q));
+    }
+    if (filters.email) {
+      const q = filters.email.toLowerCase();
+      result = result.filter((r) => (r.emails_raw ?? '').toLowerCase().includes(q));
+    }
+    if (filters.phone) {
+      const q = filters.phone.toLowerCase();
+      result = result.filter((r) => (r.phones_raw ?? '').toLowerCase().includes(q));
+    }
+    if (filters.hasEmail !== null) {
+      result = result.filter((r) => (filters.hasEmail ? r.has_email === 1 : r.has_email === 0));
+    }
+    if (filters.hasPhone !== null) {
+      result = result.filter((r) => (filters.hasPhone ? r.has_phone === 1 : r.has_phone === 0));
+    }
+    if (filters.dateLastContacted === 'never') {
+      result = result.filter((r) => r.date_last_contacted === null);
+    } else if (filters.dateLastContacted === 'contacted') {
+      result = result.filter((r) => r.date_last_contacted !== null);
+    } else if (filters.dateLastContacted === 'not_30') {
+      result = result.filter(
+        (r) => r.date_last_contacted === null || r.date_last_contacted < now - 30 * 86400,
+      );
+    } else if (filters.dateLastContacted === 'not_90') {
+      result = result.filter(
+        (r) => r.date_last_contacted === null || r.date_last_contacted < now - 90 * 86400,
+      );
+    }
+    if (filters.dateAddedFrom) {
+      const from = Math.floor(new Date(filters.dateAddedFrom).getTime() / 1000);
+      result = result.filter((r) => r.membership_created_at >= from);
+    }
+    if (filters.dateAddedTo) {
+      const to = Math.floor(new Date(filters.dateAddedTo).getTime() / 1000) + 86399;
+      result = result.filter((r) => r.membership_created_at <= to);
+    }
+    if (filters.status.length > 0) {
+      result = result.filter((r) => filters.status.includes(r.status ?? ''));
+    }
+    if (filters.priority.length > 0) {
+      result = result.filter((r) => filters.priority.includes(r.priority ?? ''));
+    }
+    if (filters.reporter.length > 0) {
+      result = result.filter((r) => filters.reporter.includes(r.reporter_name));
+    }
+
+    if (sort.key) {
+      const dir = sort.dir === 'asc' ? 1 : -1;
+      result = [...result].sort((a, b) => {
+        let cmp = 0;
+        if (sort.key === 'name') {
+          cmp = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+        } else if (sort.key === 'organization') {
+          cmp = (a.organization ?? '').localeCompare(b.organization ?? '', undefined, {
+            sensitivity: 'base',
+          });
+        } else if (sort.key === 'theme') {
+          cmp = (a.theme ?? '').localeCompare(b.theme ?? '', undefined, { sensitivity: 'base' });
+        } else if (sort.key === 'status') {
+          const si = (s: string | null) => statusOrderMap.get(s ?? '') ?? 9999;
+          cmp = si(a.status) - si(b.status);
+        } else if (sort.key === 'priority') {
+          const pi = (p: string | null) => priorityOrderMap.get(p ?? '') ?? 9999;
+          cmp = pi(a.priority) - pi(b.priority);
+        } else if (sort.key === 'reporter') {
+          cmp = a.reporter_name.localeCompare(b.reporter_name, undefined, { sensitivity: 'base' });
+        } else if (sort.key === 'date_first_contacted') {
+          if (a.date_first_contacted === null && b.date_first_contacted === null) cmp = 0;
+          else if (a.date_first_contacted === null) cmp = 1;
+          else if (b.date_first_contacted === null) cmp = -1;
+          else cmp = a.date_first_contacted - b.date_first_contacted;
+        } else if (sort.key === 'date_last_contacted') {
+          if (a.date_last_contacted === null && b.date_last_contacted === null) cmp = 0;
+          else if (a.date_last_contacted === null) cmp = 1;
+          else if (b.date_last_contacted === null) cmp = -1;
+          else cmp = a.date_last_contacted - b.date_last_contacted;
+        } else if (sort.key === 'membership_created_at') {
+          cmp = a.membership_created_at - b.membership_created_at;
+        }
+        return cmp * dir;
+      });
+    }
+
+    return result;
+  }, [rows, filters, sort, statusOptions, priorityOptions]);
+}

--- a/src/renderer/src/hooks/useSortFilter.ts
+++ b/src/renderer/src/hooks/useSortFilter.ts
@@ -4,7 +4,7 @@ import type { SortDir } from '../views/ContactsTable';
 export type SortState<K extends string> = { key: K | null; dir: SortDir };
 
 export function useSortFilter<K extends string, F>(defaultFilters: F) {
-  const [sort, setSort] = useState<{ key: K | null; dir: SortDir }>({ key: null, dir: 'asc' });
+  const [sort, setSort] = useState<SortState<K>>({ key: null, dir: 'asc' });
   const [filters, setFilters] = useState<F>(defaultFilters);
   const defaultFiltersRef = useRef(defaultFilters);
   useEffect(() => { defaultFiltersRef.current = defaultFilters; }, [defaultFilters]);

--- a/src/renderer/src/hooks/useSortFilter.ts
+++ b/src/renderer/src/hooks/useSortFilter.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { SortDir } from '../views/ContactsTable';
 
+export type SortState<K extends string> = { key: K | null; dir: SortDir };
+
 export function useSortFilter<K extends string, F>(defaultFilters: F) {
   const [sort, setSort] = useState<{ key: K | null; dir: SortDir }>({ key: null, dir: 'asc' });
   const [filters, setFilters] = useState<F>(defaultFilters);

--- a/src/renderer/src/views/BackupSection.tsx
+++ b/src/renderer/src/views/BackupSection.tsx
@@ -24,13 +24,16 @@ export default function BackupSection() {
   const autoBackupResultTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
     window.sourcerer.getAutoBackupSettings().then(({ enabled, destPath, maxCount }) => {
+      if (cancelled) return;
       setAutoBackupEnabled(enabled);
       setAutoBackupDestPath(destPath);
       setAutoBackupMaxCount(maxCount);
       setAutoBackupMaxCountInput(String(maxCount));
     });
     return () => {
+      cancelled = true;
       if (backupSavedTimerRef.current) clearTimeout(backupSavedTimerRef.current);
       if (autoBackupResultTimerRef.current) clearTimeout(autoBackupResultTimerRef.current);
     };

--- a/src/renderer/src/views/BackupSection.tsx
+++ b/src/renderer/src/views/BackupSection.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useRef, useState } from 'react';
+import Button from '../shell/Button';
+import Toggle from './SettingsToggle';
+
+export default function BackupSection() {
+  const [backingUp, setBackingUp] = useState(false);
+  const [backupError, setBackupError] = useState<string | null>(null);
+  const [exportConfirm, setExportConfirm] = useState(false);
+  const [backupSaved, setBackupSaved] = useState(false);
+  const [exportPassword, setExportPassword] = useState('');
+  const [restoreConfirm, setRestoreConfirm] = useState(false);
+  const [restorePassword, setRestorePassword] = useState('');
+  const [restoringBackup, setRestoringBackup] = useState(false);
+  const [restoreError, setRestoreError] = useState<string | null>(null);
+
+  const [autoBackupEnabled, setAutoBackupEnabled] = useState(false);
+  const [autoBackupDestPath, setAutoBackupDestPath] = useState<string | null>(null);
+  const [autoBackupMaxCount, setAutoBackupMaxCount] = useState(10);
+  const [autoBackupMaxCountInput, setAutoBackupMaxCountInput] = useState('10');
+  const [autoBackupRunning, setAutoBackupRunning] = useState(false);
+  const [autoBackupResult, setAutoBackupResult] = useState<{ kind: 'success' | 'error'; message: string } | null>(null);
+
+  const backupSavedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const autoBackupResultTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    window.sourcerer.getAutoBackupSettings().then(({ enabled, destPath, maxCount }) => {
+      setAutoBackupEnabled(enabled);
+      setAutoBackupDestPath(destPath);
+      setAutoBackupMaxCount(maxCount);
+      setAutoBackupMaxCountInput(String(maxCount));
+    });
+    return () => {
+      if (backupSavedTimerRef.current) clearTimeout(backupSavedTimerRef.current);
+      if (autoBackupResultTimerRef.current) clearTimeout(autoBackupResultTimerRef.current);
+    };
+  }, []);
+
+  async function handleExportBackup() {
+    if (!exportPassword) return;
+    setBackingUp(true);
+    setBackupError(null);
+    try {
+      const result = await window.sourcerer.exportBackup(exportPassword);
+      if (result.success) {
+        setExportConfirm(false);
+        setExportPassword('');
+        setBackupSaved(true);
+        if (backupSavedTimerRef.current) clearTimeout(backupSavedTimerRef.current);
+        backupSavedTimerRef.current = setTimeout(() => setBackupSaved(false), 3000);
+      } else if (result.error) {
+        setBackupError(result.error);
+      }
+    } catch {
+      setBackupError('Export failed. Please try again.');
+    } finally {
+      setBackingUp(false);
+    }
+  }
+
+  async function handleRestoreBackup() {
+    if (!restorePassword) return;
+    setRestoringBackup(true);
+    setRestoreError(null);
+    try {
+      const result = await window.sourcerer.restoreBackup(restorePassword);
+      if (result.canceled) {
+        setRestoreConfirm(false);
+        setRestorePassword('');
+        return;
+      }
+      if (!result.success) {
+        setRestoreError(result.error ?? 'Restore failed.');
+      }
+    } catch {
+      setRestoreError('Restore failed. Please try again.');
+    } finally {
+      setRestoringBackup(false);
+    }
+  }
+
+  async function handleChooseBackupFolder() {
+    const chosen = await window.sourcerer.chooseBackupFolder();
+    if (!chosen) return;
+    setAutoBackupDestPath(chosen);
+    await window.sourcerer.setAutoBackupSettings({ destPath: chosen });
+  }
+
+  async function handleAutoBackupToggle(enabled: boolean) {
+    setAutoBackupEnabled(enabled);
+    await window.sourcerer.setAutoBackupSettings({ enabled });
+  }
+
+  async function handleAutoBackupMaxCountBlur() {
+    const n = parseInt(autoBackupMaxCountInput, 10);
+    if (!isNaN(n) && n >= 1) {
+      setAutoBackupMaxCount(n);
+      await window.sourcerer.setAutoBackupSettings({ maxCount: n });
+    } else {
+      setAutoBackupMaxCountInput(String(autoBackupMaxCount));
+    }
+  }
+
+  async function handleRunAutoBackupNow() {
+    setAutoBackupRunning(true);
+    setAutoBackupResult(null);
+    const result = await window.sourcerer.runAutoBackup();
+    setAutoBackupRunning(false);
+    setAutoBackupResult(result.success
+      ? { kind: 'success', message: 'Backup saved.' }
+      : { kind: 'error', message: result.error ?? 'Backup failed.' });
+    if (autoBackupResultTimerRef.current) clearTimeout(autoBackupResultTimerRef.current);
+    autoBackupResultTimerRef.current = setTimeout(() => setAutoBackupResult(null), 3000);
+  }
+
+  return (
+    <>
+      <div className="sv-section">
+        <div className="sv-section-title">Backup</div>
+        {!exportConfirm ? (
+          <div className="sv-field">
+            <div className="sv-backup-export-restore">
+              <div className="sv-hint">
+                Save your encrypted database as a <code>.sourcerer-backup</code> file. The backup is encrypted with your master password — only someone with your password can restore it.
+              </div>
+              <div className="sv-inline-actions">
+                <Button variant="accent" size="sm" onClick={() => { setExportConfirm(true); setBackupError(null); setExportPassword(''); setBackupSaved(false); }}>
+                  Export backup
+                </Button>
+                {backupSaved && <span className="sv-backup-saved">Backup saved.</span>}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="sv-wipe-confirm">
+            <p className="sv-wipe-warning">
+              Enter your master password to encrypt the backup file.
+            </p>
+            <div className="sv-wipe-row">
+              <input
+                className="sv-input sv-backup-pw-input"
+                type="password"
+                placeholder="Master password"
+                value={exportPassword}
+                onChange={(e) => { setExportPassword(e.target.value); setBackupError(null); }}
+                onKeyDown={(e) => { if (e.key === 'Enter' && exportPassword && !backingUp) handleExportBackup(); }}
+                autoComplete="current-password"
+                disabled={backingUp}
+              />
+              <Button
+                variant="accent"
+                size="sm"
+                onClick={handleExportBackup}
+                disabled={backingUp || !exportPassword}
+              >
+                {backingUp ? 'Exporting…' : 'Export backup'}
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => { setExportConfirm(false); setExportPassword(''); setBackupError(null); }}
+                disabled={backingUp}
+              >
+                Cancel
+              </Button>
+            </div>
+            {backupError && <div className="sv-error-inline">{backupError}</div>}
+          </div>
+        )}
+        {!restoreConfirm ? (
+          <div className="sv-field">
+            <div>
+              <div className="sv-hint">
+                Restore a <code>.sourcerer-backup</code> file. Your current database will be permanently replaced.
+              </div>
+              <Button
+                variant="accent"
+                size="sm"
+                onClick={() => { setRestoreConfirm(true); setRestoreError(null); setRestorePassword(''); }}
+              >
+                Restore from backup
+              </Button>
+              {restoreError && <div className="sv-error-inline">{restoreError}</div>}
+            </div>
+          </div>
+        ) : (
+          <div className="sv-wipe-confirm">
+            <p className="sv-wipe-warning">
+              Restoring a backup will permanently overwrite your current database and cannot be undone.
+              Enter the master password used when the backup was created, then choose the file.
+            </p>
+            <div className="sv-wipe-row">
+              <input
+                className="sv-input"
+                type="password"
+                placeholder="Backup password"
+                value={restorePassword}
+                onChange={(e) => { setRestorePassword(e.target.value); setRestoreError(null); }}
+                onKeyDown={(e) => { if (e.key === 'Enter' && restorePassword && !restoringBackup) handleRestoreBackup(); }}
+                autoComplete="current-password"
+                disabled={restoringBackup}
+              />
+              <Button
+                variant="accent"
+                size="sm"
+                onClick={handleRestoreBackup}
+                disabled={restoringBackup || !restorePassword}
+              >
+                {restoringBackup ? 'Restoring…' : 'Choose backup file…'}
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => { setRestoreConfirm(false); setRestorePassword(''); setRestoreError(null); }}
+                disabled={restoringBackup}
+              >
+                Cancel
+              </Button>
+            </div>
+            {restoreError && <div className="sv-error-inline">{restoreError}</div>}
+          </div>
+        )}
+      </div>
+
+      <div className="sv-section">
+        <div className="sv-section-title">Automatic backups</div>
+        <div className="sv-field">
+          <div className="sv-hint">
+            Choose a folder and Sourcerer will silently save an encrypted backup on every clean quit
+            and once per day while the app is running. Backups use the same format as manual exports
+            and can be restored using your master password.
+          </div>
+        </div>
+        <div className="sv-field">
+          <label className="sv-label">Backup folder</label>
+          <div className="sv-row">
+            <code className="sv-path-code">
+              {autoBackupDestPath ?? 'No folder selected'}
+            </code>
+            <Button
+              variant="accent"
+              size="sm"
+              onClick={handleChooseBackupFolder}
+            >
+              Choose folder…
+            </Button>
+          </div>
+        </div>
+        <Toggle
+          checked={autoBackupEnabled}
+          onChange={handleAutoBackupToggle}
+          label="Enable automatic backups"
+          hint={autoBackupDestPath ? undefined : 'Choose a backup folder first.'}
+          disabled={!autoBackupDestPath}
+        />
+        <div className="sv-field sv-field--inline-row">
+          <label className="sv-label">Max backups to keep</label>
+          <div className="sv-inline-actions">
+            <input
+              className="sv-input sv-input--short"
+              type="number"
+              min={1}
+              value={autoBackupMaxCountInput}
+              onChange={(e) => setAutoBackupMaxCountInput(e.target.value)}
+              onBlur={handleAutoBackupMaxCountBlur}
+              disabled={!autoBackupDestPath || !autoBackupEnabled}
+            />
+            <Button
+              variant="accent"
+              size="sm"
+              onClick={handleRunAutoBackupNow}
+              disabled={autoBackupRunning || !autoBackupDestPath || !autoBackupEnabled}
+            >
+              {autoBackupRunning ? 'Backing up…' : 'Back up now'}
+            </Button>
+            {autoBackupResult && (
+              <span className={autoBackupResult.kind === 'success' ? 'sv-backup-saved' : 'sv-error-inline'}>{autoBackupResult.message}</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/renderer/src/views/BulkBar.tsx
+++ b/src/renderer/src/views/BulkBar.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { StatusOption, PriorityOption } from '@shared/types';
+import { useClickOutside } from '../hooks/useClickOutside';
 import Button from '../shell/Button';
 
 interface Props {
@@ -27,10 +28,15 @@ export default function BulkBar({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [bulkWorking, setBulkWorking] = useState(false);
   const [showBulkActions, setShowBulkActions] = useState(false);
+  const bulkActionsRef = useRef<HTMLDivElement>(null);
+
+  const handleCloseBulkActions = useCallback(() => setShowBulkActions(false), []);
+  useClickOutside(bulkActionsRef, handleCloseBulkActions, { isOpen: showBulkActions });
 
   useEffect(() => {
     setConfirmRemove(false);
     setConfirmDelete(false);
+    setShowBulkActions(false);
   }, [checkedCount]);
 
   async function handleRemove() {
@@ -155,7 +161,7 @@ export default function BulkBar({
               </select>
             </div>
           )}
-          <div className="bulk-bar-element bulk-bar-element--right bulk-actions-wrap">
+          <div className="bulk-bar-element bulk-bar-element--right bulk-actions-wrap" ref={bulkActionsRef}>
             <button
               className="bulk-actions-trigger"
               onClick={() => setShowBulkActions((v) => !v)}

--- a/src/renderer/src/views/BulkBar.tsx
+++ b/src/renderer/src/views/BulkBar.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState } from 'react';
+import type { StatusOption, PriorityOption } from '@shared/types';
+import Button from '../shell/Button';
+
+interface Props {
+  checkedCount: number;
+  statusOptions: StatusOption[];
+  priorityOptions: PriorityOption[];
+  onClearSelection: () => void;
+  onRemove: () => Promise<void>;
+  onDelete: () => Promise<void>;
+  onSetStatus: (status: string | null) => Promise<void>;
+  onSetPriority: (priority: string | null) => Promise<void>;
+}
+
+export default function BulkBar({
+  checkedCount,
+  statusOptions,
+  priorityOptions,
+  onClearSelection,
+  onRemove,
+  onDelete,
+  onSetStatus,
+  onSetPriority,
+}: Props) {
+  const [confirmRemove, setConfirmRemove] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [bulkWorking, setBulkWorking] = useState(false);
+  const [showBulkActions, setShowBulkActions] = useState(false);
+
+  useEffect(() => {
+    setConfirmRemove(false);
+    setConfirmDelete(false);
+  }, [checkedCount]);
+
+  async function handleRemove() {
+    setBulkWorking(true);
+    try { await onRemove(); } finally { setBulkWorking(false); setConfirmRemove(false); }
+  }
+
+  async function handleDelete() {
+    setBulkWorking(true);
+    try { await onDelete(); } finally { setBulkWorking(false); setConfirmDelete(false); }
+  }
+
+  async function handleSetStatus(status: string | null) {
+    setBulkWorking(true);
+    try { await onSetStatus(status); } finally { setBulkWorking(false); }
+  }
+
+  async function handleSetPriority(priority: string | null) {
+    setBulkWorking(true);
+    try { await onSetPriority(priority); } finally { setBulkWorking(false); }
+  }
+
+  return (
+    <div className="bulk-bar">
+      <div className="bulk-bar-element">
+        <span className="bulk-bar-count">{checkedCount} selected</span>
+        <button
+          className="bulk-bar-clear"
+          onClick={onClearSelection}
+          title="Clear selection"
+        >
+          ×
+        </button>
+      </div>
+      {confirmRemove ? (
+        <div className="bulk-bar-element">
+          <span className="bulk-delete-confirm-text">
+            Remove {checkedCount} contact{checkedCount !== 1 ? 's' : ''} from this project?
+          </span>
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={handleRemove}
+            disabled={bulkWorking}
+          >
+            {bulkWorking ? 'Removing…' : 'Confirm remove'}
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setConfirmRemove(false)}
+            disabled={bulkWorking}
+          >
+            Cancel
+          </Button>
+        </div>
+      ) : confirmDelete ? (
+        <div className="bulk-bar-element">
+          <span className="bulk-delete-confirm-text">
+            Permanently delete {checkedCount} contact{checkedCount !== 1 ? 's' : ''}?
+          </span>
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={handleDelete}
+            disabled={bulkWorking}
+          >
+            {bulkWorking ? 'Deleting…' : 'Confirm delete'}
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setConfirmDelete(false)}
+            disabled={bulkWorking}
+          >
+            Cancel
+          </Button>
+        </div>
+      ) : (
+        <>
+          {statusOptions.length > 0 && (
+            <div className="bulk-bar-element">
+              <label className="bulk-bar-label">Status</label>
+              <select
+                className="bulk-bar-select"
+                value=""
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (v === '__clear__') { handleSetStatus(null); return; }
+                  const opt = statusOptions.find((o) => o.id === v);
+                  if (opt) handleSetStatus(opt.label);
+                }}
+                disabled={bulkWorking}
+              >
+                <option value="" disabled>Set status</option>
+                {statusOptions.map((o) => (
+                  <option key={o.id} value={o.id}>{o.label}</option>
+                ))}
+                <option value="__clear__">— clear —</option>
+              </select>
+            </div>
+          )}
+          {priorityOptions.length > 0 && (
+            <div className="bulk-bar-element">
+              <label className="bulk-bar-label">Priority</label>
+              <select
+                className="bulk-bar-select"
+                value=""
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (v === '__clear__') { handleSetPriority(null); return; }
+                  const opt = priorityOptions.find((o) => o.id === v);
+                  if (opt) handleSetPriority(opt.label);
+                }}
+                disabled={bulkWorking}
+              >
+                <option value="" disabled>Set priority</option>
+                {priorityOptions.map((o) => (
+                  <option key={o.id} value={o.id}>{o.label}</option>
+                ))}
+                <option value="__clear__">— clear —</option>
+              </select>
+            </div>
+          )}
+          <div className="bulk-bar-element bulk-bar-element--right bulk-actions-wrap">
+            <button
+              className="bulk-actions-trigger"
+              onClick={() => setShowBulkActions((v) => !v)}
+              disabled={bulkWorking}
+            >
+              Remove from…
+            </button>
+            {showBulkActions && (
+              <div className="bulk-actions-menu">
+                <button
+                  className="bulk-actions-item bulk-actions-item--danger"
+                  onClick={() => { setShowBulkActions(false); setConfirmRemove(true); }}
+                >
+                  Project
+                </button>
+                <button
+                  className="bulk-actions-item bulk-actions-item--danger"
+                  onClick={() => { setShowBulkActions(false); setConfirmDelete(true); }}
+                >
+                  Sourcerer
+                </button>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/src/views/ProfileSection.tsx
+++ b/src/renderer/src/views/ProfileSection.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useRef, useState } from 'react';
+import type { User } from '@shared/types';
+import { isValidEmail } from '../contacts/contactValidation';
+import Button from '../shell/Button';
+
+interface Props {
+  user: User | null;
+  onUserUpdated: (user: User) => void;
+}
+
+export default function ProfileSection({ user, onUserUpdated }: Props) {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [profileSaving, setProfileSaving] = useState(false);
+  const [profileSaved, setProfileSaved] = useState(false);
+  const emailValid = !email.trim() || isValidEmail(email);
+  const profileSavedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordSaving, setPasswordSaving] = useState(false);
+  const [passwordResult, setPasswordResult] = useState<{ ok: boolean; msg: string } | null>(null);
+
+  useEffect(() => {
+    if (user) {
+      setFirstName(user.first_name);
+      setLastName(user.last_name);
+      setEmail(user.email);
+    }
+  }, [user?.id]);
+
+  useEffect(() => {
+    return () => {
+      if (profileSavedTimerRef.current) clearTimeout(profileSavedTimerRef.current);
+    };
+  }, []);
+
+  const profileDirty =
+    user &&
+    (firstName !== user.first_name || lastName !== user.last_name || email !== user.email);
+
+  async function handleProfileSave() {
+    if (!firstName.trim() || !email.trim() || !isValidEmail(email)) return;
+    setProfileSaving(true);
+    try {
+      const updated = await window.sourcerer.updateUser({ firstName, lastName, email });
+      onUserUpdated(updated);
+      setProfileSaved(true);
+      if (profileSavedTimerRef.current) clearTimeout(profileSavedTimerRef.current);
+      profileSavedTimerRef.current = setTimeout(() => setProfileSaved(false), 2000);
+    } finally {
+      setProfileSaving(false);
+    }
+  }
+
+  async function handleChangePassword() {
+    if (newPassword.length < 12) {
+      setPasswordResult({ ok: false, msg: 'New password must be at least 12 characters.' });
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setPasswordResult({ ok: false, msg: 'New passwords do not match.' });
+      return;
+    }
+    setPasswordSaving(true);
+    setPasswordResult(null);
+    try {
+      const result = await window.sourcerer.changePassword(currentPassword, newPassword);
+      if (result.success) {
+        setCurrentPassword('');
+        setNewPassword('');
+        setConfirmPassword('');
+        setPasswordResult({ ok: true, msg: 'Password updated successfully.' });
+      } else {
+        setPasswordResult({ ok: false, msg: result.error ?? 'Failed to change password.' });
+      }
+    } finally {
+      setPasswordSaving(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="sv-section">
+        <div className="sv-section-title">Profile</div>
+        <p className="sv-hint">Your name and email are attached to notes and interactions you log across projects.</p>
+        <div className="sv-fields">
+          <div className="sv-field">
+            <label className="sv-label">First name</label>
+            <input
+              className="sv-input"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleProfileSave(); }}
+            />
+          </div>
+          <div className="sv-field">
+            <label className="sv-label">Last name</label>
+            <input
+              className="sv-input"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleProfileSave(); }}
+            />
+          </div>
+          <div className="sv-field sv-field--full">
+            <label className="sv-label">Email</label>
+            <input
+              className="sv-input"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleProfileSave(); }}
+            />
+            {!emailValid && (
+              <p className="sv-field-error">Enter a valid email address.</p>
+            )}
+          </div>
+        </div>
+        <div className="sv-profile-actions">
+          <Button
+            variant="accent"
+            size="sm"
+            onClick={handleProfileSave}
+            disabled={profileSaving || !profileDirty || !firstName.trim() || !email.trim() || !emailValid}
+          >
+            {profileSaved ? 'Saved!' : profileSaving ? 'Saving…' : 'Save profile'}
+          </Button>
+        </div>
+      </div>
+
+      <div className="sv-section">
+        <div className="sv-section-title">Security</div>
+        <p className="sv-hint">
+          Change your Sourcerer password. You'll need to enter your current password to confirm the change.
+        </p>
+        <div className="sv-fields">
+          <div className="sv-field sv-field--full">
+            <label className="sv-label">Current password</label>
+            <input
+              className="sv-input"
+              type="password"
+              value={currentPassword}
+              onChange={(e) => { setCurrentPassword(e.target.value); setPasswordResult(null); }}
+              autoComplete="current-password"
+            />
+          </div>
+          <div className="sv-field">
+            <label className="sv-label">New password</label>
+            <input
+              className="sv-input"
+              type="password"
+              value={newPassword}
+              onChange={(e) => { setNewPassword(e.target.value); setPasswordResult(null); }}
+              autoComplete="new-password"
+            />
+          </div>
+          <div className="sv-field">
+            <label className="sv-label">Confirm new password</label>
+            <input
+              className="sv-input"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => { setConfirmPassword(e.target.value); setPasswordResult(null); }}
+              autoComplete="new-password"
+              onKeyDown={(e) => { if (e.key === 'Enter') handleChangePassword(); }}
+            />
+          </div>
+        </div>
+        <p className="sv-hint sv-hint--small">
+          Minimum 12 characters. Tip: a passphrase like "coral fence orbit lamp" is easier to remember and just as strong.
+        </p>
+        {passwordResult && (
+          <p className={passwordResult.ok ? 'sv-success' : 'sv-error-inline'}>
+            {passwordResult.msg}
+          </p>
+        )}
+        <div className="sv-profile-actions">
+          <Button
+            variant="accent"
+            size="sm"
+            onClick={handleChangePassword}
+            disabled={passwordSaving || !currentPassword || !newPassword || !confirmPassword}
+          >
+            {passwordSaving ? 'Updating…' : 'Update password'}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/renderer/src/views/ProjectView.tsx
+++ b/src/renderer/src/views/ProjectView.tsx
@@ -1,17 +1,18 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Project, ProjectContactRow, StatusOption, PriorityOption, ImportResult, User } from '@shared/types';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { useSortFilter } from '../hooks/useSortFilter';
+import { useProjectContacts } from '../hooks/useProjectContacts';
 import ImportResultModal from './ImportResultModal';
 import ContactDetail from '../contacts/ContactDetail';
 import SetupPayloadModal from '../shell/SetupPayloadModal';
 import Modal from '../shell/Modal';
 import Button from '../shell/Button';
+import BulkBar from './BulkBar';
 import ContactsTable, {
   type ProjectFilters as Filters,
   DEFAULT_PROJECT_FILTERS as DEFAULT_FILTERS,
   isProjectFilterActive as isFilterActive,
-  buildOrderMap,
 } from './ContactsTable';
 import './View.css';
 import './AllContacts.css';
@@ -61,17 +62,10 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
   const [drawerClosing, setDrawerClosing] = useState(false);
   const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
   const lastCheckedIdRef = useRef<string | null>(null);
-  const [confirmDelete, setConfirmDelete] = useState(false);
-  const [confirmRemove, setConfirmRemove] = useState(false);
-  const [showUnshareModal, setShowUnshareModal] = useState(false);
-  const [confirmRegen, setConfirmRegen] = useState(false);
-  const [showRotateModal, setShowRotateModal] = useState(false);
-  const [bulkWorking, setBulkWorking] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [syncError, setSyncError] = useState<string | null>(null);
   const [fileUnreachable, setFileUnreachable] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
-  const [showBulkActions, setShowBulkActions] = useState(false);
   const [exporting, setExporting] = useState(false);
   const { sort, filters, setFilter, handleSort, resetAll: resetSortFilter } = useSortFilter<SortKey, Filters>(DEFAULT_FILTERS);
   const [openFilter, setOpenFilter] = useState<string | null>(null);
@@ -82,15 +76,15 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
   const [editName, setEditName] = useState('');
   const [editDescription, setEditDescription] = useState('');
   const [editSubmitting, setEditSubmitting] = useState(false);
+  const [showUnshareModal, setShowUnshareModal] = useState(false);
+  const [confirmRegen, setConfirmRegen] = useState(false);
+  const [showRotateModal, setShowRotateModal] = useState(false);
   const exportMenuRef = useRef<HTMLDivElement>(null);
-  const bulkActionsRef = useRef<HTMLDivElement>(null);
   const selectAllRef = useRef<HTMLInputElement>(null);
   const syncStartedAt = useRef<number>(0);
 
   const handleCloseExportMenu = useCallback(() => setShowExportMenu(false), []);
   useClickOutside(exportMenuRef, handleCloseExportMenu, { isOpen: showExportMenu });
-  const handleCloseBulkActions = useCallback(() => setShowBulkActions(false), []);
-  useClickOutside(bulkActionsRef, handleCloseBulkActions, { isOpen: showBulkActions });
 
   const projectId = project?.id;
   const refresh = useCallback(() => {
@@ -101,8 +95,6 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
   useEffect(() => {
     setSelectedId(null);
     setCheckedIds(new Set());
-    setConfirmDelete(false);
-    setConfirmRemove(false);
     setRows([]);
     resetSortFilter();
     setOpenFilter(null);
@@ -117,7 +109,6 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
     window.sourcerer.listPriorityOptions().then(setPriorityOptions);
   }, []);
 
-  // Open a contact navigated from the Timeline view
   useEffect(() => {
     if (openContactId) {
       setSelectedId(openContactId);
@@ -262,8 +253,16 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
     }
   }
 
-  // Bulk selection handlers (allChecked/someChecked are computed after displayed is built below)
   const checkedCount = checkedIds.size;
+
+  const displayed = useProjectContacts(rows, filters, sort, statusOptions, priorityOptions);
+
+  const allChecked = displayed.length > 0 && displayed.every((r) => checkedIds.has(r.id));
+  const someChecked = !allChecked && displayed.some((r) => checkedIds.has(r.id));
+
+  useEffect(() => {
+    if (selectAllRef.current) selectAllRef.current.indeterminate = someChecked;
+  }, [someChecked]);
 
   function toggleCheck(id: string, e: React.MouseEvent) {
     e.stopPropagation();
@@ -280,8 +279,6 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
           else rangeIds.forEach((rid) => next.add(rid));
           return next;
         });
-        setConfirmDelete(false);
-        setConfirmRemove(false);
         return;
       }
     }
@@ -292,8 +289,6 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
       else next.add(id);
       return next;
     });
-    setConfirmDelete(false);
-    setConfirmRemove(false);
   }
 
   function toggleAll() {
@@ -302,186 +297,47 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
     } else {
       setCheckedIds(new Set(displayed.map((r) => r.id)));
     }
-    setConfirmDelete(false);
-    setConfirmRemove(false);
   }
 
   async function handleBulkRemove() {
     if (!project) return;
-    setBulkWorking(true);
-    try {
-      const ids = [...checkedIds];
-      const results = await Promise.allSettled(
-        ids.map((id) => window.sourcerer.removeFromProject(id, project.id)),
-      );
-      const removed = new Set(ids.filter((_, i) => results[i].status === 'fulfilled'));
-      setRows((prev) => prev.filter((r) => !removed.has(r.id)));
-      if (selectedId && removed.has(selectedId)) setSelectedId(null);
-      setCheckedIds((prev) => new Set([...prev].filter((id) => !removed.has(id))));
-      setConfirmRemove(false);
-    } finally {
-      setBulkWorking(false);
-    }
+    const ids = [...checkedIds];
+    const results = await Promise.allSettled(
+      ids.map((id) => window.sourcerer.removeFromProject(id, project.id)),
+    );
+    const removed = new Set(ids.filter((_, i) => results[i].status === 'fulfilled'));
+    setRows((prev) => prev.filter((r) => !removed.has(r.id)));
+    if (selectedId && removed.has(selectedId)) setSelectedId(null);
+    setCheckedIds((prev) => new Set([...prev].filter((id) => !removed.has(id))));
   }
 
   async function handleBulkSetStatus(status: string | null) {
     if (!project) return;
-    setBulkWorking(true);
-    try {
-      const membershipIds = rows.filter((r) => checkedIds.has(r.id)).map((r) => r.membership_id);
-      await window.sourcerer.bulkUpdateMemberships({ membershipIds, status });
-      setRows((prev) => prev.map((r) => checkedIds.has(r.id) ? { ...r, status } : r));
-    } finally {
-      setBulkWorking(false);
-    }
+    const membershipIds = rows.filter((r) => checkedIds.has(r.id)).map((r) => r.membership_id);
+    await window.sourcerer.bulkUpdateMemberships({ membershipIds, status });
+    setRows((prev) => prev.map((r) => checkedIds.has(r.id) ? { ...r, status } : r));
   }
 
   async function handleBulkSetPriority(priority: string | null) {
     if (!project) return;
-    setBulkWorking(true);
-    try {
-      const membershipIds = rows.filter((r) => checkedIds.has(r.id)).map((r) => r.membership_id);
-      await window.sourcerer.bulkUpdateMemberships({ membershipIds, priority });
-      setRows((prev) => prev.map((r) => checkedIds.has(r.id) ? { ...r, priority } : r));
-    } finally {
-      setBulkWorking(false);
-    }
+    const membershipIds = rows.filter((r) => checkedIds.has(r.id)).map((r) => r.membership_id);
+    await window.sourcerer.bulkUpdateMemberships({ membershipIds, priority });
+    setRows((prev) => prev.map((r) => checkedIds.has(r.id) ? { ...r, priority } : r));
   }
 
   async function handleBulkDelete() {
-    setBulkWorking(true);
-    try {
-      const ids = [...checkedIds];
-      const results = await Promise.allSettled(ids.map((id) => window.sourcerer.deleteContact(id)));
-      const deleted = new Set(ids.filter((_, i) => results[i].status === 'fulfilled'));
-      setRows((prev) => prev.filter((r) => !deleted.has(r.id)));
-      if (selectedId && deleted.has(selectedId)) setSelectedId(null);
-      setCheckedIds((prev) => new Set([...prev].filter((id) => !deleted.has(id))));
-      setConfirmDelete(false);
-    } finally {
-      setBulkWorking(false);
-    }
+    const ids = [...checkedIds];
+    const results = await Promise.allSettled(ids.map((id) => window.sourcerer.deleteContact(id)));
+    const deleted = new Set(ids.filter((_, i) => results[i].status === 'fulfilled'));
+    setRows((prev) => prev.filter((r) => !deleted.has(r.id)));
+    if (selectedId && deleted.has(selectedId)) setSelectedId(null);
+    setCheckedIds((prev) => new Set([...prev].filter((id) => !deleted.has(id))));
   }
 
   function toggleFilter(col: string) {
     setOpenFilter((prev) => (prev === col ? null : col));
   }
 
-  const displayed = useMemo(() => {
-    const statusOrderMap = buildOrderMap(statusOptions);
-    const priorityOrderMap = buildOrderMap(priorityOptions);
-    const now = Math.floor(Date.now() / 1000);
-    let result = rows;
-
-    if (filters.name) {
-      const q = filters.name.toLowerCase();
-      result = result.filter((r) => r.name.toLowerCase().includes(q));
-    }
-    if (filters.organization) {
-      const q = filters.organization.toLowerCase();
-      result = result.filter((r) => (r.organization ?? '').toLowerCase().includes(q));
-    }
-    if (filters.theme) {
-      const q = filters.theme.toLowerCase();
-      result = result.filter((r) => (r.theme ?? '').toLowerCase().includes(q));
-    }
-    if (filters.notes) {
-      const q = filters.notes.toLowerCase();
-      result = result.filter((r) => (r.notes ?? '').toLowerCase().includes(q));
-    }
-    if (filters.email) {
-      const q = filters.email.toLowerCase();
-      result = result.filter((r) => (r.emails_raw ?? '').toLowerCase().includes(q));
-    }
-    if (filters.phone) {
-      const q = filters.phone.toLowerCase();
-      result = result.filter((r) => (r.phones_raw ?? '').toLowerCase().includes(q));
-    }
-    if (filters.hasEmail !== null) {
-      result = result.filter((r) => (filters.hasEmail ? r.has_email === 1 : r.has_email === 0));
-    }
-    if (filters.hasPhone !== null) {
-      result = result.filter((r) => (filters.hasPhone ? r.has_phone === 1 : r.has_phone === 0));
-    }
-    if (filters.dateLastContacted === 'never') {
-      result = result.filter((r) => r.date_last_contacted === null);
-    } else if (filters.dateLastContacted === 'contacted') {
-      result = result.filter((r) => r.date_last_contacted !== null);
-    } else if (filters.dateLastContacted === 'not_30') {
-      result = result.filter(
-        (r) => r.date_last_contacted === null || r.date_last_contacted < now - 30 * 86400,
-      );
-    } else if (filters.dateLastContacted === 'not_90') {
-      result = result.filter(
-        (r) => r.date_last_contacted === null || r.date_last_contacted < now - 90 * 86400,
-      );
-    }
-    if (filters.dateAddedFrom) {
-      const from = Math.floor(new Date(filters.dateAddedFrom).getTime() / 1000);
-      result = result.filter((r) => r.membership_created_at >= from);
-    }
-    if (filters.dateAddedTo) {
-      const to = Math.floor(new Date(filters.dateAddedTo).getTime() / 1000) + 86399;
-      result = result.filter((r) => r.membership_created_at <= to);
-    }
-    if (filters.status.length > 0) {
-      result = result.filter((r) => filters.status.includes(r.status ?? ''));
-    }
-    if (filters.priority.length > 0) {
-      result = result.filter((r) => filters.priority.includes(r.priority ?? ''));
-    }
-    if (filters.reporter.length > 0) {
-      result = result.filter((r) => filters.reporter.includes(r.reporter_name));
-    }
-
-    if (sort.key) {
-      const dir = sort.dir === 'asc' ? 1 : -1;
-      result = [...result].sort((a, b) => {
-        let cmp = 0;
-        if (sort.key === 'name') {
-          cmp = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
-        } else if (sort.key === 'organization') {
-          cmp = (a.organization ?? '').localeCompare(b.organization ?? '', undefined, {
-            sensitivity: 'base',
-          });
-        } else if (sort.key === 'theme') {
-          cmp = (a.theme ?? '').localeCompare(b.theme ?? '', undefined, { sensitivity: 'base' });
-        } else if (sort.key === 'status') {
-          const si = (s: string | null) => statusOrderMap.get(s ?? '') ?? 9999;
-          cmp = si(a.status) - si(b.status);
-        } else if (sort.key === 'priority') {
-          const pi = (p: string | null) => priorityOrderMap.get(p ?? '') ?? 9999;
-          cmp = pi(a.priority) - pi(b.priority);
-        } else if (sort.key === 'reporter') {
-          cmp = a.reporter_name.localeCompare(b.reporter_name, undefined, { sensitivity: 'base' });
-        } else if (sort.key === 'date_first_contacted') {
-          if (a.date_first_contacted === null && b.date_first_contacted === null) cmp = 0;
-          else if (a.date_first_contacted === null) cmp = 1;
-          else if (b.date_first_contacted === null) cmp = -1;
-          else cmp = a.date_first_contacted - b.date_first_contacted;
-        } else if (sort.key === 'date_last_contacted') {
-          if (a.date_last_contacted === null && b.date_last_contacted === null) cmp = 0;
-          else if (a.date_last_contacted === null) cmp = 1;
-          else if (b.date_last_contacted === null) cmp = -1;
-          else cmp = a.date_last_contacted - b.date_last_contacted;
-        } else if (sort.key === 'membership_created_at') {
-          cmp = a.membership_created_at - b.membership_created_at;
-        }
-        return cmp * dir;
-      });
-    }
-
-    return result;
-  }, [rows, filters, sort, statusOptions, priorityOptions]);
-
-  const allChecked = displayed.length > 0 && displayed.every((r) => checkedIds.has(r.id));
-  const someChecked = !allChecked && displayed.some((r) => checkedIds.has(r.id));
-
-  useEffect(() => {
-    if (selectAllRef.current) selectAllRef.current.indeterminate = someChecked;
-  }, [someChecked]);
-
-  // Pre-compute filter options from the unfiltered row set (not displayed)
   const reporterOptions = [
     ...new Map(rows.map((r) => [r.reporter_name, { value: r.reporter_name, label: r.reporter_name }])).values(),
   ].sort((a, b) => a.label.localeCompare(b.label));
@@ -659,135 +515,16 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
       )}
 
       {checkedCount > 0 && (
-        <div className="bulk-bar">
-          <div className="bulk-bar-element">
-            <span className="bulk-bar-count">{checkedCount} selected</span>
-            <button
-              className="bulk-bar-clear"
-              onClick={() => { setCheckedIds(new Set()); setConfirmDelete(false); setConfirmRemove(false); }}
-              title="Clear selection"
-            >
-              ×
-            </button>
-          </div>
-          {confirmRemove ? (
-            <div className="bulk-bar-element">
-              <span className="bulk-delete-confirm-text">
-                Remove {checkedCount} contact{checkedCount !== 1 ? 's' : ''} from this project?
-              </span>
-              <Button
-                variant="danger"
-                size="sm"
-                onClick={handleBulkRemove}
-                disabled={bulkWorking}
-              >
-                {bulkWorking ? 'Removing…' : 'Confirm remove'}
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => setConfirmRemove(false)}
-                disabled={bulkWorking}
-              >
-                Cancel
-              </Button>
-            </div>
-          ) : confirmDelete ? (
-            <div className="bulk-bar-element">
-              <span className="bulk-delete-confirm-text">
-                Permanently delete {checkedCount} contact{checkedCount !== 1 ? 's' : ''}?
-              </span>
-              <Button
-                variant="danger"
-                size="sm"
-                onClick={handleBulkDelete}
-                disabled={bulkWorking}
-              >
-                {bulkWorking ? 'Deleting…' : 'Confirm delete'}
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => setConfirmDelete(false)}
-                disabled={bulkWorking}
-              >
-                Cancel
-              </Button>
-            </div>
-          ) : (
-            <>
-              {statusOptions.length > 0 && (
-                <div className="bulk-bar-element">
-                  <label className="bulk-bar-label">Status</label>
-                  <select
-                    className="bulk-bar-select"
-                    value=""
-                    onChange={(e) => {
-                      const v = e.target.value;
-                      if (v === '__clear__') { handleBulkSetStatus(null); return; }
-                      const opt = statusOptions.find((o) => o.id === v);
-                      if (opt) handleBulkSetStatus(opt.label);
-                    }}
-                    disabled={bulkWorking}
-                  >
-                    <option value="" disabled>Set status</option>
-                    {statusOptions.map((o) => (
-                      <option key={o.id} value={o.id}>{o.label}</option>
-                    ))}
-                    <option value="__clear__">— clear —</option>
-                  </select>
-                </div>
-              )}
-              {priorityOptions.length > 0 && (
-                <div className="bulk-bar-element">
-                  <label className="bulk-bar-label">Priority</label>
-                  <select
-                    className="bulk-bar-select"
-                    value=""
-                    onChange={(e) => {
-                      const v = e.target.value;
-                      if (v === '__clear__') { handleBulkSetPriority(null); return; }
-                      const opt = priorityOptions.find((o) => o.id === v);
-                      if (opt) handleBulkSetPriority(opt.label);
-                    }}
-                    disabled={bulkWorking}
-                  >
-                    <option value="" disabled>Set priority</option>
-                    {priorityOptions.map((o) => (
-                      <option key={o.id} value={o.id}>{o.label}</option>
-                    ))}
-                    <option value="__clear__">— clear —</option>
-                  </select>
-                </div>
-              )}
-              <div className="bulk-bar-element bulk-bar-element--right bulk-actions-wrap" ref={bulkActionsRef}>
-                <button
-                  className="bulk-actions-trigger"
-                  onClick={() => setShowBulkActions((v) => !v)}
-                  disabled={bulkWorking}
-                >
-                  Remove from…
-                </button>
-                {showBulkActions && (
-                  <div className="bulk-actions-menu">
-                    <button
-                      className="bulk-actions-item bulk-actions-item--danger"
-                      onClick={() => { setShowBulkActions(false); setConfirmRemove(true); }}
-                    >
-                      Project
-                    </button>
-                    <button
-                      className="bulk-actions-item bulk-actions-item--danger"
-                      onClick={() => { setShowBulkActions(false); setConfirmDelete(true); }}
-                    >
-                      Sourcerer
-                    </button>
-                  </div>
-                )}
-              </div>
-            </>
-          )}
-        </div>
+        <BulkBar
+          checkedCount={checkedCount}
+          statusOptions={statusOptions}
+          priorityOptions={priorityOptions}
+          onClearSelection={() => setCheckedIds(new Set())}
+          onRemove={handleBulkRemove}
+          onDelete={handleBulkDelete}
+          onSetStatus={handleBulkSetStatus}
+          onSetPriority={handleBulkSetPriority}
+        />
       )}
 
       <div className="contacts-body">

--- a/src/renderer/src/views/SettingsToggle.tsx
+++ b/src/renderer/src/views/SettingsToggle.tsx
@@ -1,0 +1,26 @@
+export default function Toggle({ checked, onChange, label, hint, disabled }: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+  hint?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <div className={`sv-toggle-row${hint ? ' sv-toggle-row--has-hint' : ''}`}>
+      <button
+        type="button"
+        className={`sv-toggle${checked ? ' sv-toggle--on' : ''}${disabled ? ' sv-toggle--disabled' : ''}`}
+        onClick={() => !disabled && onChange(!checked)}
+        aria-pressed={checked}
+        disabled={disabled}
+      >
+        <span className="sv-toggle-knob" />
+        <span className="sv-toggle-label">{checked ? 'ON' : 'OFF'}</span>
+      </button>
+      <div>
+        <div className="sv-toggle-text">{label}</div>
+        {hint && <div className="sv-hint sv-hint--inline">{hint}</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -81,6 +81,9 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
     window.sourcerer.getCalendarUrl().then(setCalendarUrl);
     window.sourcerer.getScreenshotFolderSize().then(setScreenshotFolderBytes);
     window.sourcerer.getVaultPath().then(setVaultPath);
+    return () => {
+      if (archiveKeysSavedTimerRef.current) clearTimeout(archiveKeysSavedTimerRef.current);
+    };
   }, [user?.id]);
 
   async function handleRegenerateToken() {

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { getCountries, getCountryCallingCode } from 'libphonenumber-js';
 import type { User } from '@shared/types';
-import { isValidEmail } from '../contacts/contactValidation';
 import Button from '../shell/Button';
+import Toggle from './SettingsToggle';
+import ProfileSection from './ProfileSection';
+import BackupSection from './BackupSection';
 import './View.css';
 import './SettingsView.css';
 
@@ -10,7 +12,6 @@ interface Props {
   user: User | null;
   onUserUpdated: (user: User) => void;
 }
-
 
 const TIMEOUT_OPTIONS = [
   { label: '1 minute', seconds: 60 },
@@ -21,35 +22,7 @@ const TIMEOUT_OPTIONS = [
   { label: 'Never', seconds: 0 },
 ];
 
-function Toggle({ checked, onChange, label, hint, disabled }: { checked: boolean; onChange: (v: boolean) => void; label: string; hint?: string; disabled?: boolean }) {
-  return (
-    <div className={`sv-toggle-row${hint ? ' sv-toggle-row--has-hint' : ''}`}>
-      <button
-        type="button"
-        className={`sv-toggle${checked ? ' sv-toggle--on' : ''}${disabled ? ' sv-toggle--disabled' : ''}`}
-        onClick={() => !disabled && onChange(!checked)}
-        aria-pressed={checked}
-        disabled={disabled}
-      >
-        <span className="sv-toggle-knob" />
-        <span className="sv-toggle-label">{checked ? 'ON' : 'OFF'}</span>
-      </button>
-      <div>
-        <div className="sv-toggle-text">{label}</div>
-        {hint && <div className="sv-hint sv-hint--inline">{hint}</div>}
-      </div>
-    </div>
-  );
-}
-
 export default function SettingsView({ user, onUserUpdated }: Props) {
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
-  const [email, setEmail] = useState('');
-  const [profileSaving, setProfileSaving] = useState(false);
-  const [profileSaved, setProfileSaved] = useState(false);
-  const emailValid = !email.trim() || isValidEmail(email);
-
   const [idleTimeout, setIdleTimeout] = useState<number>(900);
   const [phoneCountry, setPhoneCountry] = useState<string>('CA');
   const [outreachRemindersEnabled, setOutreachRemindersEnabled] = useState<boolean>(true);
@@ -64,46 +37,21 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
   const [calendarRegenConfirm, setCalendarRegenConfirm] = useState(false);
   const [calendarUrl, setCalendarUrl] = useState('');
 
-  const [currentPassword, setCurrentPassword] = useState('');
-  const [newPassword, setNewPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
-  const [passwordSaving, setPasswordSaving] = useState(false);
-  const [passwordResult, setPasswordResult] = useState<{ ok: boolean; msg: string } | null>(null);
-
-  const [backingUp, setBackingUp] = useState(false);
-  const [backupError, setBackupError] = useState<string | null>(null);
-  const [exportConfirm, setExportConfirm] = useState(false);
-  const [backupSaved, setBackupSaved] = useState(false);
-  const [exportPassword, setExportPassword] = useState('');
-  const [restoreConfirm, setRestoreConfirm] = useState(false);
-  const [restorePassword, setRestorePassword] = useState('');
-  const [restoringBackup, setRestoringBackup] = useState(false);
-  const [restoreError, setRestoreError] = useState<string | null>(null);
-  const [panicWipeConfirm, setPanicWipeConfirm] = useState(false);
-  const [panicWipeInput, setPanicWipeInput] = useState('');
-  const [panicWiping, setPanicWiping] = useState(false);
   const [screenshotFolderBytes, setScreenshotFolderBytes] = useState<number>(0);
 
   const [archiveAccessKey, setArchiveAccessKey] = useState('');
   const [archiveSecretKey, setArchiveSecretKey] = useState('');
   const [archiveKeysSaved, setArchiveKeysSaved] = useState(false);
-
-  const [autoBackupEnabled, setAutoBackupEnabled] = useState(false);
-  const [autoBackupDestPath, setAutoBackupDestPath] = useState<string | null>(null);
-  const [autoBackupMaxCount, setAutoBackupMaxCount] = useState(10);
-  const [autoBackupMaxCountInput, setAutoBackupMaxCountInput] = useState('10');
-  const [autoBackupRunning, setAutoBackupRunning] = useState(false);
-  const [autoBackupResult, setAutoBackupResult] = useState<{ kind: 'success' | 'error'; message: string } | null>(null);
-
-  const profileSavedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const backupSavedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const archiveKeysSavedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const autoBackupResultTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [vaultPath, setVaultPath] = useState<string>('');
   const [movingVault, setMovingVault] = useState(false);
   const [moveVaultError, setMoveVaultError] = useState<string | null>(null);
   const [moveVaultSuccess, setMoveVaultSuccess] = useState(false);
+
+  const [panicWipeConfirm, setPanicWipeConfirm] = useState(false);
+  const [panicWipeInput, setPanicWipeInput] = useState('');
+  const [panicWiping, setPanicWiping] = useState(false);
 
   const countryOptions = useMemo(() => {
     const names = new Intl.DisplayNames([navigator.language], { type: 'region' });
@@ -118,9 +66,6 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
 
   useEffect(() => {
     if (user) {
-      setFirstName(user.first_name);
-      setLastName(user.last_name);
-      setEmail(user.email);
       setPhoneCountry(user.phone_country ?? 'CA');
       setOutreachRemindersEnabled(user.outreach_reminders_enabled !== 0);
       setOutreachRequireInteraction(user.outreach_require_interaction !== 0);
@@ -136,115 +81,7 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
     window.sourcerer.getCalendarUrl().then(setCalendarUrl);
     window.sourcerer.getScreenshotFolderSize().then(setScreenshotFolderBytes);
     window.sourcerer.getVaultPath().then(setVaultPath);
-    window.sourcerer.getAutoBackupSettings().then(({ enabled, destPath, maxCount }) => {
-      setAutoBackupEnabled(enabled);
-      setAutoBackupDestPath(destPath);
-      setAutoBackupMaxCount(maxCount);
-      setAutoBackupMaxCountInput(String(maxCount));
-    });
   }, [user?.id]);
-
-  useEffect(() => {
-    return () => {
-      if (profileSavedTimerRef.current) clearTimeout(profileSavedTimerRef.current);
-      if (backupSavedTimerRef.current) clearTimeout(backupSavedTimerRef.current);
-      if (archiveKeysSavedTimerRef.current) clearTimeout(archiveKeysSavedTimerRef.current);
-      if (autoBackupResultTimerRef.current) clearTimeout(autoBackupResultTimerRef.current);
-    };
-  }, []);
-
-  async function handleProfileSave() {
-    if (!firstName.trim() || !email.trim() || !isValidEmail(email)) return;
-    setProfileSaving(true);
-    try {
-      const updated = await window.sourcerer.updateUser({ firstName, lastName, email });
-      onUserUpdated(updated);
-      setProfileSaved(true);
-      if (profileSavedTimerRef.current) clearTimeout(profileSavedTimerRef.current);
-      profileSavedTimerRef.current = setTimeout(() => setProfileSaved(false), 2000);
-    } finally {
-      setProfileSaving(false);
-    }
-  }
-
-  async function handleChangePassword() {
-    if (newPassword.length < 12) {
-      setPasswordResult({ ok: false, msg: 'New password must be at least 12 characters.' });
-      return;
-    }
-    if (newPassword !== confirmPassword) {
-      setPasswordResult({ ok: false, msg: 'New passwords do not match.' });
-      return;
-    }
-    setPasswordSaving(true);
-    setPasswordResult(null);
-    try {
-      const result = await window.sourcerer.changePassword(currentPassword, newPassword);
-      if (result.success) {
-        setCurrentPassword('');
-        setNewPassword('');
-        setConfirmPassword('');
-        setPasswordResult({ ok: true, msg: 'Password updated successfully.' });
-      } else {
-        setPasswordResult({ ok: false, msg: result.error ?? 'Failed to change password.' });
-      }
-    } finally {
-      setPasswordSaving(false);
-    }
-  }
-
-  async function handleExportBackup() {
-    if (!exportPassword) return;
-    setBackingUp(true);
-    setBackupError(null);
-    try {
-      const result = await window.sourcerer.exportBackup(exportPassword);
-      if (result.success) {
-        setExportConfirm(false);
-        setExportPassword('');
-        setBackupSaved(true);
-        if (backupSavedTimerRef.current) clearTimeout(backupSavedTimerRef.current);
-        backupSavedTimerRef.current = setTimeout(() => setBackupSaved(false), 3000);
-      } else if (result.error) {
-        setBackupError(result.error);
-      }
-    } catch {
-      setBackupError('Export failed. Please try again.');
-    } finally {
-      setBackingUp(false);
-    }
-  }
-
-  async function handleRestoreBackup() {
-    if (!restorePassword) return;
-    setRestoringBackup(true);
-    setRestoreError(null);
-    try {
-      const result = await window.sourcerer.restoreBackup(restorePassword);
-      if (result.canceled) {
-        setRestoreConfirm(false);
-        setRestorePassword('');
-        return;
-      }
-      if (!result.success) {
-        setRestoreError(result.error ?? 'Restore failed.');
-      }
-    } catch {
-      setRestoreError('Restore failed. Please try again.');
-    } finally {
-      setRestoringBackup(false);
-    }
-  }
-
-  async function handlePanicWipe() {
-    if (panicWipeInput !== 'WIPE') return;
-    setPanicWiping(true);
-    try {
-      await window.sourcerer.panicWipe();
-    } finally {
-      setPanicWiping(false);
-    }
-  }
 
   async function handleRegenerateToken() {
     const updated = await window.sourcerer.regenerateCalendarToken();
@@ -370,28 +207,6 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
     }
   }
 
-  async function handleChooseBackupFolder() {
-    const chosen = await window.sourcerer.chooseBackupFolder();
-    if (!chosen) return;
-    setAutoBackupDestPath(chosen);
-    await window.sourcerer.setAutoBackupSettings({ destPath: chosen });
-  }
-
-  async function handleAutoBackupToggle(enabled: boolean) {
-    setAutoBackupEnabled(enabled);
-    await window.sourcerer.setAutoBackupSettings({ enabled });
-  }
-
-  async function handleAutoBackupMaxCountBlur() {
-    const n = parseInt(autoBackupMaxCountInput, 10);
-    if (!isNaN(n) && n >= 1) {
-      setAutoBackupMaxCount(n);
-      await window.sourcerer.setAutoBackupSettings({ maxCount: n });
-    } else {
-      setAutoBackupMaxCountInput(String(autoBackupMaxCount));
-    }
-  }
-
   async function handleMoveVault() {
     setMovingVault(true);
     setMoveVaultError(null);
@@ -406,21 +221,15 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
     }
   }
 
-  async function handleRunAutoBackupNow() {
-    setAutoBackupRunning(true);
-    setAutoBackupResult(null);
-    const result = await window.sourcerer.runAutoBackup();
-    setAutoBackupRunning(false);
-    setAutoBackupResult(result.success
-      ? { kind: 'success', message: 'Backup saved.' }
-      : { kind: 'error', message: result.error ?? 'Backup failed.' });
-    if (autoBackupResultTimerRef.current) clearTimeout(autoBackupResultTimerRef.current);
-    autoBackupResultTimerRef.current = setTimeout(() => setAutoBackupResult(null), 3000);
+  async function handlePanicWipe() {
+    if (panicWipeInput !== 'WIPE') return;
+    setPanicWiping(true);
+    try {
+      await window.sourcerer.panicWipe();
+    } finally {
+      setPanicWiping(false);
+    }
   }
-
-  const profileDirty =
-    user &&
-    (firstName !== user.first_name || lastName !== user.last_name || email !== user.email);
 
   return (
     <div className="view">
@@ -432,113 +241,7 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
       </div>
 
       <div className="sv-body">
-        {/* Profile */}
-        <div className="sv-section">
-          <div className="sv-section-title">Profile</div>
-          <p className="sv-hint">Your name and email are attached to notes and interactions you log across projects.</p>
-          <div className="sv-fields">
-            <div className="sv-field">
-              <label className="sv-label">First name</label>
-              <input
-                className="sv-input"
-                value={firstName}
-                onChange={(e) => setFirstName(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Enter') handleProfileSave(); }}
-              />
-            </div>
-            <div className="sv-field">
-              <label className="sv-label">Last name</label>
-              <input
-                className="sv-input"
-                value={lastName}
-                onChange={(e) => setLastName(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Enter') handleProfileSave(); }}
-              />
-            </div>
-            <div className="sv-field sv-field--full">
-              <label className="sv-label">Email</label>
-              <input
-                className="sv-input"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Enter') handleProfileSave(); }}
-              />
-              {!emailValid && (
-                <p className="sv-field-error">Enter a valid email address.</p>
-              )}
-            </div>
-          </div>
-          <div className="sv-profile-actions">
-            <Button
-              variant="accent"
-              size="sm"
-              onClick={handleProfileSave}
-              disabled={profileSaving || !profileDirty || !firstName.trim() || !email.trim() || !emailValid}
-            >
-              {profileSaved ? 'Saved!' : profileSaving ? 'Saving…' : 'Save profile'}
-            </Button>
-          </div>
-        </div>
-
-        {/* Security */}
-        <div className="sv-section">
-          <div className="sv-section-title">Security</div>
-          <p className="sv-hint">
-            Change your Sourcerer password. You'll need to enter your current password to confirm the change.
-          </p>
-          <div className="sv-fields">
-            <div className="sv-field sv-field--full">
-              <label className="sv-label">Current password</label>
-              <input
-                className="sv-input"
-                type="password"
-                value={currentPassword}
-                onChange={(e) => { setCurrentPassword(e.target.value); setPasswordResult(null); }}
-                autoComplete="current-password"
-              />
-            </div>
-            <div className="sv-field">
-              <label className="sv-label">New password</label>
-              <input
-                className="sv-input"
-                type="password"
-                value={newPassword}
-                onChange={(e) => { setNewPassword(e.target.value); setPasswordResult(null); }}
-                autoComplete="new-password"
-              />
-            </div>
-            <div className="sv-field">
-              <label className="sv-label">Confirm new password</label>
-              <input
-                className="sv-input"
-                type="password"
-                value={confirmPassword}
-                onChange={(e) => { setConfirmPassword(e.target.value); setPasswordResult(null); }}
-                autoComplete="new-password"
-                onKeyDown={(e) => { if (e.key === 'Enter') handleChangePassword(); }}
-              />
-            </div>
-          </div>
-          <p className="sv-hint sv-hint--small">
-            Minimum 12 characters. Tip: a passphrase like "coral fence orbit lamp" is easier to remember and just as strong.
-          </p>
-          {passwordResult && (
-            <p className={passwordResult.ok ? 'sv-success' : 'sv-error-inline'}>
-              {passwordResult.msg}
-            </p>
-          )}
-          <div className="sv-profile-actions">
-            <Button
-              variant="accent"
-              size="sm"
-              onClick={handleChangePassword}
-              disabled={passwordSaving || !currentPassword || !newPassword || !confirmPassword}
-            >
-              {passwordSaving ? 'Updating…' : 'Update password'}
-            </Button>
-          </div>
-        </div>
+        <ProfileSection user={user} onUserUpdated={onUserUpdated} />
 
         {/* Staleness */}
         <div className="sv-section">
@@ -812,172 +515,7 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
           {moveVaultSuccess && <p className="sv-success sv-move-vault-msg">Vault moved. You&apos;ll be asked to unlock again.</p>}
         </div>
 
-        {/* Backup */}
-        <div className="sv-section">
-          <div className="sv-section-title">Backup</div>
-          {!exportConfirm ? (
-            <div className="sv-field">
-              <div className="sv-backup-export-restore">
-                <div className="sv-hint">
-                  Save your encrypted database as a <code>.sourcerer-backup</code> file. The backup is encrypted with your master password — only someone with your password can restore it.
-                </div>
-                <div className="sv-inline-actions">
-                  <Button variant="accent" size="sm" onClick={() => { setExportConfirm(true); setBackupError(null); setExportPassword(''); setBackupSaved(false); }}>
-                    Export backup
-                  </Button>
-                  {backupSaved && <span className="sv-backup-saved">Backup saved.</span>}
-                </div>
-              </div>
-            </div>
-          ) : (
-            <div className="sv-wipe-confirm">
-              <p className="sv-wipe-warning">
-                Enter your master password to encrypt the backup file.
-              </p>
-              <div className="sv-wipe-row">
-                <input
-                  className="sv-input sv-backup-pw-input"
-                  type="password"
-                  placeholder="Master password"
-                  value={exportPassword}
-                  onChange={(e) => { setExportPassword(e.target.value); setBackupError(null); }}
-                  onKeyDown={(e) => { if (e.key === 'Enter' && exportPassword && !backingUp) handleExportBackup(); }}
-                  autoComplete="current-password"
-                  disabled={backingUp}
-                />
-                <Button
-                  variant="accent"
-                  size="sm"
-                  onClick={handleExportBackup}
-                  disabled={backingUp || !exportPassword}
-                >
-                  {backingUp ? 'Exporting…' : 'Export backup'}
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => { setExportConfirm(false); setExportPassword(''); setBackupError(null); }}
-                  disabled={backingUp}
-                >
-                  Cancel
-                </Button>
-              </div>
-              {backupError && <div className="sv-error-inline">{backupError}</div>}
-            </div>
-          )}
-          {!restoreConfirm ? (
-            <div className="sv-field">
-              <div>
-                <div className="sv-hint">
-                  Restore a <code>.sourcerer-backup</code> file. Your current database will be permanently replaced.
-                </div>
-                <Button
-                  variant="accent"
-                  size="sm"
-                  onClick={() => { setRestoreConfirm(true); setRestoreError(null); setRestorePassword(''); }}
-                >
-                  Restore from backup
-                </Button>
-                {restoreError && <div className="sv-error-inline">{restoreError}</div>}
-              </div>
-            </div>
-          ) : (
-            <div className="sv-wipe-confirm">
-              <p className="sv-wipe-warning">
-                Restoring a backup will permanently overwrite your current database and cannot be undone.
-                Enter the master password used when the backup was created, then choose the file.
-              </p>
-              <div className="sv-wipe-row">
-                <input
-                  className="sv-input"
-                  type="password"
-                  placeholder="Backup password"
-                  value={restorePassword}
-                  onChange={(e) => { setRestorePassword(e.target.value); setRestoreError(null); }}
-                  onKeyDown={(e) => { if (e.key === 'Enter' && restorePassword && !restoringBackup) handleRestoreBackup(); }}
-                  autoComplete="current-password"
-                  disabled={restoringBackup}
-                />
-                <Button
-                  variant="accent"
-                  size="sm"
-                  onClick={handleRestoreBackup}
-                  disabled={restoringBackup || !restorePassword}
-                >
-                  {restoringBackup ? 'Restoring…' : 'Choose backup file…'}
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => { setRestoreConfirm(false); setRestorePassword(''); setRestoreError(null); }}
-                  disabled={restoringBackup}
-                >
-                  Cancel
-                </Button>
-              </div>
-              {restoreError && <div className="sv-error-inline">{restoreError}</div>}
-            </div>
-          )}
-        </div>
-
-        {/* Automatic backups */}
-        <div className="sv-section">
-          <div className="sv-section-title">Automatic backups</div>
-          <div className="sv-field">
-            <div className="sv-hint">
-              Choose a folder and Sourcerer will silently save an encrypted backup on every clean quit
-              and once per day while the app is running. Backups use the same format as manual exports
-              and can be restored using your master password.
-            </div>
-          </div>
-          <div className="sv-field">
-            <label className="sv-label">Backup folder</label>
-            <div className="sv-row">
-              <code className="sv-path-code">
-                {autoBackupDestPath ?? 'No folder selected'}
-              </code>
-              <Button
-                variant="accent"
-                size="sm"
-                onClick={handleChooseBackupFolder}
-              >
-                Choose folder…
-              </Button>
-            </div>
-          </div>
-          <Toggle
-            checked={autoBackupEnabled}
-            onChange={handleAutoBackupToggle}
-            label="Enable automatic backups"
-            hint={autoBackupDestPath ? undefined : 'Choose a backup folder first.'}
-            disabled={!autoBackupDestPath}
-          />
-          <div className="sv-field sv-field--inline-row">
-            <label className="sv-label">Max backups to keep</label>
-            <div className="sv-inline-actions">
-              <input
-                className="sv-input sv-input--short"
-                type="number"
-                min={1}
-                value={autoBackupMaxCountInput}
-                onChange={(e) => setAutoBackupMaxCountInput(e.target.value)}
-                onBlur={handleAutoBackupMaxCountBlur}
-                disabled={!autoBackupDestPath || !autoBackupEnabled}
-              />
-              <Button
-                variant="accent"
-                size="sm"
-                onClick={handleRunAutoBackupNow}
-                disabled={autoBackupRunning || !autoBackupDestPath || !autoBackupEnabled}
-              >
-                {autoBackupRunning ? 'Backing up…' : 'Back up now'}
-              </Button>
-              {autoBackupResult && (
-                <span className={autoBackupResult.kind === 'success' ? 'sv-backup-saved' : 'sv-error-inline'}>{autoBackupResult.message}</span>
-              )}
-            </div>
-          </div>
-        </div>
+        <BackupSection />
 
         {/* Danger Zone */}
         <div className="sv-section sv-danger-zone">


### PR DESCRIPTION
## Summary

- **GlobalTab** (952→371 lines, #226): contact edit form extracted to `ContactEditForm.tsx`. `SOCIAL_TYPES`/`SOCIAL_META`/`KNOWN_LINK_TYPES` constants now live there (exported) since they're form-specific; GlobalTab imports what it needs for view mode.
- **SettingsView** (1043→581 lines, #233): Profile+Security block extracted to `ProfileSection.tsx`; Backup+AutoBackup block extracted to `BackupSection.tsx`. `Toggle` component moved to `SettingsToggle.tsx` so both can share it.
- **ProjectView** (977→714 lines, #229): bulk-action bar extracted to `BulkBar.tsx` (owns its own `confirmDelete`/`confirmRemove`/`bulkWorking` state, resets automatically when `checkedCount` changes). Filter+sort `useMemo` extracted to `hooks/useProjectContacts.ts`. `SortState<K>` type added to `useSortFilter` exports to support the new hook.
- **Backup export** (#381): replaced `getDatabase().backup()` with `fs.copyFile()` — SQLCipher rejects the backup API between an encrypted source and unconfigured destination; a direct file copy is safe and correct since the DB uses DELETE journal mode.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test` — 424/424 pass
- [x] Open contact in GlobalTab, click Edit — form loads pre-populated
- [x] Make a change in edit form, save — contact updates correctly
- [x] Check email collision warnings still appear in edit form
- [x] Open Settings — Profile, Security, Backup sections all render correctly
- [x] Export backup, restore flow both work
- [x] Auto-backup folder selection works
- [x] In ProjectView, select contacts → BulkBar appears with status/priority/remove actions
- [x] Confirm remove/delete flows in BulkBar work
- [x] Filter and sort in ProjectView still work correctly

Closes #226
Closes #229
Closes #233
Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)