### PR TITLE
Fix three sync engine bugs: RSS merge, FK leak, variable limit

### DIFF
--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -236,6 +236,7 @@ export const LOCAL_SCHEMA_DDL_SQL = `
   CREATE INDEX IF NOT EXISTS idx_contact_handles_contact_id           ON contact_handles(contact_id);
   CREATE UNIQUE INDEX IF NOT EXISTS idx_contact_handles_contact_type_handle ON contact_handles(contact_id, type, handle);
   CREATE UNIQUE INDEX IF NOT EXISTS idx_contact_links_contact_url      ON contact_links(contact_id, url);
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_contact_alert_rss_contact_url ON contact_alert_rss(contact_id, rss_url);
   CREATE INDEX IF NOT EXISTS idx_contact_screenshots_contact_id   ON contact_screenshots(contact_id);
   CREATE INDEX IF NOT EXISTS idx_interaction_log_contact_created ON interaction_log_entries(contact_id, created_at);
   CREATE INDEX IF NOT EXISTS idx_interaction_projects_membership ON interaction_projects(membership_id);

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -371,11 +371,21 @@ function mergeSubTablesFromShared(
   });
 
   // ── Alert RSS ──────────────────────────────────────────────────────────────
-  local.prepare('DELETE FROM contact_alert_rss WHERE contact_id = ?').run(contactId);
-  const rssFeeds = shared
+  // Same additive union strategy as emails/phones/links/handles: preserve local-only
+  // RSS feeds that haven't been pushed to shared yet.
+  const sharedRss = shared
     .prepare('SELECT * FROM contact_alert_rss WHERE contact_id = ?')
     .all(contactId) as { id: string; rss_url: string; last_polled_at: number | null; is_invalid: number }[];
-  for (const rss of rssFeeds) {
+  const localRss = local
+    .prepare('SELECT * FROM contact_alert_rss WHERE contact_id = ?')
+    .all(contactId) as { id: string; rss_url: string; last_polled_at: number | null; is_invalid: number }[];
+
+  const sharedRssUrls = new Set(sharedRss.map((r) => r.rss_url));
+  const localOnlyRss = localRss.filter((r) => !sharedRssUrls.has(r.rss_url));
+  const mergedRss = [...sharedRss, ...localOnlyRss];
+
+  local.prepare('DELETE FROM contact_alert_rss WHERE contact_id = ?').run(contactId);
+  for (const rss of mergedRss) {
     local
       .prepare(
         'INSERT INTO contact_alert_rss (id, contact_id, rss_url, last_polled_at, is_invalid) VALUES (?, ?, ?, ?, ?)',
@@ -761,81 +771,87 @@ function pushAppendOnly(
   contactIds: string[],
   membershipIds: string[],
 ): { mentionIds: string[]; logEntryIds: string[] } {
+  const membershipIdSet = new Set(membershipIds);
+  // SQLite's SQLITE_LIMIT_VARIABLE_NUMBER defaults to 999. Chunk large ID lists
+  // to stay safely below that limit.
+  const CHUNK = 500;
+
   const mentionIds: string[] = [];
   const logEntryIds: string[] = [];
   if (contactIds.length > 0) {
-    const cPlaceholders = contactIds.map(() => '?').join(',');
-
     // Alert mentions
-    for (const m of local
-      .prepare(
-        `SELECT * FROM contact_alert_mentions WHERE contact_id IN (${cPlaceholders}) AND synced_at IS NULL`,
-      )
-      .all(...contactIds) as {
-      id: string;
-      contact_id: string;
-      headline: string;
-      source_url: string;
-      published_at: number | null;
-      fetched_at: number;
-      guid: string;
-      seen: number;
-    }[]) {
-      shared
+    for (let i = 0; i < contactIds.length; i += CHUNK) {
+      const chunk = contactIds.slice(i, i + CHUNK);
+      const cPlaceholders = chunk.map(() => '?').join(',');
+      for (const m of local
         .prepare(
-          `INSERT OR IGNORE INTO contact_alert_mentions
-             (id, contact_id, headline, source_url, published_at, fetched_at, guid, seen)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          `SELECT * FROM contact_alert_mentions WHERE contact_id IN (${cPlaceholders}) AND synced_at IS NULL`,
         )
-        .run(
-          m.id,
-          m.contact_id,
-          m.headline,
-          m.source_url,
-          m.published_at,
-          m.fetched_at,
-          m.guid,
-          m.seen,
-        );
-      mentionIds.push(m.id);
+        .all(...chunk) as {
+        id: string;
+        contact_id: string;
+        headline: string;
+        source_url: string;
+        published_at: number | null;
+        fetched_at: number;
+        guid: string;
+        seen: number;
+      }[]) {
+        shared
+          .prepare(
+            `INSERT OR IGNORE INTO contact_alert_mentions
+               (id, contact_id, headline, source_url, published_at, fetched_at, guid, seen)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          )
+          .run(m.id, m.contact_id, m.headline, m.source_url, m.published_at, m.fetched_at, m.guid, m.seen);
+        mentionIds.push(m.id);
+      }
     }
   }
 
   if (membershipIds.length > 0) {
-    const mPlaceholders = membershipIds.map(() => '?').join(',');
-
     // Interaction log entries (push entries not yet synced that are linked to these memberships)
-    for (const e of local
-      .prepare(
-        `SELECT DISTINCT ile.id, ile.contact_id, ile.reporter_email, ile.reporter_name, ile.body, ile.created_at
-         FROM interaction_log_entries ile
-         JOIN interaction_projects ip ON ip.interaction_id = ile.id
-         WHERE ip.membership_id IN (${mPlaceholders}) AND ile.synced_at IS NULL`,
-      )
-      .all(...membershipIds) as {
-      id: string;
-      contact_id: string;
-      reporter_email: string;
-      reporter_name: string;
-      body: string;
-      created_at: number;
-    }[]) {
-      shared
+    const seenEntryIds = new Set<string>();
+    for (let i = 0; i < membershipIds.length; i += CHUNK) {
+      const chunk = membershipIds.slice(i, i + CHUNK);
+      const mPlaceholders = chunk.map(() => '?').join(',');
+      for (const e of local
         .prepare(
-          `INSERT OR IGNORE INTO interaction_log_entries
-             (id, contact_id, reporter_email, reporter_name, body, created_at)
-           VALUES (?, ?, ?, ?, ?, ?)`,
+          `SELECT DISTINCT ile.id, ile.contact_id, ile.reporter_email, ile.reporter_name, ile.body, ile.created_at
+           FROM interaction_log_entries ile
+           JOIN interaction_projects ip ON ip.interaction_id = ile.id
+           WHERE ip.membership_id IN (${mPlaceholders}) AND ile.synced_at IS NULL`,
         )
-        .run(e.id, e.contact_id, e.reporter_email, e.reporter_name, e.body, e.created_at);
-      // Push all interaction_projects rows for this entry
-      for (const ip of local
-        .prepare('SELECT interaction_id, membership_id FROM interaction_projects WHERE interaction_id = ?')
-        .all(e.id) as { interaction_id: string; membership_id: string }[]) {
+        .all(...chunk) as {
+        id: string;
+        contact_id: string;
+        reporter_email: string;
+        reporter_name: string;
+        body: string;
+        created_at: number;
+      }[]) {
+        if (seenEntryIds.has(e.id)) continue;
+        seenEntryIds.add(e.id);
         shared
-          .prepare('INSERT OR IGNORE INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)')
-          .run(ip.interaction_id, ip.membership_id);
+          .prepare(
+            `INSERT OR IGNORE INTO interaction_log_entries
+               (id, contact_id, reporter_email, reporter_name, body, created_at)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+          )
+          .run(e.id, e.contact_id, e.reporter_email, e.reporter_name, e.body, e.created_at);
+        // Only push interaction_projects rows referencing this project's memberships.
+        // Rows pointing at other projects' memberships don't exist in this shared DB
+        // and would cause FK violations.
+        for (const ip of local
+          .prepare('SELECT interaction_id, membership_id FROM interaction_projects WHERE interaction_id = ?')
+          .all(e.id) as { interaction_id: string; membership_id: string }[]) {
+          if (!membershipIdSet.has(ip.membership_id)) continue;
+          shared
+            .prepare('INSERT OR IGNORE INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)')
+            .run(ip.interaction_id, ip.membership_id);
+        }
+        logEntryIds.push(e.id);
       }
-      logEntryIds.push(e.id);
     }
   }
 

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -830,6 +830,10 @@ function pushAppendOnly(
         body: string;
         created_at: number;
       }[]) {
+        // seenEntryIds prevents double-inserting entries that appear across multiple membership
+        // chunks. The interaction_projects loop below fetches all rows for e.id (not just the
+        // current chunk), so the first encounter pushes everything valid — later encounters
+        // are safe to skip entirely.
         if (seenEntryIds.has(e.id)) continue;
         seenEntryIds.add(e.id);
         shared

--- a/src/test/sync-engine.test.ts
+++ b/src/test/sync-engine.test.ts
@@ -802,3 +802,67 @@ describe('sub-table deletion self-healing', () => {
     expect((sharedDb.prepare('SELECT phone FROM contact_phones WHERE contact_id = ?').all(contactId) as { phone: string }[]).map((r) => r.phone)).toContain('+15551234567'); // B's phone also present ✓
   });
 });
+
+// ---------------------------------------------------------------------------
+// RSS sub-table additive merge (#411)
+// ---------------------------------------------------------------------------
+
+describe('mergeSubTablesFromShared — RSS additive merge (#411)', () => {
+  it('preserves a local-only RSS feed when the shared contact is newer', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'RSS Merge Test');
+
+    const contactId = uuidv4();
+    localDb.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Alice', NOW - 100, NOW - 100);
+    // Local has an RSS feed not yet pushed to shared
+    localDb.prepare('INSERT INTO contact_alert_rss (id, contact_id, rss_url, is_invalid) VALUES (?, ?, ?, 0)').run(uuidv4(), contactId, 'https://alice.com/feed.rss');
+    localInsertMembership(localDb, contactId, projectId);
+
+    // Shared is newer and has a different RSS feed
+    sharedInsertContact(sharedDb, contactId, 'Alice Updated', { updatedAt: NOW });
+    sharedDb.prepare('INSERT INTO contact_alert_rss (id, contact_id, rss_url, is_invalid) VALUES (?, ?, ?, 0)').run(uuidv4(), contactId, 'https://alice.com/news.rss');
+    sharedInsertMembership(sharedDb, uuidv4(), contactId);
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+
+    const feeds = (localDb.prepare('SELECT rss_url FROM contact_alert_rss WHERE contact_id = ?').all(contactId) as { rss_url: string }[]).map((r) => r.rss_url);
+    expect(feeds).toContain('https://alice.com/feed.rss');   // local-only preserved
+    expect(feeds).toContain('https://alice.com/news.rss');   // from shared
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pushAppendOnly — cross-project membership guard (#410)
+// ---------------------------------------------------------------------------
+
+describe('pushAppendOnly — cross-project membership guard (#410)', () => {
+  it('does not push interaction_projects rows for memberships outside the current project', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Project A');
+    const otherProjectId = insertProject(localDb, 'Project B');
+
+    const contactId = insertContact(localDb, 'Alice');
+    const membershipA = localInsertMembership(localDb, contactId, projectId);
+    const membershipB = localInsertMembership(localDb, contactId, otherProjectId);
+
+    // One log entry linked to BOTH memberships
+    const logId = uuidv4();
+    localDb.prepare('INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)').run(logId, contactId, 'r@r.com', 'Reporter', 'Log entry', NOW);
+    localDb.prepare('INSERT INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)').run(logId, membershipA);
+    localDb.prepare('INSERT INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)').run(logId, membershipB);
+
+    // Syncing Project A's shared DB — membershipB doesn't exist there, so pushing it would be an FK violation
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+
+    // The log entry should be in shared, but only linked to membershipA
+    expect(sharedDb.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(logId)).toBeDefined();
+    const ipRows = sharedDb.prepare('SELECT membership_id FROM interaction_projects WHERE interaction_id = ?').all(logId) as { membership_id: string }[];
+    const pushedMembershipIds = ipRows.map((r) => r.membership_id);
+    expect(pushedMembershipIds).toContain(membershipA);
+    expect(pushedMembershipIds).not.toContain(membershipB);
+  });
+});

--- a/src/test/sync-engine.test.ts
+++ b/src/test/sync-engine.test.ts
@@ -828,6 +828,7 @@ describe('mergeSubTablesFromShared — RSS additive merge (#411)', () => {
     expect(result.success).toBe(true);
 
     const feeds = (localDb.prepare('SELECT rss_url FROM contact_alert_rss WHERE contact_id = ?').all(contactId) as { rss_url: string }[]).map((r) => r.rss_url);
+    expect(feeds).toHaveLength(2);
     expect(feeds).toContain('https://alice.com/feed.rss');   // local-only preserved
     expect(feeds).toContain('https://alice.com/news.rss');   // from shared
   });


### PR DESCRIPTION
## Summary

Three correctness bugs found during a sync engine code review.

- **RSS sub-table additive merge** (#411): `contact_alert_rss` was doing a destructive DELETE+replace on pull, silently discarding local-only RSS feeds when a newer shared contact was pulled. All other sub-tables (emails, phones, links, handles) use an additive union; RSS now does too.

- **Cross-project membership FK leak** (#410): `pushAppendOnly` was fetching _all_ `interaction_projects` rows for a log entry and pushing them to the current project's shared DB — including rows referencing memberships from other projects. Since `INSERT OR IGNORE` doesn't suppress FK violations, this would cause the shared transaction to roll back and the project to get stuck at `shared_pending_writes = 1`. The fix filters to only rows whose `membership_id` is in the current project's membership set.

- **SQLite variable limit for large projects** (#412): The `IN (?)` queries in `pushAppendOnly` spread contact/membership IDs directly as bind parameters. SQLite's default `SQLITE_LIMIT_VARIABLE_NUMBER` is 999; projects with 1000+ contacts would fail with "too many SQL variables". Both queries are now chunked in batches of 500.

## Test plan

- New test: `mergeSubTablesFromShared — RSS additive merge (#411)` — verifies local-only RSS feed survives a pull where shared contact is newer
- New test: `pushAppendOnly — cross-project membership guard (#410)` — verifies only current-project membership IDs are pushed; cross-project IDs are filtered out
- Existing self-healing test confirms RSS and sub-table merge behaviour is preserved
- All 439 tests pass

Closes #410
Closes #411
Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)