### PR TITLE
Surface initial sync error when joining a shared project

### DIFF
--- a/src/main/ipc/projects.ts
+++ b/src/main/ipc/projects.ts
@@ -7,7 +7,7 @@ import { createSharedDb, openSharedDb, closeSharedDb, rekeySharedDb } from '../d
 import { encodePayload, decodePayload } from '../sync/payload';
 import { syncProject } from '../sync/engine';
 import { broadcastRemindersChanged } from './reminders';
-import type { Project, User, TimelineEntry, TimelineEntryProject } from '@shared/types';
+import type { Project, User, TimelineEntry, TimelineEntryProject, JoinSharedProjectResult } from '@shared/types';
 
 export function registerProjectHandlers(): void {
   ipcMain.handle('projects:list', (): Project[] => {
@@ -116,7 +116,7 @@ export function registerProjectHandlers(): void {
     async (
       _event,
       { encodedPayload, localPath }: { encodedPayload: string; localPath: string },
-    ): Promise<Project | null> => {
+    ): Promise<JoinSharedProjectResult | null> => {
       const decoded = decodePayload(encodedPayload);
       const { keyHex } = decoded;
       const keyBytes = Buffer.from(keyHex, 'hex');
@@ -134,7 +134,7 @@ export function registerProjectHandlers(): void {
           localPath,
           existing.id,
         );
-        return db.prepare('SELECT * FROM projects WHERE id = ?').get(existing.id) as Project;
+        return { project: db.prepare('SELECT * FROM projects WHERE id = ?').get(existing.id) as Project };
       }
 
       // Open and validate the shared DB
@@ -167,13 +167,15 @@ export function registerProjectHandlers(): void {
       })();
 
       // Initial pull from shared
+      let syncError: string | undefined;
       try {
         syncProject(db, sharedDb, id);
-      } catch {
-        // Non-fatal — project is created, sync will retry
+      } catch (err) {
+        syncError = String(err);
       }
 
-      return db.prepare('SELECT * FROM projects WHERE id = ?').get(id) as Project;
+      const project = db.prepare('SELECT * FROM projects WHERE id = ?').get(id) as Project;
+      return { project, syncError };
     },
   );
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -21,6 +21,7 @@ import type {
   StatusOption,
   PriorityOption,
   CreateSharedProjectResult,
+  JoinSharedProjectResult,
   SyncStatusEvent,
   DecodePayloadResult,
   ContactAlertRss,
@@ -93,7 +94,7 @@ const sourcererApi = {
   joinSharedProject: (data: {
     encodedPayload: string;
     localPath: string;
-  }): Promise<Project | null> => ipcRenderer.invoke('projects:joinShared', data),
+  }): Promise<JoinSharedProjectResult | null> => ipcRenderer.invoke('projects:joinShared', data),
   getSetupPayload: (projectId: string): Promise<string | null> =>
     ipcRenderer.invoke('projects:getSetupPayload', projectId),
   relocateSharedProject: (projectId: string, newPath: string): Promise<void> =>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -15,6 +15,7 @@ import type {
   StatusOption,
   PriorityOption,
   CreateSharedProjectResult,
+  JoinSharedProjectResult,
   SyncStatusEvent,
   DecodePayloadResult,
   ContactAlertRss,
@@ -64,7 +65,7 @@ declare global {
       joinSharedProject: (data: {
         encodedPayload: string;
         localPath: string;
-      }) => Promise<Project | null>;
+      }) => Promise<JoinSharedProjectResult | null>;
       getSetupPayload: (projectId: string) => Promise<string | null>;
       relocateSharedProject: (projectId: string, newPath: string) => Promise<void>;
       convertProjectToShared: (projectId: string) => Promise<{ project: Project; payload: string } | null>;

--- a/src/renderer/src/shell/JoinProjectModal.tsx
+++ b/src/renderer/src/shell/JoinProjectModal.tsx
@@ -16,6 +16,7 @@ export default function JoinProjectModal({ onJoined, onCancel }: Props) {
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [joinedProject, setJoinedProject] = useState<import('@shared/types').Project | null>(null);
 
   useEffect(() => {
     setPreview(null);
@@ -51,12 +52,17 @@ export default function JoinProjectModal({ onJoined, onCancel }: Props) {
     setSubmitting(true);
     setError(null);
     try {
-      const project = await window.sourcerer.joinSharedProject({
+      const result = await window.sourcerer.joinSharedProject({
         encodedPayload: payload.trim(),
         localPath: selectedPath,
       });
-      if (project) {
-        onJoined(project);
+      if (result) {
+        if (result.syncError) {
+          setJoinedProject(result.project);
+          setError(`Joined, but the initial sync failed — contacts will load on the next sync. (${result.syncError})`);
+        } else {
+          onJoined(result.project);
+        }
       } else {
         setError('Could not join the project. The file may have moved or the link is invalid.');
       }
@@ -129,9 +135,15 @@ export default function JoinProjectModal({ onJoined, onCancel }: Props) {
             <Button type="button" variant="secondary" onClick={onCancel} disabled={submitting}>
               Cancel
             </Button>
-            <Button type="submit" variant="primary" disabled={!canJoin}>
-              {submitting ? 'Joining…' : 'Join project'}
-            </Button>
+            {joinedProject ? (
+              <Button type="button" variant="primary" onClick={() => onJoined(joinedProject)}>
+                Go to project
+              </Button>
+            ) : (
+              <Button type="submit" variant="primary" disabled={!canJoin}>
+                {submitting ? 'Joining…' : 'Join project'}
+              </Button>
+            )}
           </div>
       </form>
     </Modal>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -284,6 +284,11 @@ export interface CreateSharedProjectResult {
   payload: string;
 }
 
+export interface JoinSharedProjectResult {
+  project: Project;
+  syncError?: string;
+}
+
 export interface SyncStatusEvent {
   projectId: string;
   success: boolean;


### PR DESCRIPTION
## Summary

If `syncProject` threw during `projects:joinShared`, the error was silently swallowed and the user saw an empty project with no explanation. The poller would eventually retry, but with no indication of when or why it failed.

- Adds `JoinSharedProjectResult` to shared types (`{ project: Project; syncError?: string }`)
- IPC handler now captures the sync error and returns it alongside the project instead of swallowing it
- `JoinProjectModal` shows a warning message if the initial sync failed, keeps the modal open, and surfaces a "Go to project" button so the user can still navigate to the (empty) project knowing contacts will load on the next sync cycle

Closes #404