### PR TITLE
Restrict claude-review to diff only; cap at 5 turns

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,12 +25,10 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           label_trigger: claude-review
-          additional_permissions: |
-            actions: read
+          claude_args: '--allowedTools "Bash(gh pr diff *),Bash(gh pr view *),Read" --max-turns 5'
           prompt: |
-            Review the changes in this pull request. Focus on:
-            - Bugs and edge cases
-            - Anything that violates patterns already established in the codebase
+            Run `gh pr diff $PR_NUMBER` to get the diff for this pull request, then review only those changes. Focus on:
+            - Bugs and edge cases introduced by the diff
             - Security issues
-            - Overly complex code that could be simplified
-            Post your findings as a PR review comment.
+            - Code that violates patterns visible in the changed files
+            Be concise. Only flag real issues. Post your findings as a PR review comment.


### PR DESCRIPTION
## Summary

Without tool restrictions, Claude explores the entire codebase — in testing it ran for 10+ minutes and consumed 22% of token budget before being killed.

Changes:
- `claude_args` restricts available tools to `gh pr diff`, `gh pr view`, and `Read` only — no filesystem traversal
- `--max-turns 5` caps the number of agentic iterations
- Prompt now explicitly instructs Claude to fetch the diff first and review only those changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)