### PR TITLE
Fix lock screen height; add version number to settings footer

### DIFF
--- a/src/main/auto-lock.ts
+++ b/src/main/auto-lock.ts
@@ -9,7 +9,7 @@ const IDLE_CHECK_INTERVAL_MS = 15_000;
 const DEFAULT_IDLE_THRESHOLD_MS = 15 * 60 * 1000;
 
 const AUTH_WIDTH = 560;
-const AUTH_HEIGHT = 720;
+const AUTH_HEIGHT = 520;
 
 class AutoLockManager {
   private timer: ReturnType<typeof setInterval> | null = null;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -399,6 +399,7 @@ const sourcererApi = {
   getUpdateState: (): Promise<{ event: 'available' | 'downloading' | 'downloaded'; version: string; percent?: number } | null> =>
     ipcRenderer.invoke('update:get-state'),
   showUpdateError: (): Promise<void> => ipcRenderer.invoke('update:show-error'),
+  appVersion: process.env.npm_package_version ?? '',
 };
 
 contextBridge.exposeInMainWorld('sourcerer', sourcererApi);

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -249,6 +249,7 @@ declare global {
       simulateUpdate?: () => Promise<void>;
       getUpdateState: () => Promise<{ event: 'available' | 'downloading' | 'downloaded'; version: string; percent?: number } | null>;
       showUpdateError: () => Promise<void>;
+      appVersion: string;
     };
   }
 }

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -578,8 +578,12 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
 
         <div className="sv-credit">
           Sourcerer is open source.{' '}
-          <a href="https://github.com/tomcardoso/sourcerer" target="_blank" rel="noreferrer">
-            github.com/tomcardoso/sourcerer
+          <a
+            href={`https://github.com/tomcardoso/sourcerer/releases/tag/v${window.sourcerer.appVersion}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            v{window.sourcerer.appVersion}
           </a>
         </div>
 


### PR DESCRIPTION
## Summary

- **#394 — Lock screen height**: `AUTH_HEIGHT` was 720px (the full app height), so re-locking after use left the window tall. Changed to 520px to match the compact size of the initial launch window.
- **#393 — Version in settings footer**: Replaced the generic GitHub repo link with the app version number, linking directly to that version's GitHub release page. Version is read from `process.env.npm_package_version` in the preload and exposed via the context bridge.

Closes #394
Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)