### PR TITLE
Four small UI/doc polish fixes

### DIFF
--- a/docs/security.html
+++ b/docs/security.html
@@ -153,7 +153,7 @@
             <p>The calendar feed URL includes a persistent token. Anyone with this URL can read your upcoming reminders (but not your contacts, notes, or any other data). If you believe the URL has been compromised, regenerate the token from Settings — the old URL will immediately stop working.</p>
 
             <h3>CORS</h3>
-            <p>Cross-Origin Resource Sharing headers are set to allow requests only from the extension's own origin. Web pages cannot make requests to the local server.</p>
+            <p>CORS headers are only set when the request includes an <code>Origin</code> or <code>Referer</code> header matching an extension scheme (<code>chrome-extension://</code> or <code>moz-extension://</code>). In that case the header is reflected back to permit the request. Ordinary web pages — whose origins are <code>http://</code> or <code>https://</code> — never receive CORS headers and cannot make cross-origin requests to the local server. The session token is the primary authentication gate; CORS is a defence-in-depth measure against browser-based cross-origin attacks.</p>
           </section>
 
           <section id="panic-wipe">

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -954,10 +954,15 @@
 
 /* Scratchpad */
 .pt-draft {
+  border-bottom: 1px solid var(--color-border);
+  padding: 13px 0;
+  background: var(--color-bg);
+}
+
+.pt-draft--editing {
   border: 1px solid var(--color-border);
   padding: 10px;
   margin-bottom: 10px;
-  background: var(--color-bg);
 }
 
 /* View mode (read-only) */

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -960,6 +960,43 @@
   background: var(--color-bg);
 }
 
+/* View mode (read-only) */
+.pt-draft-view-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.pt-draft-view-label {
+  font-size: 13px;
+  font-weight: 600;
+  font-family: var(--font-serif);
+  color: var(--color-text);
+}
+
+.pt-draft-view-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.pt-draft-view-body {
+  font-size: 13px;
+  font-family: var(--font-serif);
+  color: var(--color-text-muted);
+  line-height: 1.55;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.pt-draft-view-body--empty {
+  color: var(--color-text-dim);
+  font-style: italic;
+}
+
+/* Edit mode */
 .pt-draft-header {
   display: flex;
   gap: 6px;

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -989,7 +989,7 @@
 .pt-draft-view-body {
   font-size: 13px;
   font-family: var(--font-serif);
-  color: var(--color-text-muted);
+  color: var(--color-text);
   line-height: 1.55;
   margin: 0;
 }
@@ -1046,8 +1046,9 @@
 .pt-draft-delete {
   background: none;
   border: none;
-  font-size: 16px;
-  color: var(--color-text-muted);
+  font-size: 14px;
+  line-height: 1;
+  color: var(--color-text-dim);
   cursor: pointer;
   padding: 0 4px;
   flex-shrink: 0;

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -996,7 +996,6 @@
 
 .pt-draft-view-body p {
   margin: 0;
-  white-space: pre-wrap;
   word-break: break-word;
 }
 

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -1001,6 +1001,16 @@
   font-style: italic;
 }
 
+.pt-draft-view-meta {
+  margin: 6px 0 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-dim);
+}
+
 /* Edit mode */
 .pt-draft-header {
   display: flex;

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -992,8 +992,16 @@
   color: var(--color-text-muted);
   line-height: 1.55;
   margin: 0;
+}
+
+.pt-draft-view-body p {
+  margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.pt-draft-view-body p:not(:last-child) {
+  padding-bottom: 10px;
 }
 
 .pt-draft-view-body--empty {

--- a/src/renderer/src/contacts/GlobalLogSection.tsx
+++ b/src/renderer/src/contacts/GlobalLogSection.tsx
@@ -134,7 +134,7 @@ export default function GlobalLogSection({ contact, onUpdated }: { contact: Cont
             rows={3}
             autoFocus
             onKeyDown={(e) => {
-              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleLogSubmit();
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && logText.trim() && logDate && !logSubmitting) handleLogSubmit();
             }}
           />
           {contact.projects.length > 0 && (

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -353,6 +353,9 @@ function ScratchpadSection({
                   onChange={(e) => setEdit(draft.id, { body: e.target.value })}
                   placeholder="Write your draft message here…"
                   rows={5}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleSave(draft);
+                  }}
                 />
                 <div className="pt-reminder-form-actions">
                   <button className="pt-log-submit" onClick={() => handleSave(draft)}>Save</button>

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -376,7 +376,7 @@ function ScratchpadSection({
                 {draft.body
                   ? (
                     <div className="pt-draft-view-body">
-                      {draft.body.split(/\n\n+/).map((para, i) => <p key={i}>{para}</p>)}
+                      {draft.body.split('\n').map((line, i) => <p key={i}>{line}</p>)}
                     </div>
                   )
                   : <p className="pt-draft-view-body pt-draft-view-body--empty">No content yet.</p>

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -232,12 +232,14 @@ function ScratchpadSection({
 }) {
   const [drafts, setDrafts] = useState<ScratchpadDraft[]>([]);
   const [draftEdits, setDraftEdits] = useState<Record<string, { label: string; body: string }>>({});
+  const [editingIds, setEditingIds] = useState<Set<string>>(new Set());
   const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setDrafts([]);
     setDraftEdits({});
+    setEditingIds(new Set());
     window.sourcerer.listScratchpad(contactId, membership.id).then((drafts) => {
       if (!cancelled) setDrafts(drafts);
     });
@@ -253,6 +255,18 @@ function ScratchpadSection({
     setDraftEdits((prev) => {
       const current = prev[id] ?? { label: draft.label, body: draft.body };
       return { ...prev, [id]: { ...current, ...patch } };
+    });
+  }
+
+  function startEditing(id: string) {
+    setEditingIds((prev) => new Set([...prev, id]));
+  }
+
+  function stopEditing(id: string) {
+    setEditingIds((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
     });
   }
 
@@ -273,6 +287,7 @@ function ScratchpadSection({
         delete next[draft.id];
         return next;
       });
+      stopEditing(draft.id);
     } catch {
       setSaveError('Failed to save draft. Please try again.');
     }
@@ -286,6 +301,7 @@ function ScratchpadSection({
       body: '',
     });
     setDrafts((prev) => [...prev, draft]);
+    setEditingIds((prev) => new Set([...prev, draft.id]));
   }
 
   function handleDiscard(id: string) {
@@ -294,6 +310,7 @@ function ScratchpadSection({
       delete next[id];
       return next;
     });
+    stopEditing(id);
   }
 
   async function handleDelete(id: string) {
@@ -312,33 +329,52 @@ function ScratchpadSection({
       {saveError && <p className="pt-draft-error">{saveError}</p>}
       {drafts.length === 0 && <p className="pt-reminders-empty">No drafts yet.</p>}
       {drafts.map((draft) => {
+        const editing = editingIds.has(draft.id);
         const edit = getEdit(draft);
-        const dirty = edit.label !== draft.label || edit.body !== draft.body;
         return (
-          <div key={draft.id} className="pt-draft">
-            <div className="pt-draft-header">
-              <input
-                className="pt-draft-label"
-                value={edit.label}
-                onChange={(e) => setEdit(draft.id, { label: e.target.value })}
-                placeholder="Draft label"
-              />
-              <button className="pt-draft-delete" onClick={() => handleDelete(draft.id)} title="Delete draft">
-                ×
-              </button>
-            </div>
-            <textarea
-              className="pt-draft-body"
-              value={edit.body}
-              onChange={(e) => setEdit(draft.id, { body: e.target.value })}
-              placeholder="Write your draft message here…"
-              rows={5}
-            />
-            {dirty && (
-              <div className="pt-reminder-form-actions">
-                <button className="pt-log-submit" onClick={() => handleSave(draft)}>Save</button>
-                <button className="pt-reminder-cancel" onClick={() => handleDiscard(draft.id)}>Discard</button>
-              </div>
+          <div key={draft.id} className={`pt-draft${editing ? ' pt-draft--editing' : ''}`}>
+            {editing ? (
+              <>
+                <div className="pt-draft-header">
+                  <input
+                    className="pt-draft-label"
+                    value={edit.label}
+                    onChange={(e) => setEdit(draft.id, { label: e.target.value })}
+                    placeholder="Draft label"
+                    autoFocus
+                  />
+                  <button className="pt-draft-delete" onClick={() => handleDelete(draft.id)} title="Delete draft">
+                    ×
+                  </button>
+                </div>
+                <textarea
+                  className="pt-draft-body"
+                  value={edit.body}
+                  onChange={(e) => setEdit(draft.id, { body: e.target.value })}
+                  placeholder="Write your draft message here…"
+                  rows={5}
+                />
+                <div className="pt-reminder-form-actions">
+                  <button className="pt-log-submit" onClick={() => handleSave(draft)}>Save</button>
+                  <button className="pt-reminder-cancel" onClick={() => handleDiscard(draft.id)}>Discard</button>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="pt-draft-view-header">
+                  <span className="pt-draft-view-label">{draft.label || 'Draft'}</span>
+                  <div className="pt-draft-view-actions">
+                    <Button variant="ghost" onClick={() => startEditing(draft.id)}>Edit</Button>
+                    <button className="pt-draft-delete" onClick={() => handleDelete(draft.id)} title="Delete draft">
+                      ×
+                    </button>
+                  </div>
+                </div>
+                {draft.body
+                  ? <p className="pt-draft-view-body">{draft.body}</p>
+                  : <p className="pt-draft-view-body pt-draft-view-body--empty">No content yet.</p>
+                }
+              </>
             )}
           </div>
         );

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -374,7 +374,11 @@ function ScratchpadSection({
                   </div>
                 </div>
                 {draft.body
-                  ? <p className="pt-draft-view-body">{draft.body}</p>
+                  ? (
+                    <div className="pt-draft-view-body">
+                      {draft.body.split(/\n\n+/).map((para, i) => <p key={i}>{para}</p>)}
+                    </div>
+                  )
                   : <p className="pt-draft-view-body pt-draft-view-body--empty">No content yet.</p>
                 }
                 <p className="pt-draft-view-meta">Updated {fmtLogDate(draft.updated_at)}</p>

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -4,7 +4,7 @@ import { fmtDateFull, dateStrToUnix } from '../utils/fmtDate';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { CalendarPicker } from '../views/CalendarPicker';
 import Button from '../shell/Button';
-import { LogRow, LogAllModal, fmtReminderDate, sortReminders } from './logShared';
+import { LogRow, LogAllModal, fmtReminderDate, sortReminders, fmtLogDate } from './logShared';
 import LogProjectPicker from './LogProjectPicker';
 import './ContactDetail.css';
 import type {
@@ -377,6 +377,7 @@ function ScratchpadSection({
                   ? <p className="pt-draft-view-body">{draft.body}</p>
                   : <p className="pt-draft-view-body pt-draft-view-body--empty">No content yet.</p>
                 }
+                <p className="pt-draft-view-meta">Updated {fmtLogDate(draft.updated_at)}</p>
               </>
             )}
           </div>

--- a/src/renderer/src/contacts/ProjectTab.tsx
+++ b/src/renderer/src/contacts/ProjectTab.tsx
@@ -196,7 +196,7 @@ function LogSection({
             rows={3}
             autoFocus
             onKeyDown={(e) => {
-              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleSubmit();
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && text.trim() && logDate && !submitting) handleSubmit();
             }}
           />
           <div className="pt-log-projects">
@@ -288,6 +288,14 @@ function ScratchpadSection({
     setDrafts((prev) => [...prev, draft]);
   }
 
+  function handleDiscard(id: string) {
+    setDraftEdits((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  }
+
   async function handleDelete(id: string) {
     await window.sourcerer.deleteScratchpad(id);
     setDrafts((prev) => prev.filter((d) => d.id !== id));
@@ -327,9 +335,10 @@ function ScratchpadSection({
               rows={5}
             />
             {dirty && (
-              <button className="pt-draft-save" onClick={() => handleSave(draft)}>
-                Save draft
-              </button>
+              <div className="pt-reminder-form-actions">
+                <button className="pt-log-submit" onClick={() => handleSave(draft)}>Save</button>
+                <button className="pt-reminder-cancel" onClick={() => handleDiscard(draft.id)}>Discard</button>
+              </div>
             )}
           </div>
         );

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -63,6 +63,7 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
   const [stalenessThresholdInput, setStalenessThresholdInput] = useState<string>('90');
   const [calendarRegenConfirm, setCalendarRegenConfirm] = useState(false);
   const [calendarUrl, setCalendarUrl] = useState('');
+  const [calendarUrlCopied, setCalendarUrlCopied] = useState(false);
 
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -742,10 +743,14 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
               variant="secondary"
               size="sm"
               onClick={() => {
-                if (calendarUrl) navigator.clipboard.writeText(calendarUrl);
+                if (!calendarUrl) return;
+                navigator.clipboard.writeText(calendarUrl).then(() => {
+                  setCalendarUrlCopied(true);
+                  setTimeout(() => setCalendarUrlCopied(false), 2000);
+                });
               }}
             >
-              Copy
+              {calendarUrlCopied ? 'Copied!' : 'Copy'}
             </Button>
           </div>
           {calendarRegenConfirm ? (


### PR DESCRIPTION
## Summary

- **#383** — `SettingsView` calendar URL copy button now shows "Copied!" for 2 s, matching the identical pattern already used in `RemindersView` and `SetupPayloadModal`
- **#368** — Scratchpad "Save draft" button replaced with a **Save / Discard** pair when unsaved changes exist; Discard clears the local edit and reverts to last-saved state without touching the DB
- **#296** — `Cmd+Enter` on the log entry textarea is now guarded by the same conditions as the submit button (`text.trim() && logDate && !submitting`), so pressing the shortcut with no date set no longer silently no-ops without feedback
- **#171** — `security.html` CORS section rewritten to accurately describe the reflected-origin behaviour (extension-scheme check gates the header, token is the primary auth gate) instead of overstating the strictness

Closes #383
Closes #368
Closes #296
Closes #171