### PR TITLE
Persist sort/filter state across navigation

### DIFF
--- a/src/renderer/src/hooks/useSortFilter.ts
+++ b/src/renderer/src/hooks/useSortFilter.ts
@@ -3,11 +3,20 @@ import type { SortDir } from '../views/ContactsTable';
 
 export type SortState<K extends string> = { key: K | null; dir: SortDir };
 
-export function useSortFilter<K extends string, F>(defaultFilters: F) {
-  const [sort, setSort] = useState<SortState<K>>({ key: null, dir: 'asc' });
-  const [filters, setFilters] = useState<F>(defaultFilters);
+const stateCache = new Map<string, { sort: SortState<string>; filters: unknown }>();
+
+export function useSortFilter<K extends string, F>(defaultFilters: F, cacheKey?: string) {
+  const cached = cacheKey ? stateCache.get(cacheKey) : undefined;
+
+  const [sort, setSort] = useState<SortState<K>>((cached?.sort as SortState<K>) ?? { key: null, dir: 'asc' });
+  const [filters, setFilters] = useState<F>((cached?.filters as F) ?? defaultFilters);
   const defaultFiltersRef = useRef(defaultFilters);
   useEffect(() => { defaultFiltersRef.current = defaultFilters; }, [defaultFilters]);
+
+  const cacheKeyRef = useRef(cacheKey);
+  useEffect(() => {
+    if (cacheKeyRef.current) stateCache.set(cacheKeyRef.current, { sort, filters });
+  }, [sort, filters]);
 
   function setFilter(key: string, value: unknown) {
     setFilters((prev) => ({ ...prev, [key]: value }));
@@ -26,6 +35,7 @@ export function useSortFilter<K extends string, F>(defaultFilters: F) {
   const resetAll = useCallback(() => {
     setSort({ key: null, dir: 'asc' });
     setFilters(defaultFiltersRef.current);
+    if (cacheKeyRef.current) stateCache.delete(cacheKeyRef.current);
   }, []);
 
   return { sort, filters, setFilter, handleSort, resetAll };

--- a/src/renderer/src/views/AllContacts.tsx
+++ b/src/renderer/src/views/AllContacts.tsx
@@ -32,7 +32,7 @@ export default function AllContacts({ projects, user, openContactId, onOpenConta
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [bulkProjectMenuOpen, setBulkProjectMenuOpen] = useState(false);
   const [bulkWorking, setBulkWorking] = useState(false);
-  const { sort, filters, setFilter, handleSort, resetAll: resetSortFilter } = useSortFilter<SortKey, Filters>(DEFAULT_FILTERS);
+  const { sort, filters, setFilter, handleSort, resetAll: resetSortFilter } = useSortFilter<SortKey, Filters>(DEFAULT_FILTERS, 'all-contacts');
   const [openFilter, setOpenFilter] = useState<string | null>(null);
   const [dupCount, setDupCount] = useState(0);
   const [showDedup, setShowDedup] = useState(false);

--- a/src/renderer/src/views/ProjectView.tsx
+++ b/src/renderer/src/views/ProjectView.tsx
@@ -67,7 +67,7 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
   const [fileUnreachable, setFileUnreachable] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [exporting, setExporting] = useState(false);
-  const { sort, filters, setFilter, handleSort, resetAll: resetSortFilter } = useSortFilter<SortKey, Filters>(DEFAULT_FILTERS);
+  const { sort, filters, setFilter, handleSort, resetAll: resetSortFilter } = useSortFilter<SortKey, Filters>(DEFAULT_FILTERS, project?.id ? `project-${project.id}` : undefined);
   const [openFilter, setOpenFilter] = useState<string | null>(null);
   const [regenPayload, setRegenPayload] = useState<{ projectName: string; payload: string } | null>(null);
   const [importResult, setImportResult] = useState<ImportResult | null>(null);
@@ -96,13 +96,12 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
     setSelectedId(null);
     setCheckedIds(new Set());
     setRows([]);
-    resetSortFilter();
     setOpenFilter(null);
     setSyncError(null);
     setFileUnreachable(false);
     setLastSyncedAt(project?.last_synced_at ? project.last_synced_at * 1000 : null);
     refresh();
-  }, [project?.id, resetSortFilter, refresh]);
+  }, [project?.id, refresh]);
 
   useEffect(() => {
     window.sourcerer.listStatusOptions().then(setStatusOptions);


### PR DESCRIPTION
## Summary

Sort and filter state was reset every time the user navigated away from a project view (to the Timeline sub-view, to another section, or back) because `useSortFilter` re-initialised on every mount.

Fix: `useSortFilter` now accepts an optional `cacheKey` and stores state in a module-level `Map` that lives for the session. State is keyed per project ID in `ProjectView` and by a fixed key in `AllContacts`, so:

- Navigating from a project to its Timeline sub-view and back restores the previous sort/filter
- Switching between projects and returning restores that project's last sort/filter
- The **Reset** button still clears both in-memory state and the cache entry
- The explicit `resetSortFilter()` in the `project?.id` effect is removed (state is now naturally keyed per project)

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)