### PR TITLE
chore: bump to v0.1.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sourcerer",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sourcerer",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcerer",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "description": "Encrypted source management for journalists",
   "author": "Tom Cardoso",


### PR DESCRIPTION
## What's new

### New features
- **Linkify URLs in notes** — URLs in contact notes and interaction log entries are now clickable links.
- **Scratchpad view/edit mode** — the scratchpad now has a read-only view mode with an Edit button; Cmd+Enter saves.
- **Mark individual mentions as read** — alert mentions can now be dismissed one at a time with a dedicated button, rather than only in bulk.
- **Sort and filter state persists** — the sort order and active filters you set on a contacts list are remembered when you navigate away and come back.

### Bug fixes and improvements
- **Print layouts overhauled** — contact sheets, interaction log modals, and the timeline print view reworked: better typography, correct page breaks, a unified print stylesheet, and the interaction log now reliably populates when printing.
- **Sync reliability improvements** — RSS feed subscriptions are now preserved on both sides during a concurrent sync (previously a newer edit from another client could silently wipe local-only feeds); large projects (1000+ contacts) no longer hit a SQLite variable limit that caused sync to get stuck; a cross-project data leak in interaction log entries has been closed.
- **Calendar subscription fix** — changed from `webcal://` to `http://` to fix broken Apple Calendar subscriptions.
- **Import improvements** — fixed CSV malformed quotes and BOM handling, VCF name fallback, and added a file size limit.
- **Calendar picker** — fixed disabled day cursor cursor feedback and year grid re-centering.
- **RSS feed list refreshes immediately after saving** — previously required a manual reload to see new feeds.
- **Screenshot height cap raised to 25,000px** — with a visible warning when a page is taller than the cap.
- **Error shown when joining a shared project fails** — rather than silently doing nothing.
- **Version number in settings** — the app version is now shown at the bottom of the Settings panel.
- **Lock screen height fix** — the lock screen no longer overflows on smaller displays.
- **Backup system reliability** — entry bounds checks, forward-compat handling, vault teardown safety, and consistent snapshot behaviour.
- **Performance improvements** — faster contacts list query, FTS5 full-text search index for contacts, lazy-loaded renderer data, debounced search, and reduced IPC call overhead throughout.

### Accessibility
- **Keyboard navigation** — improved across the sidebar, dropdowns, and calendar picker.

### Security and stability
- **IPC input validation** — bounds checks and array length caps on all IPC handlers.
- **Security hardening** — preload, linkify, and shared-type security fixes; SSRF guard improvements.
- **Transaction safety** — multi-statement DB writes wrapped in transactions throughout.
- **Cancellation guards** — race conditions in search, contact switching, and reminder submission fixed.

<details>
<summary>Full commit list</summary>

- #414 Fix sync engine bugs: RSS merge, FK leak, variable limit (#410, #411, #412)
- #409 Polish print layouts across contact detail, log modal, and timeline (#392)
- #405 Surface initial sync error when joining a shared project
- #403 Add IPC input validation (#193)
- #402 Add mark-as-read button to individual mentions (#391)
- #401 Persist sort/filter state across navigation (#221)
- #400 Fix lock screen height; add version number to settings footer (#393, #394)
- #399 Fix sync inflight guard and pull filter
- #389 Fix isPolling deadlock on synchronous exception in pollAll
- #386 Fix RSS list not refreshing after save; raise screenshot cap to 25,000px (#369, #377)
- #385 Add useMutation hook; scratchpad view/edit mode (#166, #344)
- #384 Four small UI/doc polish fixes (#171, #296, #368, #383)
- #382 Fix calendar subscription: webcal:// → http:// (#380)
- #379 Split three oversized components (#226, #229, #233)
- #378 Extract duplicated constants, validation hook, and reminder utils (#230, #234, #285)
- #374, #375 Keyboard accessibility improvements
- #372 Fix four isolated bugs (#241, #283, #302, #307)
- #373 Replace inline styles with CSS custom properties
- #366 Performance: stream interaction log during export; reduce peak memory
- #370 Performance: reduce renderer IPC calls; lazy-load expensive data
- #367 Add FTS5 full-text search index for contacts (#213)
- #364 Cache prepared statements per DB connection
- #363 Fix backup system: entry bounds, forward compat, vault teardown safety
- #362 Rewrite contacts:list to one row per contact; add LIMIT to timelines
- #361 Fix DB/IPC correctness: read-back, merge validation, key-compare, cipher pragmas
- #359 Three sync engine performance fixes
- #358 Debounce search modal IPC calls by 250ms
- #357 Eliminate redundant IPC calls and lazy-load expensive renderer data
- #356 Fix import bugs: CSV malformed quotes + BOM, VCF FN fallback, file size limit
- #355 Fix CalendarPicker: disabled day cursor feedback, year grid re-centering
- #360 Fix UI error handling: optimistic revert, allSettled bulk ops, dropdown stability
- #354 Fix UI logic bugs: inverted outreach toggle, DynamicList stable keys, print timestamp
- #353 Add missing indexes on reminders and contact_alert_mentions
- #352 Fix extension: surface fetchContacts errors, screenshot upload timeout
- #351 Wrap settings:set-auto-backup writes in a transaction
- #350 Wrap multi-statement DB writes in transactions
- #342, #343 CSS design system and code fixes (#163, #167, #254, #260, #266, #274, #284, #292, #293, #294, #299, #322, #331)
- #339 Fix transaction safety and atomicity in DB layer and IPC handlers
- #338 Fix cancellation guards in AddContactModal, ScreenshotPanel, JoinProjectModal
- #337 Fix small renderer bugs: stale unseen count, Modal autoFocus, DST date math
- #336 Harden SSRF guard and RSS error classification
- #335 Fix file operation safety: temp-file writes, operation ordering
- #340 Fix bugs introduced by GlobalTab split
- #333 Fix security bugs in preload, linkify, and shared types
- #332 Replace hand-rolled modal scaffolds with shared Modal component
- #330 Fix border-radius and CSS declaration violations
- #155 Split GlobalTab into focused sub-components (#127)
- #153 Fix async error handling in GlobalTab (#134)
- #152 Migrate AddContactModal to shared Modal component (#135)
- #150 Extract useSortFilter hook (#128)
- #149 Fix timeline contact drawer (#148)
- #141 Refactor LogAllModal to use Modal component (#126)
- #143 Fix contact switch race condition in ContactDetail (#131)
- #142 Fix search result race condition in SearchModal (#130)
- #144 Guard reminder Add button against double-submit (#132)
- #145 Move backup/restore loading flags into finally blocks (#133)
- #146 Replace off-palette colours in Sidebar.css (#136)
- #147 Fix db:export to find vault via vault.json
- #139 Linkify URLs in notes and interaction log entries
- #129 Fix stale updated_at after contact dedup merge
- #125 Remove border-radius from interactive elements and modal cards
- #124 Replace inline styles with CSS classes

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)