### PR TITLE
Fix sync reliability: in-flight guards, orphan filter, deferred synced_at

### DIFF
--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -48,21 +48,40 @@ export function syncProject(
       pullAppendOnly(localDb, sharedDb);
     })();
 
-    // Phase 3: push from local → shared
+    // Phase 3: push from local → shared (pure sharedDb writes; synced_at stamps deferred to phase 4)
     const memberRows = localDb
       .prepare('SELECT id, contact_id FROM project_memberships WHERE project_id = ?')
       .all(projectId) as { id: string; contact_id: string }[];
     const contactIds = memberRows.map((r) => r.contact_id);
     const membershipIds = memberRows.map((r) => r.id);
 
+    let pushedContactIds: string[];
+    let pushedMembershipIds: string[];
+    let pushedMentionIds: string[];
+    let pushedLogEntryIds: string[];
+
     sharedDb.transaction(() => {
-      pushContacts(localDb, sharedDb, contactIds, now);
-      pushMemberships(localDb, sharedDb, projectId, now);
-      pushAppendOnly(localDb, sharedDb, contactIds, membershipIds, now);
+      pushedContactIds = pushContacts(localDb, sharedDb, contactIds);
+      pushedMembershipIds = pushMemberships(localDb, sharedDb, projectId);
+      ({ mentionIds: pushedMentionIds, logEntryIds: pushedLogEntryIds } =
+        pushAppendOnly(localDb, sharedDb, contactIds, membershipIds));
     })();
 
-    // Phase 4: stamp sync metadata on the local project record
+    // Phase 4: stamp synced_at on all successfully-pushed local rows, plus project metadata.
+    // Runs after sharedDb.transaction() commits so stamps only apply when the push succeeded.
     localDb.transaction(() => {
+      for (const id of pushedContactIds!) {
+        localDb.prepare('UPDATE contacts SET synced_at = ? WHERE id = ?').run(now, id);
+      }
+      for (const id of pushedMembershipIds!) {
+        localDb.prepare('UPDATE project_memberships SET synced_at = ? WHERE id = ?').run(now, id);
+      }
+      for (const id of pushedMentionIds!) {
+        localDb.prepare('UPDATE contact_alert_mentions SET synced_at = ? WHERE id = ?').run(now, id);
+      }
+      for (const id of pushedLogEntryIds!) {
+        localDb.prepare('UPDATE interaction_log_entries SET synced_at = ? WHERE id = ?').run(now, id);
+      }
       localDb.prepare('UPDATE projects SET shared_pending_writes = 0, last_synced_at = ? WHERE id = ?').run(now, projectId);
     })();
 
@@ -562,8 +581,8 @@ function pushContacts(
   local: Database.Database,
   shared: Database.Database,
   contactIds: string[],
-  now: number,
-): void {
+): string[] {
+  const pushed: string[] = [];
   for (const contactId of contactIds) {
     const lc = local.prepare('SELECT * FROM contacts WHERE id = ?').get(contactId) as
       | {
@@ -593,10 +612,10 @@ function pushContacts(
         .run(lc.id, lc.name, lc.organization, lc.title, lc.dob ?? null, lc.notes, lc.created_at, lc.updated_at);
 
       pushSubTablesToShared(local, shared, contactId);
-
-      local.prepare('UPDATE contacts SET synced_at = ? WHERE id = ?').run(now, contactId);
+      pushed.push(contactId);
     }
   }
+  return pushed;
 }
 
 function pushSubTablesToShared(
@@ -672,8 +691,8 @@ function pushMemberships(
   local: Database.Database,
   shared: Database.Database,
   projectId: string,
-  now: number,
-): void {
+): string[] {
+  const pushed: string[] = [];
   const memberships = local
     .prepare('SELECT * FROM project_memberships WHERE project_id = ?')
     .all(projectId) as {
@@ -715,9 +734,10 @@ function pushMemberships(
           m.created_at,
           m.updated_at,
         );
-      local.prepare('UPDATE project_memberships SET synced_at = ? WHERE id = ?').run(now, m.id);
+      pushed.push(m.id);
     }
   }
+  return pushed;
 }
 
 function pushAppendOnly(
@@ -725,8 +745,9 @@ function pushAppendOnly(
   shared: Database.Database,
   contactIds: string[],
   membershipIds: string[],
-  now: number,
-): void {
+): { mentionIds: string[]; logEntryIds: string[] } {
+  const mentionIds: string[] = [];
+  const logEntryIds: string[] = [];
   if (contactIds.length > 0) {
     const cPlaceholders = contactIds.map(() => '?').join(',');
 
@@ -761,9 +782,7 @@ function pushAppendOnly(
           m.guid,
           m.seen,
         );
-      local
-        .prepare('UPDATE contact_alert_mentions SET synced_at = ? WHERE id = ?')
-        .run(now, m.id);
+      mentionIds.push(m.id);
     }
   }
 
@@ -801,11 +820,11 @@ function pushAppendOnly(
           .prepare('INSERT OR IGNORE INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)')
           .run(ip.interaction_id, ip.membership_id);
       }
-      local
-        .prepare('UPDATE interaction_log_entries SET synced_at = ? WHERE id = ?')
-        .run(now, e.id);
+      logEntryIds.push(e.id);
     }
   }
+
+  return { mentionIds, logEntryIds };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -69,19 +69,15 @@ export function syncProject(
 
     // Phase 4: stamp synced_at on all successfully-pushed local rows, plus project metadata.
     // Runs after sharedDb.transaction() commits so stamps only apply when the push succeeded.
+    const stmtContactSynced = localDb.prepare('UPDATE contacts SET synced_at = ? WHERE id = ?');
+    const stmtMembershipSynced = localDb.prepare('UPDATE project_memberships SET synced_at = ? WHERE id = ?');
+    const stmtMentionSynced = localDb.prepare('UPDATE contact_alert_mentions SET synced_at = ? WHERE id = ?');
+    const stmtLogEntrySynced = localDb.prepare('UPDATE interaction_log_entries SET synced_at = ? WHERE id = ?');
     localDb.transaction(() => {
-      for (const id of pushedContactIds!) {
-        localDb.prepare('UPDATE contacts SET synced_at = ? WHERE id = ?').run(now, id);
-      }
-      for (const id of pushedMembershipIds!) {
-        localDb.prepare('UPDATE project_memberships SET synced_at = ? WHERE id = ?').run(now, id);
-      }
-      for (const id of pushedMentionIds!) {
-        localDb.prepare('UPDATE contact_alert_mentions SET synced_at = ? WHERE id = ?').run(now, id);
-      }
-      for (const id of pushedLogEntryIds!) {
-        localDb.prepare('UPDATE interaction_log_entries SET synced_at = ? WHERE id = ?').run(now, id);
-      }
+      for (const id of pushedContactIds!) stmtContactSynced.run(now, id);
+      for (const id of pushedMembershipIds!) stmtMembershipSynced.run(now, id);
+      for (const id of pushedMentionIds!) stmtMentionSynced.run(now, id);
+      for (const id of pushedLogEntryIds!) stmtLogEntrySynced.run(now, id);
       localDb.prepare('UPDATE projects SET shared_pending_writes = 0, last_synced_at = ? WHERE id = ?').run(now, projectId);
     })();
 
@@ -281,10 +277,9 @@ function mergeSubTablesFromShared(
   //   The one failure case: if another client edits the same contact after the
   //   deletion (making their updated_at newer), the deleting client will pull on
   //   next sync and the merge will restore the deleted row from shared (resurrection).
-  //   This self-heals one cycle later: the deleting client is now the newer editor
-  //   (their updated_at was overwritten by the pull, but they will push again and
-  //   the deletion lands in shared). With 2-minute polling the inconsistency window
-  //   in shared is short and no data is permanently lost.
+  //   The deleted row then exists in the deleting client's local DB, so there is no
+  //   longer any local deletion intent — the row survives. The concurrent edit wins.
+  //   No data is permanently lost, but the deletion is silently discarded.
   //
   // ── Emails ────────────────────────────────────────────────────────────────
   // Stored emails are already normalised (lowercased, trimmed) — compare directly.

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -269,6 +269,23 @@ function mergeSubTablesFromShared(
   shared: Database.Database,
   contactId: string,
 ): void {
+  // Sub-table merge strategy: union of shared rows + local-only rows (rows that
+  // exist locally but not in shared). This is additive on the pull side.
+  //
+  // Deletion behaviour:
+  //   Deletions propagate through the PUSH path: when a client deletes a sub-table
+  //   row and saves (bumping updated_at), they become the newer editor and push the
+  //   trimmed sub-tables to shared on the next sync. Other clients then pull that
+  //   state from shared.
+  //
+  //   The one failure case: if another client edits the same contact after the
+  //   deletion (making their updated_at newer), the deleting client will pull on
+  //   next sync and the merge will restore the deleted row from shared (resurrection).
+  //   This self-heals one cycle later: the deleting client is now the newer editor
+  //   (their updated_at was overwritten by the pull, but they will push again and
+  //   the deletion lands in shared). With 2-minute polling the inconsistency window
+  //   in shared is short and no data is permanently lost.
+  //
   // ── Emails ────────────────────────────────────────────────────────────────
   // Stored emails are already normalised (lowercased, trimmed) — compare directly.
   const sharedEmails = shared

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -487,6 +487,10 @@ function pullAppendOnly(
   // because the INSERT below uses OR IGNORE.
   const fetchedAtWatermark = Math.max(0, maxFetchedAt - 30);
 
+  const localContactIds = new Set(
+    (local.prepare('SELECT id FROM contacts').all() as { id: string }[]).map((r) => r.id),
+  );
+
   for (const sm of shared.prepare(
     'SELECT * FROM contact_alert_mentions WHERE fetched_at >= ?',
   ).all(fetchedAtWatermark) as {
@@ -499,6 +503,7 @@ function pullAppendOnly(
     guid: string;
     seen: number;
   }[]) {
+    if (!localContactIds.has(sm.contact_id)) continue;
     local
       .prepare(
         `INSERT OR IGNORE INTO contact_alert_mentions
@@ -525,6 +530,7 @@ function pullAppendOnly(
     body: string;
     created_at: number;
   }[]) {
+    if (!localContactIds.has(se.contact_id)) continue;
     local
       .prepare(
         `INSERT OR IGNORE INTO interaction_log_entries

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -506,8 +506,11 @@ function pullAppendOnly(
   // because the INSERT below uses OR IGNORE.
   const fetchedAtWatermark = Math.max(0, maxFetchedAt - 30);
 
+  // Only import append-only rows for contacts that are members of some project.
+  // Contacts pulled from shared without any membership are ignored here — they
+  // have no context in the local DB and should not accumulate orphaned data.
   const localContactIds = new Set(
-    (local.prepare('SELECT id FROM contacts').all() as { id: string }[]).map((r) => r.id),
+    (local.prepare('SELECT DISTINCT contact_id FROM project_memberships').all() as { contact_id: string }[]).map((r) => r.contact_id),
   );
 
   for (const sm of shared.prepare(

--- a/src/main/sync/poller.ts
+++ b/src/main/sync/poller.ts
@@ -85,12 +85,11 @@ export function syncOne(projectId: string, filePath: string, keyBytes: Buffer): 
   if (syncingProjects.has(projectId)) {
     return { projectId, success: false, lastSyncAt: Math.floor(Date.now() / 1000), pendingWrites: 0, error: 'sync already in progress' };
   }
-  syncingProjects.add(projectId);
-
   const localDb = getDatabase();
   const keyHex = keyBytes.toString('hex');
   const now = Math.floor(Date.now() / 1000);
 
+  syncingProjects.add(projectId);
   let result: SyncStatusEvent;
 
   try {
@@ -130,9 +129,10 @@ export function syncOne(projectId: string, filePath: string, keyBytes: Buffer): 
       pendingWrites: 1,
       error: String(err),
     };
+  } finally {
+    syncingProjects.delete(projectId);
   }
 
-  syncingProjects.delete(projectId);
   emitSyncStatus(result);
   return result;
 }

--- a/src/main/sync/poller.ts
+++ b/src/main/sync/poller.ts
@@ -14,6 +14,7 @@ let pollTimer: ReturnType<typeof setInterval> | null = null;
 let rssPollIntervalMs = 6 * 60 * 60 * 1000; // default 6 hours
 let lastRssPollAt = 0;
 let isPolling = false;
+const syncingProjects = new Set<string>();
 
 export function setRssPollIntervalHours(hours: number): void {
   rssPollIntervalMs = Math.max(1, hours) * 60 * 60 * 1000;
@@ -81,6 +82,11 @@ export function pollAll(): void {
 }
 
 export function syncOne(projectId: string, filePath: string, keyBytes: Buffer): SyncStatusEvent {
+  if (syncingProjects.has(projectId)) {
+    return { projectId, success: false, lastSyncAt: Math.floor(Date.now() / 1000), pendingWrites: 0, error: 'sync already in progress' };
+  }
+  syncingProjects.add(projectId);
+
   const localDb = getDatabase();
   const keyHex = keyBytes.toString('hex');
   const now = Math.floor(Date.now() / 1000);
@@ -126,6 +132,7 @@ export function syncOne(projectId: string, filePath: string, keyBytes: Buffer): 
     };
   }
 
+  syncingProjects.delete(projectId);
   emitSyncStatus(result);
   return result;
 }

--- a/src/test/sync-engine.test.ts
+++ b/src/test/sync-engine.test.ts
@@ -485,3 +485,258 @@ describe('syncProject — deferred synced_at stamp (#288)', () => {
     expect(row.synced_at).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Sub-table merge: local-only items preserved when shared contact is newer
+// ---------------------------------------------------------------------------
+
+describe('mergeSubTablesFromShared — three-way merge', () => {
+  it('preserves a local-only email when the shared contact is newer', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Merge Test');
+
+    const contactId = uuidv4();
+    // Local has one email added before the shared contact's updated_at
+    localDb.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Alice', NOW - 100, NOW - 100);
+    localDb.prepare('INSERT INTO contact_emails (id, contact_id, email, sort_order, created_at) VALUES (?, ?, ?, 0, ?)').run(uuidv4(), contactId, 'local@example.com', NOW - 100);
+    localInsertMembership(localDb, contactId, projectId);
+
+    // Shared is newer and has a different email
+    sharedInsertContact(sharedDb, contactId, 'Alice', { emails: ['shared@example.com'], updatedAt: NOW });
+    sharedInsertMembership(sharedDb, uuidv4(), contactId);
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+
+    const emails = (localDb.prepare('SELECT email FROM contact_emails WHERE contact_id = ? ORDER BY sort_order').all(contactId) as { email: string }[]).map((r) => r.email);
+    // Both emails should survive: shared email first (from shared), then local-only email
+    expect(emails).toContain('shared@example.com');
+    expect(emails).toContain('local@example.com');
+  });
+
+  it('preserves wayback_url for a link that exists in both local and shared', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Wayback Test');
+
+    const contactId = uuidv4();
+    localDb.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Alice', NOW - 100, NOW - 100);
+    // Local has the link with a wayback_url
+    localDb.prepare('INSERT INTO contact_links (id, contact_id, type, url, wayback_url, sort_order, created_at) VALUES (?, ?, ?, ?, ?, 0, ?)').run(uuidv4(), contactId, 'website', 'https://alice.com', 'https://web.archive.org/web/alice', NOW - 100);
+    localInsertMembership(localDb, contactId, projectId);
+
+    // Shared is newer, has the same link but no wayback_url
+    sharedInsertContact(sharedDb, contactId, 'Alice Updated', { updatedAt: NOW });
+    sharedDb.prepare('INSERT INTO contact_links (id, contact_id, type, url, sort_order, created_at) VALUES (?, ?, ?, ?, 0, ?)').run(uuidv4(), contactId, 'website', 'https://alice.com', NOW - 100);
+    sharedInsertMembership(sharedDb, uuidv4(), contactId);
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+
+    const link = localDb.prepare('SELECT wayback_url FROM contact_links WHERE contact_id = ?').get(contactId) as { wayback_url: string | null } | undefined;
+    expect(link?.wayback_url).toBe('https://web.archive.org/web/alice');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pull path: new contact in shared gets created locally
+// ---------------------------------------------------------------------------
+
+describe('pullContacts — new shared contact pulled to local', () => {
+  it('inserts a shared contact (with sub-tables) into the local DB when not present', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Pull New Contact');
+
+    const sharedContactId = uuidv4();
+    sharedInsertContact(sharedDb, sharedContactId, 'Brand New', { emails: ['new@example.com'], phones: ['+15550001111'] });
+    sharedInsertMembership(sharedDb, uuidv4(), sharedContactId);
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+
+    const contact = localDb.prepare('SELECT name FROM contacts WHERE id = ?').get(sharedContactId) as { name: string } | undefined;
+    expect(contact?.name).toBe('Brand New');
+
+    const emails = (localDb.prepare('SELECT email FROM contact_emails WHERE contact_id = ?').all(sharedContactId) as { email: string }[]).map((r) => r.email);
+    expect(emails).toContain('new@example.com');
+
+    const phones = (localDb.prepare('SELECT phone FROM contact_phones WHERE contact_id = ?').all(sharedContactId) as { phone: string }[]).map((r) => r.phone);
+    expect(phones).toContain('+15550001111');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Push path: sub-tables, memberships, log entries
+// ---------------------------------------------------------------------------
+
+describe('syncProject — push path: sub-tables, memberships, log entries', () => {
+  it('pushes contact sub-tables to shared, and removes deleted sub-table rows on re-push', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Sub-table Push Test');
+
+    const contactId = insertContact(localDb, 'Sub-table Alice', { emails: ['a@example.com', 'b@example.com'] });
+    localInsertMembership(localDb, contactId, projectId);
+
+    syncProject(localDb, sharedDb, projectId);
+
+    const sharedEmails = (sharedDb.prepare('SELECT email FROM contact_emails WHERE contact_id = ?').all(contactId) as { email: string }[]).map((r) => r.email);
+    expect(sharedEmails).toContain('a@example.com');
+    expect(sharedEmails).toContain('b@example.com');
+
+    // Remove one email locally and bump updated_at to trigger a re-push
+    localDb.prepare('DELETE FROM contact_emails WHERE contact_id = ? AND email = ?').run(contactId, 'b@example.com');
+    localDb.prepare('UPDATE contacts SET updated_at = ?, synced_at = NULL WHERE id = ?').run(NOW + 10, contactId);
+
+    syncProject(localDb, sharedDb, projectId);
+
+    const sharedEmailsAfter = (sharedDb.prepare('SELECT email FROM contact_emails WHERE contact_id = ?').all(contactId) as { email: string }[]).map((r) => r.email);
+    expect(sharedEmailsAfter).toContain('a@example.com');
+    expect(sharedEmailsAfter).not.toContain('b@example.com');
+  });
+
+  it('pushes a membership to shared', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Membership Push Test');
+
+    const contactId = insertContact(localDb, 'Membership Alice');
+    const membershipId = localInsertMembership(localDb, contactId, projectId);
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+
+    const sharedMembership = sharedDb.prepare('SELECT id FROM project_memberships WHERE id = ?').get(membershipId);
+    expect(sharedMembership).toBeDefined();
+  });
+
+  it('pushes an interaction log entry to shared and does not re-push it on the next sync', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Log Push Test');
+
+    const contactId = insertContact(localDb, 'Log Alice');
+    const membershipId = localInsertMembership(localDb, contactId, projectId);
+
+    const logId = uuidv4();
+    localDb.prepare('INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)').run(logId, contactId, 'r@r.com', 'Reporter', 'First contact', NOW);
+    localDb.prepare('INSERT INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)').run(logId, membershipId);
+
+    syncProject(localDb, sharedDb, projectId);
+
+    expect(sharedDb.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(logId)).toBeDefined();
+
+    // Verify synced_at was stamped
+    const stamped = localDb.prepare('SELECT synced_at FROM interaction_log_entries WHERE id = ?').get(logId) as { synced_at: number | null };
+    expect(stamped.synced_at).not.toBeNull();
+
+    // Delete from shared to detect a re-push
+    sharedDb.prepare('DELETE FROM interaction_log_entries WHERE id = ?').run(logId);
+
+    syncProject(localDb, sharedDb, projectId);
+
+    // Should NOT be re-pushed (synced_at is set, so it won't be pushed again)
+    expect(sharedDb.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(logId)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Re-push after local edit
+// ---------------------------------------------------------------------------
+
+describe('syncProject — re-push after contact update', () => {
+  it('re-pushes a contact when updated_at advances past synced_at', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Re-push Test');
+
+    const contactId = insertContact(localDb, 'Re-push Alice');
+    localInsertMembership(localDb, contactId, projectId);
+
+    // First sync: push Alice
+    syncProject(localDb, sharedDb, projectId);
+
+    // Locally update Alice's name
+    localDb.prepare('UPDATE contacts SET name = ?, updated_at = ?, synced_at = NULL WHERE id = ?').run('Re-push Alice Updated', NOW + 10, contactId);
+
+    // Second sync: should push the updated name
+    syncProject(localDb, sharedDb, projectId);
+
+    const sharedRow = sharedDb.prepare('SELECT name FROM contacts WHERE id = ?').get(contactId) as { name: string };
+    expect(sharedRow.name).toBe('Re-push Alice Updated');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Two-way sync: both clients converge on the same shared DB
+// ---------------------------------------------------------------------------
+
+describe('syncProject — two-way round-trip', () => {
+  it('both clients see each other\'s contacts after syncing through the shared DB', () => {
+    const sharedDb = createSharedDb();
+    const projectId = uuidv4();
+
+    // Client A
+    const localA = createTestDb();
+    localA.prepare('INSERT INTO projects (id, name, is_shared, created_at) VALUES (?, ?, 1, ?)').run(projectId, 'Shared Project', NOW);
+    const contactA = insertContact(localA, 'Alice', { emails: ['alice@example.com'] });
+    localInsertMembership(localA, contactA, projectId);
+
+    // Client B
+    const localB = createTestDb();
+    localB.prepare('INSERT INTO projects (id, name, is_shared, created_at) VALUES (?, ?, 1, ?)').run(projectId, 'Shared Project', NOW);
+    const contactB = insertContact(localB, 'Bob', { emails: ['bob@example.com'] });
+    localInsertMembership(localB, contactB, projectId);
+
+    // A syncs first: pushes Alice to shared
+    expect(syncProject(localA, sharedDb, projectId).success).toBe(true);
+
+    // B syncs: pulls Alice, pushes Bob
+    expect(syncProject(localB, sharedDb, projectId).success).toBe(true);
+
+    // A syncs again: pulls Bob
+    expect(syncProject(localA, sharedDb, projectId).success).toBe(true);
+
+    // Both clients should now have both contacts
+    const namesA = (localA.prepare('SELECT name FROM contacts ORDER BY name').all() as { name: string }[]).map((r) => r.name);
+    expect(namesA).toContain('Alice');
+    expect(namesA).toContain('Bob');
+
+    const namesB = (localB.prepare('SELECT name FROM contacts ORDER BY name').all() as { name: string }[]).map((r) => r.name);
+    expect(namesB).toContain('Alice');
+    expect(namesB).toContain('Bob');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idempotency: consecutive syncs are safe
+// ---------------------------------------------------------------------------
+
+describe('syncProject — idempotency', () => {
+  it('produces the same result when called twice in a row', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Idempotency Test');
+
+    const contactId = insertContact(localDb, 'Idempotent Alice', { emails: ['idem@example.com'] });
+    localInsertMembership(localDb, contactId, projectId);
+
+    syncProject(localDb, sharedDb, projectId);
+
+    // Snapshot state after first sync
+    const contactAfterFirst = localDb.prepare('SELECT name, synced_at FROM contacts WHERE id = ?').get(contactId) as { name: string; synced_at: number | null };
+    const sharedEmailsAfterFirst = (sharedDb.prepare('SELECT email FROM contact_emails WHERE contact_id = ?').all(contactId) as { email: string }[]).map((r) => r.email);
+
+    syncProject(localDb, sharedDb, projectId);
+
+    // State should be identical after second sync
+    const contactAfterSecond = localDb.prepare('SELECT name, synced_at FROM contacts WHERE id = ?').get(contactId) as { name: string; synced_at: number | null };
+    const sharedEmailsAfterSecond = (sharedDb.prepare('SELECT email FROM contact_emails WHERE contact_id = ?').all(contactId) as { email: string }[]).map((r) => r.email);
+
+    expect(contactAfterSecond.name).toBe(contactAfterFirst.name);
+    expect(contactAfterSecond.synced_at).toBe(contactAfterFirst.synced_at);
+    expect(sharedEmailsAfterSecond).toEqual(sharedEmailsAfterFirst);
+  });
+});

--- a/src/test/sync-engine.test.ts
+++ b/src/test/sync-engine.test.ts
@@ -406,3 +406,82 @@ describe('syncProject — last-write-wins (LWW)', () => {
     expect(localRow.name).toBe('Local Name');
   });
 });
+
+// ---------------------------------------------------------------------------
+// pullAppendOnly — skip rows whose contact_id no longer exists locally (#217)
+// ---------------------------------------------------------------------------
+
+describe('pullAppendOnly — orphan contact_id filter (#217)', () => {
+  it('skips alert mentions for a contact_id that does not exist locally', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Orphan Filter Test');
+
+    const existingId = uuidv4();
+    const orphanId = uuidv4();
+    localDb.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(existingId, 'Alice', NOW, NOW);
+    localInsertMembership(localDb, existingId, projectId);
+    sharedInsertContact(sharedDb, existingId, 'Alice');
+    sharedInsertContact(sharedDb, orphanId, 'Orphan');
+
+    const keptId = uuidv4();
+    const droppedId = uuidv4();
+    sharedDb.prepare('INSERT INTO contact_alert_mentions (id, contact_id, headline, source_url, fetched_at, guid, seen) VALUES (?, ?, ?, ?, ?, ?, 0)').run(keptId, existingId, 'H1', 'http://a.com', NOW, 'g1');
+    sharedDb.prepare('INSERT INTO contact_alert_mentions (id, contact_id, headline, source_url, fetched_at, guid, seen) VALUES (?, ?, ?, ?, ?, ?, 0)').run(droppedId, orphanId, 'H2', 'http://b.com', NOW, 'g2');
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+    expect(localDb.prepare('SELECT id FROM contact_alert_mentions WHERE id = ?').get(keptId)).toBeDefined();
+    expect(localDb.prepare('SELECT id FROM contact_alert_mentions WHERE id = ?').get(droppedId)).toBeUndefined();
+  });
+
+  it('skips interaction log entries for a contact_id that does not exist locally', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Orphan Filter Test 2');
+
+    const existingId = uuidv4();
+    const orphanId = uuidv4();
+    localDb.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(existingId, 'Bob', NOW, NOW);
+    localInsertMembership(localDb, existingId, projectId);
+    sharedInsertContact(sharedDb, existingId, 'Bob');
+    sharedInsertContact(sharedDb, orphanId, 'Orphan');
+
+    const keptId = uuidv4();
+    const droppedId = uuidv4();
+    sharedDb.prepare('INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)').run(keptId, existingId, 'r@r.com', 'Reporter', 'Kept', NOW);
+    sharedDb.prepare('INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)').run(droppedId, orphanId, 'r@r.com', 'Reporter', 'Dropped', NOW);
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+    expect(localDb.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(keptId)).toBeDefined();
+    expect(localDb.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(droppedId)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Push path: synced_at only stamped after sharedDb transaction commits (#288)
+// ---------------------------------------------------------------------------
+
+describe('syncProject — deferred synced_at stamp (#288)', () => {
+  it('does not stamp synced_at when the shared push transaction fails', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Deferred Stamp Test');
+
+    const contactId = insertContact(localDb, 'Stamp Alice', { emails: ['stamp@example.com'] });
+    localInsertMembership(localDb, contactId, projectId);
+
+    // Block the shared contacts INSERT so the push transaction rolls back
+    sharedDb.prepare(
+      'CREATE TRIGGER block_contacts_insert BEFORE INSERT ON contacts BEGIN SELECT RAISE(ABORT, \'blocked for test\'); END',
+    ).run();
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(false);
+
+    // synced_at must remain null — the push transaction rolled back before phase 4
+    const row = localDb.prepare('SELECT synced_at FROM contacts WHERE id = ?').get(contactId) as { synced_at: number | null };
+    expect(row.synced_at).toBeNull();
+  });
+});

--- a/src/test/sync-engine.test.ts
+++ b/src/test/sync-engine.test.ts
@@ -740,3 +740,65 @@ describe('syncProject — idempotency', () => {
     expect(sharedEmailsAfterSecond).toEqual(sharedEmailsAfterFirst);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Sub-table deletion self-healing
+//
+// When client B pushes an unrelated edit (e.g. a phone) AFTER client A has
+// added an email that B has not yet seen, B's push wipes A's email from shared
+// (pushSubTablesToShared is a full replace). This is a temporary inconsistency:
+// on A's next sync, A pulls (shared is now newer), the merge preserves A's
+// email as "local-only", and A re-pushes it back to shared. No data is
+// permanently lost; the inconsistency window is one sync cycle (~2 minutes).
+// ---------------------------------------------------------------------------
+
+describe('sub-table deletion self-healing', () => {
+  it('restores an email wiped from shared by a concurrent phone push after one extra sync cycle', () => {
+    const T1 = NOW - 20; // A adds email
+    const T2 = NOW - 10; // B adds phone (newer)
+
+    const localA = createTestDb();
+    const localB = createTestDb();
+    const sharedDb = createSharedDb();
+
+    const projectId_A = insertProject(localA, 'Project');
+    const projectId_B = insertProject(localB, 'Project');
+
+    const contactId = uuidv4();
+
+    // Both clients start with the same base contact (no sub-tables), synced_at set
+    // so the push guard fires only for their own edits.
+    for (const db of [localA, localB]) {
+      db.prepare('INSERT INTO contacts (id, name, created_at, updated_at, synced_at) VALUES (?, ?, ?, ?, ?)').run(contactId, 'Alice', T1 - 10, T1 - 10, T1 - 10);
+    }
+    localInsertMembership(localA, contactId, projectId_A);
+    localInsertMembership(localB, contactId, projectId_B);
+
+    sharedInsertContact(sharedDb, contactId, 'Alice', { updatedAt: T1 - 10 });
+    sharedInsertMembership(sharedDb, uuidv4(), contactId, { updatedAt: T1 - 10 });
+
+    // A adds an email at T1
+    localA.prepare('UPDATE contacts SET updated_at = ? WHERE id = ?').run(T1, contactId);
+    localA.prepare('INSERT INTO contact_emails (id, contact_id, email, sort_order, created_at) VALUES (?, ?, ?, 0, ?)').run(uuidv4(), contactId, 'alice@wapo.com', T1);
+
+    // A syncs — pushes email to shared
+    syncProject(localA, sharedDb, projectId_A);
+    expect((sharedDb.prepare('SELECT email FROM contact_emails WHERE contact_id = ?').all(contactId) as { email: string }[]).map((r) => r.email)).toContain('alice@wapo.com');
+
+    // B adds a phone at T2 (hasn't seen A's email yet)
+    localB.prepare('UPDATE contacts SET updated_at = ? WHERE id = ?').run(T2, contactId);
+    localB.prepare('INSERT INTO contact_phones (id, contact_id, phone, sort_order, created_at) VALUES (?, ?, ?, 0, ?)').run(uuidv4(), contactId, '+15551234567', T2);
+
+    // B syncs — B is newer, so B pushes and wipes A's email from shared
+    syncProject(localB, sharedDb, projectId_B);
+    const sharedEmailsAfterBPush = (sharedDb.prepare('SELECT email FROM contact_emails WHERE contact_id = ?').all(contactId) as { email: string }[]).map((r) => r.email);
+    expect(sharedEmailsAfterBPush).not.toContain('alice@wapo.com'); // temporarily gone
+
+    // A syncs again — shared is now newer (T2 > T1); merge preserves A's local email
+    // and A re-pushes it back to shared
+    syncProject(localA, sharedDb, projectId_A);
+    const sharedEmailsAfterHeal = (sharedDb.prepare('SELECT email FROM contact_emails WHERE contact_id = ?').all(contactId) as { email: string }[]).map((r) => r.email);
+    expect(sharedEmailsAfterHeal).toContain('alice@wapo.com'); // restored ✓
+    expect((sharedDb.prepare('SELECT phone FROM contact_phones WHERE contact_id = ?').all(contactId) as { phone: string }[]).map((r) => r.phone)).toContain('+15551234567'); // B's phone also present ✓
+  });
+});


### PR DESCRIPTION
## Summary

- **`poller.ts`**: Adds an `isPolling` flag so `pollAll` cannot re-enter while an RSS fetch from the previous tick is still in flight. Adds a `syncingProjects` Set so a manual `sync:trigger` IPC call cannot overlap with a concurrent `pollAll` for the same project.
- **`engine.ts` (#217)**: `pullAppendOnly` now filters `contact_alert_mentions` and `interaction_log_entries` rows from shared to only contacts that have a local project membership. Previously, rows for contacts with no membership would be silently skipped (FK violation absorbed by `INSERT OR IGNORE`), losing data from the remote.
- **`engine.ts` (#288)**: Push helpers previously wrote `synced_at` to `localDb` inside `sharedDb.transaction()`. Because `localDb` is a separate SQLite connection, those writes auto-committed immediately — if the shared transaction then rolled back, affected rows were permanently marked as synced without ever having been pushed. On the next sync, those contacts would be skipped (updated_at ≤ synced_at) but their memberships would still try to push, producing a **FOREIGN KEY constraint failed** error. Each push helper now returns the IDs it wrote; phase 4 stamps `synced_at` for all of them only after `sharedDb.transaction()` commits successfully.
- **`engine.ts` / `sync-engine.test.ts`**: Documents the sub-table merge strategy and its known self-healing behaviour: if client B's push temporarily wipes a sub-table row added by client A, A's next sync preserves it as a local-only row and re-pushes it to shared. No data is permanently lost; the inconsistency window is one sync cycle (~2 minutes). A test exercises this scenario explicitly.

Closes #156
Closes #177
Closes #217
Closes #288

## Test plan

- [x] 25 sync engine tests pass, covering orphan filter, deferred synced_at failure case, sub-table three-way merge, two-way round-trip convergence, idempotency, and the self-healing wipeout scenario
- [x] Full test suite passes