### PR TITLE
Fix claude-review workflow: remove spurious single quotes from claude_args

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,7 +25,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           label_trigger: claude-review
           claude_args: |
-            '--allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

The `claude_args` value in `.github/workflows/claude-review.yml` was wrapped in single quotes, which were being passed as literal characters to the Claude Code CLI and causing it to exit with code 1 on every run.

```yaml
# Before (broken)
claude_args: |
  '--allowedTools "..."'

# After (correct, matches official action examples)
claude_args: |
  --allowedTools "..."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)