### PR TITLE
Add light / dark / system theme toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,11 @@ All design tokens are CSS custom properties defined in `src/renderer/src/global.
 - Always use `CalendarPicker` (`src/renderer/src/views/CalendarPicker.tsx`) for any date input — never use `<input type="date">` (see issue #46 for outstanding cases)
 - Always use `Modal` (`src/renderer/src/shell/Modal.tsx`) for any new modal — never reimplement the overlay/card/title/Escape scaffold by hand. Pass `title`, `onDismiss`, and optionally `className` (appended to `modal-card`); put all content including `.modal-actions` as children. Use `modal-description` for the primary intro paragraph beneath the title
 
+**Theming:**
+- The app supports light, dark, and system themes. The active theme is stored as `theme` on the `users` row (`'light' | 'dark' | 'system'`) and applied by setting `data-theme` on `<html>` from AppShell.
+- Dark tokens are defined in `[data-theme="dark"] { … }` in `global.css`. System follows the OS via `@media (prefers-color-scheme: dark) { [data-theme="system"] { … } }` — no JS logic needed.
+- Always use CSS custom properties for colours. Never hardcode hex or rgba colour values in component CSS — every colour must come from a token defined in `global.css`. The only accepted exception is box-shadow `rgba(0,0,0,…)` values, which represent ambient shadow physics and are fine as-is in both themes.
+
 **Hard rules — do not break these:**
 - All interactive elements (buttons, inputs, selects, textareas) use `border-radius: 0` — square corners everywhere, no exceptions
 - Mono type is almost always `text-transform: uppercase` — exceptions only for body-level mono (e.g. code snippets)

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -27,7 +27,8 @@ export const LOCAL_SCHEMA_DDL_SQL = `
     auto_backup_enabled            INTEGER NOT NULL DEFAULT 0,
     auto_backup_dest_path          TEXT,
     auto_backup_max_count          INTEGER NOT NULL DEFAULT 10,
-    dev_seeded                     INTEGER NOT NULL DEFAULT 0
+    dev_seeded                     INTEGER NOT NULL DEFAULT 0,
+    theme                          TEXT    NOT NULL DEFAULT 'light'
   );
 
   CREATE TABLE IF NOT EXISTS contacts (

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -9,7 +9,9 @@ import { getPaths, deriveKey, getVaultBundlePath, writeVaultConfig, clearVaultCo
 import { autoLock } from '../auto-lock';
 import { setRssPollIntervalHours } from '../sync/poller';
 import { validateEmail } from '@shared/validation';
-import type { User } from '@shared/types';
+import type { ThemeMode, User } from '@shared/types';
+
+const VALID_THEMES = new Set<ThemeMode>(['light', 'dark', 'system']);
 
 const SAFE_USER_SQL = `
   SELECT id, first_name, last_name, email, created_at, idle_timeout_seconds,
@@ -17,7 +19,7 @@ const SAFE_USER_SQL = `
          staleness_enabled, staleness_threshold_days, alert_notifications_enabled,
          reminder_notifications_enabled, rss_poll_interval_hours, wayback_enabled,
          CASE WHEN archive_access_key IS NOT NULL AND archive_secret_key IS NOT NULL THEN 1 ELSE 0 END AS wayback_keys_configured,
-         auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count
+         auto_backup_enabled, auto_backup_dest_path, auto_backup_max_count, theme
   FROM users WHERE id = 1`;
 
 export function getSafeUser(db: Database.Database): User {
@@ -377,5 +379,19 @@ export function registerSettingsHandlers(): void {
       properties: ['openDirectory', 'createDirectory'],
     });
     return canceled || filePaths.length === 0 ? null : filePaths[0];
+  });
+
+  ipcMain.handle('settings:get-theme', (): ThemeMode => {
+    const row = getDatabase()
+      .prepare('SELECT theme FROM users WHERE id = 1')
+      .get() as { theme: ThemeMode } | undefined;
+    return row?.theme ?? 'light';
+  });
+
+  ipcMain.handle('settings:set-theme', (_, mode: ThemeMode): User => {
+    if (!VALID_THEMES.has(mode)) throw new Error(`Invalid theme: ${mode}`);
+    const db = getDatabase();
+    db.prepare('UPDATE users SET theme = ? WHERE id = 1').run(mode);
+    return getSafeUser(db);
   });
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import type {
+  ThemeMode,
   SetupFormData,
   SetupResult,
   FirstLaunchResult,
@@ -215,6 +216,8 @@ const sourcererApi = {
   getIdleTimeout: (): Promise<number> => ipcRenderer.invoke('settings:get-idle-timeout'),
   setIdleTimeout: (seconds: number): Promise<void> =>
     ipcRenderer.invoke('settings:set-idle-timeout', seconds),
+  getTheme: (): Promise<ThemeMode> => ipcRenderer.invoke('settings:get-theme'),
+  setTheme: (mode: ThemeMode): Promise<User> => ipcRenderer.invoke('settings:set-theme', mode),
 
   // Export
   exportProject: (projectId: string, mode: 'full' | 'sanitized', contactIds?: string[]): Promise<{ success: boolean; error?: string }> =>

--- a/src/renderer/src/components/WordmarkLogo.tsx
+++ b/src/renderer/src/components/WordmarkLogo.tsx
@@ -90,7 +90,7 @@ export function WordmarkLogo({ compact = false, size, className }: Props) {
         fontWeight="700"
         fontSize="56"
         letterSpacing="-1"
-        fill={INK}
+        fill="currentColor"
       >
         Sourcerer
       </text>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 import type {
+  ThemeMode,
   Project,
   User,
   ContactListItem,
@@ -145,6 +146,8 @@ declare global {
       regenerateCalendarToken: () => Promise<User>;
       getIdleTimeout: () => Promise<number>;
       setIdleTimeout: (seconds: number) => Promise<void>;
+      getTheme: () => Promise<ThemeMode>;
+      setTheme: (mode: ThemeMode) => Promise<User>;
 
       // Export
       exportProject: (projectId: string, mode: 'full' | 'sanitized', contactIds?: string[]) => Promise<{ success: boolean; error?: string }>;

--- a/src/renderer/src/global.css
+++ b/src/renderer/src/global.css
@@ -99,6 +99,105 @@
 
   /* ── Chrome ───────────────────────────────────── */
   --titlebar-height: 38px;
+
+  /* ── Scrollbar ────────────────────────────────── */
+  --scrollthumb:       rgba(0, 0, 0, 0.22);
+  --scrollthumb-hover: rgba(0, 0, 0, 0.38);
+}
+
+/* ── Explicit light theme (data-theme="light") ───── */
+[data-theme="light"] {
+  --color-bg:              #faf9f5;
+  --color-surface:         #f3f1ea;
+  --color-surface-2:       #eceadf;
+  --color-text:            #1a1815;
+  --color-text-muted:      #5b5750;
+  --color-text-dim:        #8a857c;
+  --color-border:          rgba(26, 24, 21, 0.14);
+  --color-border-strong:   rgba(26, 24, 21, 0.28);
+  --color-amber:           #e8a840;
+  --color-primary:         #c87a1a;
+  --color-primary-hover:   #a8641a;
+  --color-success:         #2d8f6a;
+  --color-danger:          #b91c1c;
+  --color-danger-bg:       #fff5f5;
+  --color-danger-bg-hover: #fee2e2;
+  --color-warning-bg:      #fef3c7;
+  --color-warning-border:  #f59e0b;
+  --color-warning-text:    #92400e;
+  --sidebar-bg:            #edeae0;
+  --sidebar-text:          #1a1815;
+  --sidebar-text-muted:    #5b5750;
+  --sidebar-active-bg:     #1a1815;
+  --sidebar-active-text:   #faf9f5;
+  --sidebar-hover-bg:      #e4e1d7;
+  --sidebar-border:        rgba(26, 24, 21, 0.14);
+  --scrollthumb:           rgba(0, 0, 0, 0.22);
+  --scrollthumb-hover:     rgba(0, 0, 0, 0.38);
+}
+
+/* ── Dark theme ──────────────────────────────────── */
+[data-theme="dark"] {
+  --color-bg:              #1b1812;
+  --color-surface:         #232019;
+  --color-surface-2:       #2c2820;
+  --color-text:            #f1ede4;
+  --color-text-muted:      #b4ada0;
+  --color-text-dim:        #847d6f;
+  --color-border:          rgba(241, 237, 228, 0.12);
+  --color-border-strong:   rgba(241, 237, 228, 0.26);
+  --color-amber:           #eab44f;
+  --color-primary:         #e0973a;
+  --color-primary-hover:   #efb162;
+  --color-success:         #46b88c;
+  --color-danger:          #ee6058;
+  --color-danger-bg:       #2c1715;
+  --color-danger-bg-hover: #3a1d1a;
+  --color-warning-bg:      #2e2613;
+  --color-warning-border:  #f3a52a;
+  --color-warning-text:    #edc079;
+  --sidebar-bg:            #16130d;
+  --sidebar-text:          #f1ede4;
+  --sidebar-text-muted:    #b4ada0;
+  --sidebar-active-bg:     #efe9df;
+  --sidebar-active-text:   #1b1812;
+  --sidebar-hover-bg:      #221f17;
+  --sidebar-border:        rgba(241, 237, 228, 0.12);
+  --scrollthumb:           rgba(255, 252, 245, 0.22);
+  --scrollthumb-hover:     rgba(255, 252, 245, 0.38);
+}
+
+/* ── System theme: follow OS preference ─────────── */
+@media (prefers-color-scheme: dark) {
+  [data-theme="system"] {
+    --color-bg:              #1b1812;
+    --color-surface:         #232019;
+    --color-surface-2:       #2c2820;
+    --color-text:            #f1ede4;
+    --color-text-muted:      #b4ada0;
+    --color-text-dim:        #847d6f;
+    --color-border:          rgba(241, 237, 228, 0.12);
+    --color-border-strong:   rgba(241, 237, 228, 0.26);
+    --color-amber:           #eab44f;
+    --color-primary:         #e0973a;
+    --color-primary-hover:   #efb162;
+    --color-success:         #46b88c;
+    --color-danger:          #ee6058;
+    --color-danger-bg:       #2c1715;
+    --color-danger-bg-hover: #3a1d1a;
+    --color-warning-bg:      #2e2613;
+    --color-warning-border:  #f3a52a;
+    --color-warning-text:    #edc079;
+    --sidebar-bg:            #16130d;
+    --sidebar-text:          #f1ede4;
+    --sidebar-text-muted:    #b4ada0;
+    --sidebar-active-bg:     #efe9df;
+    --sidebar-active-text:   #1b1812;
+    --sidebar-hover-bg:      #221f17;
+    --sidebar-border:        rgba(241, 237, 228, 0.12);
+    --scrollthumb:           rgba(255, 252, 245, 0.22);
+    --scrollthumb-hover:     rgba(255, 252, 245, 0.38);
+  }
 }
 
 /* Lock typefaces — only Spectral and JetBrains Mono */
@@ -157,11 +256,11 @@ body {
 
 *:hover::-webkit-scrollbar-thumb,
 *:focus::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--scrollthumb);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(0, 0, 0, 0.35);
+  background: var(--scrollthumb-hover);
 }
 
 ::-webkit-scrollbar-corner {

--- a/src/renderer/src/shell/AppShell.tsx
+++ b/src/renderer/src/shell/AppShell.tsx
@@ -72,6 +72,10 @@ export default function AppShell() {
   }, [refreshOverdue]);
 
   useEffect(() => {
+    document.documentElement.dataset.theme = user?.theme ?? 'light';
+  }, [user?.theme]);
+
+  useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'R') {
         e.preventDefault();

--- a/src/renderer/src/shell/Button.css
+++ b/src/renderer/src/shell/Button.css
@@ -97,5 +97,5 @@
 }
 
 .btn--danger-outline:hover:not(:disabled) {
-  background: rgba(185, 28, 28, 0.06);
+  background: var(--color-danger-bg);
 }

--- a/src/renderer/src/shell/Sidebar.css
+++ b/src/renderer/src/shell/Sidebar.css
@@ -19,6 +19,7 @@
   display: block;
   line-height: 0;
   padding-left: 12px;
+  color: var(--sidebar-text);
 }
 
 .sidebar-header-add {

--- a/src/renderer/src/views/SettingsView.css
+++ b/src/renderer/src/views/SettingsView.css
@@ -490,3 +490,39 @@
 .sv-input--short {
   width: 72px;
 }
+
+/* ── Theme segmented control ─────────────────────── */
+.sv-theme-seg {
+  display: inline-flex;
+  border: 1px solid var(--color-border-strong);
+}
+
+.sv-theme-seg-btn {
+  height: 28px;
+  padding: 0 14px;
+  border: none;
+  border-right: 1px solid var(--color-border-strong);
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+
+.sv-theme-seg-btn:last-child {
+  border-right: none;
+}
+
+.sv-theme-seg-btn:hover:not(.sv-theme-seg-btn--active) {
+  color: var(--color-text);
+}
+
+.sv-theme-seg-btn--active {
+  background: var(--color-primary);
+  color: #fff;
+  border-right-color: var(--color-primary);
+}

--- a/src/renderer/src/views/SettingsView.css
+++ b/src/renderer/src/views/SettingsView.css
@@ -113,7 +113,7 @@
 .sv-input:focus,
 .sv-select:focus {
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(29, 78, 216, 0.1);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
 .sv-input:disabled,
@@ -193,7 +193,7 @@
 }
 
 .sv-move-btn:hover:not(:disabled) {
-  background: #f3f4f6;
+  background: var(--color-surface-2);
   color: var(--color-text);
 }
 
@@ -219,8 +219,8 @@
 }
 
 .sv-delete-btn:hover {
-  background: #fef2f2;
-  border-color: #fca5a5;
+  background: var(--color-danger-bg);
+  border-color: color-mix(in srgb, var(--color-danger) 40%, transparent);
   color: var(--color-danger);
 }
 
@@ -296,7 +296,7 @@
 
 .sv-success {
   font-size: 12px;
-  color: #16a34a;
+  color: var(--color-success);
   margin: 0 0 10px;
 }
 
@@ -409,7 +409,7 @@
 
 .sv-backup-saved {
   font-size: 12px;
-  color: #16a34a;
+  color: var(--color-success);
   animation: sv-fade-out 3s ease forwards;
 }
 

--- a/src/renderer/src/views/SettingsView.css
+++ b/src/renderer/src/views/SettingsView.css
@@ -361,8 +361,8 @@
 }
 
 .sv-danger-inset {
-  border: 1px solid #fecaca;
-  background: #fff5f5;
+  border: 1px solid var(--color-danger-bg-hover);
+  background: var(--color-danger-bg);
   padding: 14px 16px;
 }
 

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { getCountries, getCountryCallingCode } from 'libphonenumber-js';
-import type { User } from '@shared/types';
+import type { ThemeMode, User } from '@shared/types';
 import Button from '../shell/Button';
 import Toggle from './SettingsToggle';
 import ProfileSection from './ProfileSection';
@@ -23,6 +23,7 @@ const TIMEOUT_OPTIONS = [
 ];
 
 export default function SettingsView({ user, onUserUpdated }: Props) {
+  const [theme, setThemeState] = useState<ThemeMode>('light');
   const [idleTimeout, setIdleTimeout] = useState<number>(900);
   const [phoneCountry, setPhoneCountry] = useState<string>('CA');
   const [outreachRemindersEnabled, setOutreachRemindersEnabled] = useState<boolean>(true);
@@ -67,6 +68,7 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
 
   useEffect(() => {
     if (user) {
+      setThemeState(user.theme ?? 'light');
       setPhoneCountry(user.phone_country ?? 'CA');
       setOutreachRemindersEnabled(user.outreach_reminders_enabled !== 0);
       setOutreachRequireInteraction(user.outreach_require_interaction !== 0);
@@ -86,6 +88,16 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
       if (archiveKeysSavedTimerRef.current) clearTimeout(archiveKeysSavedTimerRef.current);
     };
   }, [user?.id]);
+
+  async function handleThemeChange(mode: ThemeMode) {
+    setThemeState(mode);
+    try {
+      const updated = await window.sourcerer.setTheme(mode);
+      onUserUpdated(updated);
+    } catch {
+      setThemeState(theme);
+    }
+  }
 
   async function handleRegenerateToken() {
     const updated = await window.sourcerer.regenerateCalendarToken();
@@ -246,6 +258,29 @@ export default function SettingsView({ user, onUserUpdated }: Props) {
 
       <div className="sv-body">
         <ProfileSection user={user} onUserUpdated={onUserUpdated} />
+
+        {/* Appearance */}
+        <div className="sv-section">
+          <div className="sv-section-title">Appearance</div>
+          <p className="sv-hint">Choose a colour scheme for the app.</p>
+          <div
+            className="sv-theme-seg"
+            role="group"
+            aria-label="Colour scheme"
+          >
+            {(['light', 'dark', 'system'] as ThemeMode[]).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                className={`sv-theme-seg-btn${theme === mode ? ' sv-theme-seg-btn--active' : ''}`}
+                onClick={() => handleThemeChange(mode)}
+                aria-pressed={theme === mode}
+              >
+                {mode}
+              </button>
+            ))}
+          </div>
+        </div>
 
         {/* Staleness */}
         <div className="sv-section">

--- a/src/renderer/src/views/Timeline.css
+++ b/src/renderer/src/views/Timeline.css
@@ -1,3 +1,15 @@
+/* Keep the print button out of the heading flow so .view-rule-thick aligns
+   with other views (AllContacts, ProjectView) that have no extra flex child. */
+.view-header-row {
+  position: relative;
+}
+
+.view-header-row > .btn {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
 .ptl-meta-bar {
   flex-wrap: wrap;
   gap: 4px 0;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,3 +1,5 @@
+export type ThemeMode = 'light' | 'dark' | 'system';
+
 export interface SetupFormData {
   firstName: string;
   lastName: string;
@@ -70,6 +72,7 @@ export interface User {
   auto_backup_enabled: 0 | 1;
   auto_backup_dest_path: string | null;
   auto_backup_max_count: number;
+  theme: ThemeMode;
 }
 
 export interface ContactListItem {

--- a/src/test/settings-theme.test.ts
+++ b/src/test/settings-theme.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDb } from './vitest.setup';
+import type Database from 'better-sqlite3-multiple-ciphers';
+
+function getTheme(db: Database.Database): string {
+  const row = db.prepare('SELECT theme FROM users WHERE id = 1').get() as { theme: string } | undefined;
+  return row?.theme ?? 'light';
+}
+
+function setTheme(db: Database.Database, mode: string): void {
+  db.prepare('UPDATE users SET theme = ? WHERE id = 1').run(mode);
+}
+
+describe('settings: theme', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('defaults to "light"', () => {
+    expect(getTheme(db)).toBe('light');
+  });
+
+  it('persists "dark"', () => {
+    setTheme(db, 'dark');
+    expect(getTheme(db)).toBe('dark');
+  });
+
+  it('persists "system"', () => {
+    setTheme(db, 'system');
+    expect(getTheme(db)).toBe('system');
+  });
+
+  it('can round-trip back to "light"', () => {
+    setTheme(db, 'dark');
+    setTheme(db, 'light');
+    expect(getTheme(db)).toBe('light');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `theme` column (`TEXT NOT NULL DEFAULT 'light'`) to the `users` table — no migration, schema updated directly (pre-production)
- Exposes `settings:get-theme` / `settings:set-theme` IPC handlers and wires them through the preload bridge and `env.d.ts` type declaration
- Applies `data-theme` on `<html>` from AppShell; a `useEffect` on `user?.theme` keeps it in sync when the user changes the setting
- Dark palette follows the warm, paper-toned aesthetic: near-black warm backgrounds (`#1b1812`), paper-white ink (`#f1ede4`), amber accent lifted for contrast — no cold greys or blues
- System mode works purely in CSS via `@media (prefers-color-scheme: dark) { [data-theme="system"] { … } }`, so it responds to OS changes with no JS polling
- `--scrollthumb` / `--scrollthumb-hover` tokens replace hardcoded `rgba(0,0,0,…)` scrollbar values so they flip with the theme
- 3-way segmented control (Light / Dark / System) added to Settings > Appearance — mono uppercase, square corners, amber active state, CSS co-located in `SettingsView.css`
- 4 new tests covering default value (`'light'`), each valid mode, and round-trip

## Test plan

- [x] CI `test` check passes
- [x] Settings > Appearance shows Light / Dark / System segmented control
- [x] Switching to Dark applies warm dark palette across all views (sidebar, contacts table, modals, detail drawer)
- [x] Switching to System follows macOS appearance preference; toggling OS dark/light mode updates the app immediately (CSS media query)
- [x] Switching back to Light restores the original palette
- [x] Selected theme persists across lock/unlock cycle

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)