### PR TITLE
Fix allowedTools quoting in claude-review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           label_trigger: claude-review
-          claude_args: '--allowedTools "Bash(gh pr diff *),Bash(gh pr view *),Read" --max-turns 5'
+          claude_args: '--allowedTools Bash(gh pr *),Read --max-turns 5'
           prompt: |
             Run `gh pr diff $PR_NUMBER` to get the diff for this pull request, then review only those changes. Focus on:
             - Bugs and edge cases introduced by the diff


### PR DESCRIPTION
## Summary

The inner double quotes around the tool list in `claude_args` caused the entire comma-separated string to be parsed as a single tool name, resulting in a permission denial on every run. Removed them and broadened the pattern from `Bash(gh pr diff *),Bash(gh pr view *)` to just `Bash(gh pr *)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)