### PR TITLE
Fix claude-review workflow: pass label_trigger to action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,6 +24,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          label_trigger: claude-review
           additional_permissions: |
             actions: read
           prompt: |


### PR DESCRIPTION
## Summary

The `claude-code-action` internally defaults `label_trigger` to `claude`. When our workflow fires on the `claude-review` label, the action silently skips execution because the label name doesn't match its internal default.

Adds `label_trigger: claude-review` to the action inputs so it recognises the correct label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)