### PR TITLE
Fix Dependabot #30: pin tmp to patched commit (GHSA-ph9p-34f9-6g65)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7629,8 +7629,8 @@
     },
     "node_modules/tmp": {
       "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "resolved": "git+ssh://git@github.com/raszi/node-tmp.git#efa4a06f24374797ae32ab2b6ae39b7a611ae429",
+      "integrity": "sha512-s54nhz2bVzm+SVfXr0e2SI6UZJ+wxvhE6xhsm/6FtHXBFAI8J9x5oUaCGSt98ruDY+v/Smnlbh11TcRRLd27+A==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "overrides": {
     "tar": "7.5.15",
     "@tootallnate/once": "3.0.1",
+    "tmp": "github:raszi/node-tmp#efa4a06f24374797ae32ab2b6ae39b7a611ae429",
     "exceljs": {
       "uuid": "11.1.1"
     }


### PR DESCRIPTION
## Summary

- `tmp@0.2.5` has a HIGH severity path traversal vulnerability (CVE-2026-44705 / GHSA-ph9p-34f9-6g65) via unsanitised prefix/postfix parameters
- The fix is committed upstream ([efa4a06](https://github.com/raszi/node-tmp/commit/efa4a06f24374797ae32ab2b6ae39b7a611ae429)) but `0.2.6` has not been published to npm yet
- Adds `"tmp": "github:raszi/node-tmp#efa4a06f..."` to `overrides` in `package.json` — the same pattern already used for `tar` and `@tootallnate/once`
- When `tmp@0.2.6` ships to npm, update the override to `"^0.2.6"` and run `npm install`

Closes https://github.com/tomcardoso/sourcerer/security/dependabot/30

## Test plan
- [x] `npm install` resolves `node_modules/tmp` to the patched commit
- [x] All 424 tests pass