### PR TITLE
Add mark-as-read button to individual mentions; fix keyboard a11y

### DIFF
--- a/src/renderer/src/views/AlertMentions.css
+++ b/src/renderer/src/views/AlertMentions.css
@@ -159,6 +159,14 @@
   margin-top: 5px;
 }
 
+.alerts-item-actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 2px;
+  margin-top: 2px;
+}
+
+.alerts-markread-btn,
 .alerts-dismiss-btn {
   background: none;
   border: none;
@@ -167,15 +175,21 @@
   line-height: 1;
   color: var(--color-text-dim);
   cursor: pointer;
-  margin-top: 2px;
   opacity: 0;
   transition: opacity 0.1s;
+}
+
+.alerts-markread-btn:hover {
+  color: var(--color-primary);
 }
 
 .alerts-dismiss-btn:hover {
   color: var(--color-text);
 }
 
-.alerts-item:hover .alerts-dismiss-btn {
+.alerts-item:hover .alerts-markread-btn,
+.alerts-item:hover .alerts-dismiss-btn,
+.alerts-markread-btn:focus-visible,
+.alerts-dismiss-btn:focus-visible {
   opacity: 1;
 }

--- a/src/renderer/src/views/AlertMentions.tsx
+++ b/src/renderer/src/views/AlertMentions.tsx
@@ -241,10 +241,19 @@ function MentionGroups({
                 </div>
               </div>
               <div className="alerts-item-actions">
+                {m.seen === 0 && (
+                  <button
+                    className="alerts-markread-btn"
+                    onClick={() => onMarkSeen(m.id)}
+                    title="Mark as read"
+                    aria-label="Mark as read"
+                  >✓</button>
+                )}
                 <button
                   className="alerts-dismiss-btn"
                   onClick={() => onDismiss(m.id)}
                   title="Dismiss permanently"
+                  aria-label="Dismiss permanently"
                 >×</button>
               </div>
             </div>


### PR DESCRIPTION
## Summary

- Adds a `✓` button on each unread mention row that marks it as read without requiring a click-through to the article. The button uses the existing `markMentionSeen` IPC call.
- Fixes keyboard accessibility: action buttons were `opacity: 0` and only revealed on hover, making them invisible to keyboard users. They now also become visible on `:focus-visible`.
- Adds `aria-label` to both the mark-read and dismiss buttons.

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)