### PR TITLE
Fix RSS list stale after save; raise screenshot cap and warn when capped

### DIFF
--- a/extension/popup.js
+++ b/extension/popup.js
@@ -208,7 +208,8 @@ async function captureFullPage(tabId, onProgress) {
         ? { left: 0, top: 0, width: window.innerWidth, height: window.innerHeight }
         : (() => { const r = el.getBoundingClientRect(); return { left: r.left, top: r.top, width: r.width, height: r.height }; })();
       return {
-        totalHeight: Math.min(el.scrollHeight, 15000),
+        totalHeight: Math.min(el.scrollHeight, 25000),
+        fullHeight: el.scrollHeight,
         origScrollTop: el.scrollTop,
         dpr: window.devicePixelRatio || 1,
         scrollElLeft: rect.left,
@@ -220,7 +221,7 @@ async function captureFullPage(tabId, onProgress) {
   });
 
   if (!metricsResult?.result) throw new Error('Could not read page dimensions — try reloading the tab.');
-  const { totalHeight, origScrollTop, dpr,
+  const { totalHeight, fullHeight, origScrollTop, dpr,
           scrollElLeft, scrollElTop, scrollElWidth, scrollElHeight } = metricsResult.result;
 
   // Guard band: for non-first strips we scroll back this many px so the top
@@ -233,7 +234,11 @@ async function captureFullPage(tabId, onProgress) {
   const effectiveStep = scrollElHeight - GUARD;
   const totalSteps = 1 + Math.ceil(Math.max(0, totalHeight - scrollElHeight) / effectiveStep);
 
-  onProgress(`Page is ${Math.round(totalHeight)}px — ${totalSteps} section${totalSteps === 1 ? '' : 's'}`);
+  const capped = fullHeight > totalHeight;
+  const progressMsg = capped
+    ? `Page is ${Math.round(fullHeight)}px — capturing first ${Math.round(totalHeight)}px (${totalSteps} section${totalSteps === 1 ? '' : 's'})`
+    : `Page is ${Math.round(totalHeight)}px — ${totalSteps} section${totalSteps === 1 ? '' : 's'}`;
+  onProgress(progressMsg);
   await new Promise(r => setTimeout(r, 600));
 
   // Best-effort: hide fixed/sticky elements that exist at capture start.

--- a/src/renderer/src/contacts/ContactDetail.css
+++ b/src/renderer/src/contacts/ContactDetail.css
@@ -1052,7 +1052,7 @@
 
 .detail-rss-url {
   display: block;
-  font-size: 11px;
+  font-size: 13px;
   word-break: break-all;
   overflow-wrap: anywhere;
   white-space: normal;

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -139,7 +139,11 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
         onNewRssUrlChange={setNewRssUrl}
         onAddRss={handleAddRss}
         onRemoveRss={handleRemoveRss}
-        onSaved={() => { onRefresh(); setEditingAndNotify(false); }}
+        onSaved={() => {
+          window.sourcerer.listAlertRss(contact.id).then(setAlertRssList);
+          onRefresh();
+          setEditingAndNotify(false);
+        }}
         onCancel={() => setEditingAndNotify(false)}
       />
     );


### PR DESCRIPTION
## Summary

**#377 — RSS feed doesn't appear after saving**

`ContactEditForm.handleSave` calls `window.sourcerer.addAlertRss` directly (rather than through `onAddRss`), bypassing `GlobalTab`'s `alertRssList` state. The RSS load effect only fires on `contact.id` changes, so the list stayed stale after saving. Fix: re-fetch `alertRssList` in the `onSaved` callback in `GlobalTab`.

**#369 — Screenshot max height**

The 15 000px hard cap in `captureFullPage` was silently producing partial images with no user feedback. The server accepts up to 50 MB, so there is headroom. Fix: raise the cap to 25 000px, return the actual `fullHeight` alongside `totalHeight`, and surface a status message ("Page is Xpx — capturing first 25 000px") whenever the page is taller than the cap.

## Test plan

- [x] Add an RSS URL in a contact's edit form and save — feed appears immediately without reopening the drawer
- [x] Screenshot a page taller than 25 000px — confirm partial capture and warning message
- [x] Screenshot a normal page — confirm no change in behaviour

Closes #377
Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)