### PR TITLE
Add contact tags

### DIFF
--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -229,6 +229,16 @@ export const LOCAL_SCHEMA_DDL_SQL = `
     captured_at INTEGER NOT NULL
   );
 
+  CREATE TABLE IF NOT EXISTS contact_tags (
+    id         TEXT    PRIMARY KEY,
+    contact_id TEXT    NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+    tag        TEXT    NOT NULL,
+    created_at INTEGER NOT NULL DEFAULT 0,
+    synced_at  INTEGER,
+    UNIQUE(contact_id, tag)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_contact_tags_contact_id ON contact_tags(contact_id);
   CREATE INDEX IF NOT EXISTS idx_contact_emails_contact_id        ON contact_emails(contact_id);
   CREATE UNIQUE INDEX IF NOT EXISTS idx_contact_emails_contact_email  ON contact_emails(contact_id, email);
   CREATE INDEX IF NOT EXISTS idx_contact_phones_contact_id        ON contact_phones(contact_id);

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -234,7 +234,6 @@ export const LOCAL_SCHEMA_DDL_SQL = `
     contact_id TEXT    NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
     tag        TEXT    NOT NULL,
     created_at INTEGER NOT NULL DEFAULT 0,
-    synced_at  INTEGER,
     UNIQUE(contact_id, tag)
   );
 

--- a/src/main/database/shared-schema.ts
+++ b/src/main/database/shared-schema.ts
@@ -56,6 +56,14 @@ export const SHARED_SCHEMA_SQL = `
     created_at INTEGER NOT NULL DEFAULT 0
   );
 
+  CREATE TABLE IF NOT EXISTS contact_tags (
+    id         TEXT    PRIMARY KEY,
+    contact_id TEXT    NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+    tag        TEXT    NOT NULL,
+    created_at INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(contact_id, tag)
+  );
+
   CREATE TABLE IF NOT EXISTS contact_alert_rss (
     id             TEXT    PRIMARY KEY,
     contact_id     TEXT    NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
@@ -109,6 +117,7 @@ export const SHARED_SCHEMA_SQL = `
     value TEXT NOT NULL
   );
 
+  CREATE INDEX IF NOT EXISTS idx_shared_contact_tags_contact_id ON contact_tags(contact_id);
   CREATE INDEX IF NOT EXISTS idx_shared_contact_emails_contact_id     ON contact_emails(contact_id);
   CREATE UNIQUE INDEX IF NOT EXISTS idx_shared_contact_emails_contact_email ON contact_emails(contact_id, email);
   CREATE INDEX IF NOT EXISTS idx_shared_contact_phones_contact_id     ON contact_phones(contact_id);

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -763,9 +763,9 @@ export function registerContactHandlers(): void {
     const db = getDatabase();
     const now = Math.floor(Date.now() / 1000);
     db.transaction(() => {
-      db.prepare('INSERT OR IGNORE INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)')
+      const { changes } = db.prepare('INSERT OR IGNORE INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)')
         .run(uuidv4(), contactId, normalized, now);
-      db.prepare('UPDATE contacts SET updated_at = ? WHERE id = ?').run(now, contactId);
+      if (changes > 0) db.prepare('UPDATE contacts SET updated_at = ? WHERE id = ?').run(now, contactId);
     })();
     broadcastContactsChanged();
   });
@@ -774,8 +774,8 @@ export function registerContactHandlers(): void {
     const db = getDatabase();
     const now = Math.floor(Date.now() / 1000);
     db.transaction(() => {
-      db.prepare('DELETE FROM contact_tags WHERE contact_id = ? AND tag = ?').run(contactId, tag);
-      db.prepare('UPDATE contacts SET updated_at = ? WHERE id = ?').run(now, contactId);
+      const { changes } = db.prepare('DELETE FROM contact_tags WHERE contact_id = ? AND tag = ?').run(contactId, tag);
+      if (changes > 0) db.prepare('UPDATE contacts SET updated_at = ? WHERE id = ?').run(now, contactId);
     })();
     broadcastContactsChanged();
   });

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -762,13 +762,21 @@ export function registerContactHandlers(): void {
     if (!normalized || normalized.length > 50) return;
     const db = getDatabase();
     const now = Math.floor(Date.now() / 1000);
-    db.prepare('INSERT OR IGNORE INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)')
-      .run(uuidv4(), contactId, normalized, now);
+    db.transaction(() => {
+      db.prepare('INSERT OR IGNORE INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)')
+        .run(uuidv4(), contactId, normalized, now);
+      db.prepare('UPDATE contacts SET updated_at = ? WHERE id = ?').run(now, contactId);
+    })();
     broadcastContactsChanged();
   });
 
   ipcMain.handle('contacts:remove-tag', (_, { contactId, tag }: { contactId: string; tag: string }): void => {
-    getDatabase().prepare('DELETE FROM contact_tags WHERE contact_id = ? AND tag = ?').run(contactId, tag);
+    const db = getDatabase();
+    const now = Math.floor(Date.now() / 1000);
+    db.transaction(() => {
+      db.prepare('DELETE FROM contact_tags WHERE contact_id = ? AND tag = ?').run(contactId, tag);
+      db.prepare('UPDATE contacts SET updated_at = ? WHERE id = ?').run(now, contactId);
+    })();
     broadcastContactsChanged();
   });
 

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -174,7 +174,8 @@ export function registerContactHandlers(): void {
                  FROM (SELECT pm.project_id AS pid, p.name AS pname
                        FROM project_memberships pm JOIN projects p ON p.id = pm.project_id
                        WHERE pm.contact_id = c.id
-                       ORDER BY p.name COLLATE NOCASE ASC)) AS projects_raw
+                       ORDER BY p.name COLLATE NOCASE ASC)) AS projects_raw,
+                (SELECT GROUP_CONCAT(tag, '\x1f') FROM contact_tags WHERE contact_id = c.id ORDER BY tag) AS tags_raw
          FROM contacts c
          ORDER BY c.name COLLATE NOCASE ASC`,
       )
@@ -192,6 +193,7 @@ export function registerContactHandlers(): void {
       date_first_contacted: number | null;
       date_last_contacted: number | null;
       projects_raw: string | null;
+      tags_raw: string | null;
     }>;
 
     return rows.map((row) => ({
@@ -210,6 +212,7 @@ export function registerContactHandlers(): void {
       projects: row.projects_raw
         ? (JSON.parse(row.projects_raw) as { id: string; name: string }[])
         : [],
+      tags: row.tags_raw ? row.tags_raw.split('\x1f') : [],
     }));
   });
 
@@ -267,7 +270,10 @@ export function registerContactHandlers(): void {
       reporters: allReporters.filter((r) => r.membership_id === p.membership_id),
     }));
 
-    return { ...contact, emails, phones, links, handles, projects: projectsWithReporters } as ContactDetail;
+    const tags = (stmt(db, 'SELECT tag FROM contact_tags WHERE contact_id = ? ORDER BY tag')
+      .all(id) as { tag: string }[]).map((r) => r.tag);
+
+    return { ...contact, emails, phones, links, handles, projects: projectsWithReporters, tags } as ContactDetail;
   });
 
   ipcMain.handle('contacts:create', (_, data: CreateContactInput): ContactListItem => {
@@ -333,7 +339,7 @@ export function registerContactHandlers(): void {
               (SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contact_id = c.id) AS phones_raw
        FROM contacts c WHERE c.id = ?`,
     ).get(id) as { id: string; name: string; organization: string | null; title: string | null; notes: string | null; created_at: number; has_email: 0|1; has_phone: 0|1; emails_raw: string|null; phones_raw: string|null };
-    return { ...row, date_first_contacted: null, date_last_contacted: null, projects: [] };
+    return { ...row, date_first_contacted: null, date_last_contacted: null, projects: [], tags: [] };
   });
 
   ipcMain.handle('contacts:delete', (_, id: string): void => {
@@ -405,7 +411,7 @@ export function registerContactHandlers(): void {
 
   ipcMain.handle('contacts:list-for-project', (_, projectId: string): ProjectContactRow[] => {
     const db = getDatabase();
-    return stmt(db,
+    const rows = stmt(db,
       `SELECT c.id, c.name, c.organization, c.notes,
               pm.id AS membership_id, pm.created_at AS membership_created_at,
               pm.reporter_name, pm.reporter_email,
@@ -415,12 +421,14 @@ export function registerContactHandlers(): void {
               (SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contact_id = c.id) AS emails_raw,
               (SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contact_id = c.id) AS phones_raw,
               (SELECT MIN(ile.created_at) FROM interaction_log_entries ile JOIN interaction_projects ip ON ip.interaction_id = ile.id WHERE ip.membership_id = pm.id) AS date_first_contacted,
-              (SELECT MAX(ile.created_at) FROM interaction_log_entries ile JOIN interaction_projects ip ON ip.interaction_id = ile.id WHERE ip.membership_id = pm.id) AS date_last_contacted
+              (SELECT MAX(ile.created_at) FROM interaction_log_entries ile JOIN interaction_projects ip ON ip.interaction_id = ile.id WHERE ip.membership_id = pm.id) AS date_last_contacted,
+              (SELECT GROUP_CONCAT(tag, '\x1f') FROM contact_tags WHERE contact_id = c.id ORDER BY tag) AS tags_raw
        FROM project_memberships pm
        JOIN contacts c ON c.id = pm.contact_id
        WHERE pm.project_id = ?
        ORDER BY c.name COLLATE NOCASE ASC`,
-    ).all(projectId) as ProjectContactRow[];
+    ).all(projectId) as Array<Omit<ProjectContactRow, 'tags'> & { tags_raw: string | null }>;
+    return rows.map((r) => ({ ...r, tags: r.tags_raw ? r.tags_raw.split('\x1f') : [] }));
   });
 
   ipcMain.handle('contacts:update', (_, data: UpdateContactInput): void => {
@@ -747,6 +755,25 @@ export function registerContactHandlers(): void {
     checkOutreachReminders();
     broadcastContactsChanged();
     if (membershipIds.length > 0) broadcastRemindersChanged();
+  });
+
+  ipcMain.handle('contacts:add-tag', (_, { contactId, tag }: { contactId: string; tag: string }): void => {
+    const normalized = tag.trim().toLowerCase();
+    if (!normalized || normalized.length > 50) return;
+    const db = getDatabase();
+    const now = Math.floor(Date.now() / 1000);
+    db.prepare('INSERT OR IGNORE INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)')
+      .run(uuidv4(), contactId, normalized, now);
+    broadcastContactsChanged();
+  });
+
+  ipcMain.handle('contacts:remove-tag', (_, { contactId, tag }: { contactId: string; tag: string }): void => {
+    getDatabase().prepare('DELETE FROM contact_tags WHERE contact_id = ? AND tag = ?').run(contactId, tag);
+    broadcastContactsChanged();
+  });
+
+  ipcMain.handle('contacts:list-all-tags', (): string[] => {
+    return (getDatabase().prepare('SELECT DISTINCT tag FROM contact_tags ORDER BY tag').all() as { tag: string }[]).map((r) => r.tag);
   });
 
   ipcMain.handle('contacts:count', (): number => {

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -771,10 +771,11 @@ export function registerContactHandlers(): void {
   });
 
   ipcMain.handle('contacts:remove-tag', (_, { contactId, tag }: { contactId: string; tag: string }): void => {
+    const normalized = tag.trim().toLowerCase();
     const db = getDatabase();
     const now = Math.floor(Date.now() / 1000);
     db.transaction(() => {
-      const { changes } = db.prepare('DELETE FROM contact_tags WHERE contact_id = ? AND tag = ?').run(contactId, tag);
+      const { changes } = db.prepare('DELETE FROM contact_tags WHERE contact_id = ? AND tag = ?').run(contactId, normalized);
       if (changes > 0) db.prepare('UPDATE contacts SET updated_at = ? WHERE id = ?').run(now, contactId);
     })();
     broadcastContactsChanged();

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -175,7 +175,7 @@ export function registerContactHandlers(): void {
                        FROM project_memberships pm JOIN projects p ON p.id = pm.project_id
                        WHERE pm.contact_id = c.id
                        ORDER BY p.name COLLATE NOCASE ASC)) AS projects_raw,
-                (SELECT GROUP_CONCAT(tag, '\x1f') FROM contact_tags WHERE contact_id = c.id ORDER BY tag) AS tags_raw
+                (SELECT GROUP_CONCAT(tag, '\x1f') FROM contact_tags WHERE contact_id = c.id ORDER BY created_at) AS tags_raw
          FROM contacts c
          ORDER BY c.name COLLATE NOCASE ASC`,
       )
@@ -270,7 +270,7 @@ export function registerContactHandlers(): void {
       reporters: allReporters.filter((r) => r.membership_id === p.membership_id),
     }));
 
-    const tags = (stmt(db, 'SELECT tag FROM contact_tags WHERE contact_id = ? ORDER BY tag')
+    const tags = (stmt(db, 'SELECT tag FROM contact_tags WHERE contact_id = ? ORDER BY created_at')
       .all(id) as { tag: string }[]).map((r) => r.tag);
 
     return { ...contact, emails, phones, links, handles, projects: projectsWithReporters, tags } as ContactDetail;
@@ -422,7 +422,7 @@ export function registerContactHandlers(): void {
               (SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contact_id = c.id) AS phones_raw,
               (SELECT MIN(ile.created_at) FROM interaction_log_entries ile JOIN interaction_projects ip ON ip.interaction_id = ile.id WHERE ip.membership_id = pm.id) AS date_first_contacted,
               (SELECT MAX(ile.created_at) FROM interaction_log_entries ile JOIN interaction_projects ip ON ip.interaction_id = ile.id WHERE ip.membership_id = pm.id) AS date_last_contacted,
-              (SELECT GROUP_CONCAT(tag, '\x1f') FROM contact_tags WHERE contact_id = c.id ORDER BY tag) AS tags_raw
+              (SELECT GROUP_CONCAT(tag, '\x1f') FROM contact_tags WHERE contact_id = c.id ORDER BY created_at) AS tags_raw
        FROM project_memberships pm
        JOIN contacts c ON c.id = pm.contact_id
        WHERE pm.project_id = ?

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -175,7 +175,7 @@ export function registerContactHandlers(): void {
                        FROM project_memberships pm JOIN projects p ON p.id = pm.project_id
                        WHERE pm.contact_id = c.id
                        ORDER BY p.name COLLATE NOCASE ASC)) AS projects_raw,
-                (SELECT GROUP_CONCAT(tag, '\x1f') FROM contact_tags WHERE contact_id = c.id ORDER BY created_at) AS tags_raw
+                (SELECT GROUP_CONCAT(tag, '\x1f') FROM (SELECT tag FROM contact_tags WHERE contact_id = c.id ORDER BY created_at)) AS tags_raw
          FROM contacts c
          ORDER BY c.name COLLATE NOCASE ASC`,
       )
@@ -422,7 +422,7 @@ export function registerContactHandlers(): void {
               (SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contact_id = c.id) AS phones_raw,
               (SELECT MIN(ile.created_at) FROM interaction_log_entries ile JOIN interaction_projects ip ON ip.interaction_id = ile.id WHERE ip.membership_id = pm.id) AS date_first_contacted,
               (SELECT MAX(ile.created_at) FROM interaction_log_entries ile JOIN interaction_projects ip ON ip.interaction_id = ile.id WHERE ip.membership_id = pm.id) AS date_last_contacted,
-              (SELECT GROUP_CONCAT(tag, '\x1f') FROM contact_tags WHERE contact_id = c.id ORDER BY created_at) AS tags_raw
+              (SELECT GROUP_CONCAT(tag, '\x1f') FROM (SELECT tag FROM contact_tags WHERE contact_id = c.id ORDER BY created_at)) AS tags_raw
        FROM project_memberships pm
        JOIN contacts c ON c.id = pm.contact_id
        WHERE pm.project_id = ?

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -406,10 +406,9 @@ function mergeSubTablesFromShared(
   const mergedTags = [...sharedTags, ...localOnlyTags];
 
   local.prepare('DELETE FROM contact_tags WHERE contact_id = ?').run(contactId);
+  const insertLocalTag = local.prepare('INSERT OR IGNORE INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)');
   for (const t of mergedTags) {
-    local
-      .prepare('INSERT OR IGNORE INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)')
-      .run(t.id, contactId, t.tag, t.created_at);
+    insertLocalTag.run(t.id, contactId, t.tag, t.created_at);
   }
 }
 
@@ -730,14 +729,17 @@ function pushSubTablesToShared(
       .run(rss.id, contactId, rss.rss_url, rss.last_polled_at, rss.is_invalid);
   }
 
-  shared.prepare('DELETE FROM contact_tags WHERE contact_id = ?').run(contactId);
+  const sharedTagSet = new Set(
+    (shared.prepare('SELECT tag FROM contact_tags WHERE contact_id = ?').all(contactId) as { tag: string }[]).map((r) => r.tag),
+  );
   const tagRows = local
     .prepare('SELECT * FROM contact_tags WHERE contact_id = ?')
     .all(contactId) as { id: string; tag: string; created_at: number }[];
+  const insertSharedTag = shared.prepare('INSERT OR IGNORE INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)');
   for (const t of tagRows) {
-    shared
-      .prepare('INSERT OR IGNORE INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)')
-      .run(t.id, contactId, t.tag, t.created_at);
+    if (!sharedTagSet.has(t.tag)) {
+      insertSharedTag.run(t.id, contactId, t.tag, t.created_at);
+    }
   }
 }
 

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -392,6 +392,25 @@ function mergeSubTablesFromShared(
       )
       .run(rss.id, contactId, rss.rss_url, rss.last_polled_at, rss.is_invalid);
   }
+
+  // ── Tags ──────────────────────────────────────────────────────────────────
+  const sharedTags = shared
+    .prepare('SELECT * FROM contact_tags WHERE contact_id = ?')
+    .all(contactId) as { id: string; tag: string; created_at: number }[];
+  const localTags = local
+    .prepare('SELECT * FROM contact_tags WHERE contact_id = ?')
+    .all(contactId) as { id: string; tag: string; created_at: number }[];
+
+  const sharedTagValues = new Set(sharedTags.map((t) => t.tag));
+  const localOnlyTags = localTags.filter((t) => !sharedTagValues.has(t.tag));
+  const mergedTags = [...sharedTags, ...localOnlyTags];
+
+  local.prepare('DELETE FROM contact_tags WHERE contact_id = ?').run(contactId);
+  for (const t of mergedTags) {
+    local
+      .prepare('INSERT OR IGNORE INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)')
+      .run(t.id, contactId, t.tag, t.created_at);
+  }
 }
 
 function pullMemberships(
@@ -709,6 +728,16 @@ function pushSubTablesToShared(
         'INSERT INTO contact_alert_rss (id, contact_id, rss_url, last_polled_at, is_invalid) VALUES (?, ?, ?, ?, ?)',
       )
       .run(rss.id, contactId, rss.rss_url, rss.last_polled_at, rss.is_invalid);
+  }
+
+  shared.prepare('DELETE FROM contact_tags WHERE contact_id = ?').run(contactId);
+  const tagRows = local
+    .prepare('SELECT * FROM contact_tags WHERE contact_id = ?')
+    .all(contactId) as { id: string; tag: string; created_at: number }[];
+  for (const t of tagRows) {
+    shared
+      .prepare('INSERT OR IGNORE INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)')
+      .run(t.id, contactId, t.tag, t.created_at);
   }
 }
 

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -394,6 +394,9 @@ function mergeSubTablesFromShared(
   }
 
   // ── Tags ──────────────────────────────────────────────────────────────────
+  // Additive-only merge: deletions do not propagate across clients. A tag
+  // removed on one client will be restored on next sync if it still exists on
+  // shared. Full deletion propagation requires a tombstone table — see #422.
   const sharedTags = shared
     .prepare('SELECT * FROM contact_tags WHERE contact_id = ?')
     .all(contactId) as { id: string; tag: string; created_at: number }[];

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -167,6 +167,11 @@ const sourcererApi = {
   getContactInteractionCount: (contactId: string): Promise<number> =>
     ipcRenderer.invoke('contacts:interaction-count', contactId),
   validatePhone: (raw: string): Promise<boolean> => ipcRenderer.invoke('contacts:validate-phone', raw),
+  addContactTag: (contactId: string, tag: string): Promise<void> =>
+    ipcRenderer.invoke('contacts:add-tag', { contactId, tag }),
+  removeContactTag: (contactId: string, tag: string): Promise<void> =>
+    ipcRenderer.invoke('contacts:remove-tag', { contactId, tag }),
+  listAllContactTags: (): Promise<string[]> => ipcRenderer.invoke('contacts:list-all-tags'),
 
   // Scratchpad
   listScratchpad: (contactId: string, projectId: string): Promise<ScratchpadDraft[]> =>

--- a/src/renderer/src/contacts/GlobalTab.tsx
+++ b/src/renderer/src/contacts/GlobalTab.tsx
@@ -7,6 +7,7 @@ import ContactEditForm, { SOCIAL_TYPES, SOCIAL_META, KNOWN_LINK_TYPES } from './
 import { isGoogleAlertUrl } from './contactValidation';
 import RssAlertPanel from './RssAlertPanel';
 import ScreenshotPanel from './ScreenshotPanel';
+import TagsSection from './TagsSection';
 import { linkifyText } from '../utils/linkify';
 import { HANDLE_TYPES, HANDLE_META } from './handleMeta';
 import type { HandleType } from './handleMeta';
@@ -253,6 +254,12 @@ export default function GlobalTab({ contact, allProjects, onRefresh, onMembershi
           <p className="detail-notes">{linkifyText(contact.notes ?? '')}</p>
         </div>
       )}
+
+      <TagsSection
+        contactId={contact.id}
+        tags={contact.tags}
+        onChanged={onRefresh}
+      />
 
       <RssAlertPanel
         editing={false}

--- a/src/renderer/src/contacts/TagsSection.css
+++ b/src/renderer/src/contacts/TagsSection.css
@@ -1,0 +1,96 @@
+.tags-editor {
+  position: relative;
+}
+
+.tags-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+  min-height: 28px;
+}
+
+.tags-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px 2px 8px;
+  background: var(--color-surface-2);
+  border: 1px solid rgba(26, 24, 21, 0.14);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.tags-chip-remove {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-text-dim);
+  line-height: 1;
+  display: flex;
+  align-items: center;
+}
+
+.tags-chip-remove:hover {
+  color: var(--color-text);
+}
+
+.tags-input {
+  border: none;
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--color-text);
+  padding: 2px 4px;
+  min-width: 80px;
+  flex: 1;
+  outline: none;
+}
+
+.tags-input::placeholder {
+  color: var(--color-text-dim);
+}
+
+.tags-dropdown {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  z-index: 100;
+  background: var(--color-surface);
+  border: 1px solid rgba(26, 24, 21, 0.28);
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  min-width: 160px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.tags-dropdown-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 5px 10px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.tags-dropdown-item:hover {
+  background: var(--color-surface-2);
+  color: var(--color-text);
+}

--- a/src/renderer/src/contacts/TagsSection.css
+++ b/src/renderer/src/contacts/TagsSection.css
@@ -28,6 +28,7 @@
 .tags-chip-remove {
   background: none;
   border: none;
+  border-radius: 0;
   padding: 0;
   margin: 0;
   cursor: pointer;

--- a/src/renderer/src/contacts/TagsSection.css
+++ b/src/renderer/src/contacts/TagsSection.css
@@ -50,7 +50,7 @@
   font-size: 11px;
   letter-spacing: 0.1em;
   color: var(--color-text);
-  padding: 2px 4px;
+  padding: 2px 4px 2px 0;
   min-width: 80px;
   flex: 1;
   outline: none;

--- a/src/renderer/src/contacts/TagsSection.css
+++ b/src/renderer/src/contacts/TagsSection.css
@@ -57,6 +57,9 @@
 }
 
 .tags-input::placeholder {
+  font-family: var(--font-serif);
+  font-size: 13px;
+  letter-spacing: 0;
   color: var(--color-text-dim);
 }
 

--- a/src/renderer/src/contacts/TagsSection.tsx
+++ b/src/renderer/src/contacts/TagsSection.tsx
@@ -20,15 +20,6 @@ export default function TagsSection({ contactId, tags, onChanged }: Props) {
 
   useEffect(() => {
     if (!dropdownOpen) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setDropdownOpen(false);
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [dropdownOpen]);
-
-  useEffect(() => {
-    if (!dropdownOpen) return;
     const onPointer = (e: PointerEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setDropdownOpen(false);
@@ -39,9 +30,9 @@ export default function TagsSection({ contactId, tags, onChanged }: Props) {
   }, [dropdownOpen]);
 
   const trimmed = input.trim().toLowerCase();
-  const suggestions = allTags.filter(
-    (t) => !tags.includes(t) && (trimmed === '' || t.includes(trimmed)),
-  );
+  const suggestions = allTags
+    .filter((t) => !tags.includes(t) && (trimmed === '' || t.includes(trimmed)))
+    .slice(0, 10);
 
   async function addTag(tag: string) {
     const normalized = tag.trim().toLowerCase();
@@ -58,7 +49,12 @@ export default function TagsSection({ contactId, tags, onChanged }: Props) {
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === 'Enter' || e.key === ',') {
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      e.nativeEvent.stopImmediatePropagation();
+      setDropdownOpen(false);
+      inputRef.current?.blur();
+    } else if (e.key === 'Enter' || e.key === ',') {
       e.preventDefault();
       if (trimmed) addTag(trimmed);
     } else if (e.key === 'Backspace' && input === '' && tags.length > 0) {

--- a/src/renderer/src/contacts/TagsSection.tsx
+++ b/src/renderer/src/contacts/TagsSection.tsx
@@ -16,7 +16,7 @@ export default function TagsSection({ contactId, tags, onChanged }: Props) {
 
   useEffect(() => {
     window.sourcerer.listAllContactTags().then(setAllTags);
-  }, [tags]);
+  }, [contactId]);
 
   useEffect(() => {
     if (!dropdownOpen) return;
@@ -40,6 +40,7 @@ export default function TagsSection({ contactId, tags, onChanged }: Props) {
     await window.sourcerer.addContactTag(contactId, normalized);
     setInput('');
     setDropdownOpen(false);
+    setAllTags((prev) => prev.includes(normalized) ? prev : [...prev, normalized].sort());
     onChanged();
   }
 

--- a/src/renderer/src/contacts/TagsSection.tsx
+++ b/src/renderer/src/contacts/TagsSection.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useRef, useState } from 'react';
+import './TagsSection.css';
+
+interface Props {
+  contactId: string;
+  tags: string[];
+  onChanged: () => void;
+}
+
+export default function TagsSection({ contactId, tags, onChanged }: Props) {
+  const [input, setInput] = useState('');
+  const [allTags, setAllTags] = useState<string[]>([]);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    window.sourcerer.listAllContactTags().then(setAllTags);
+  }, [tags]);
+
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setDropdownOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [dropdownOpen]);
+
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    const onPointer = (e: PointerEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+    document.addEventListener('pointerdown', onPointer);
+    return () => document.removeEventListener('pointerdown', onPointer);
+  }, [dropdownOpen]);
+
+  const trimmed = input.trim().toLowerCase();
+  const suggestions = allTags.filter(
+    (t) => !tags.includes(t) && (trimmed === '' || t.includes(trimmed)),
+  );
+
+  async function addTag(tag: string) {
+    const normalized = tag.trim().toLowerCase();
+    if (!normalized || normalized.length > 50 || tags.includes(normalized)) return;
+    await window.sourcerer.addContactTag(contactId, normalized);
+    setInput('');
+    setDropdownOpen(false);
+    onChanged();
+  }
+
+  async function removeTag(tag: string) {
+    await window.sourcerer.removeContactTag(contactId, tag);
+    onChanged();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      if (trimmed) addTag(trimmed);
+    } else if (e.key === 'Backspace' && input === '' && tags.length > 0) {
+      removeTag(tags[tags.length - 1]);
+    }
+  }
+
+  return (
+    <div className="detail-section">
+      <div className="detail-section-label">Tags</div>
+      <div className="tags-editor" ref={containerRef}>
+        <div className="tags-chips">
+          {tags.map((t) => (
+            <span key={t} className="tags-chip">
+              {t}
+              <button
+                className="tags-chip-remove"
+                onClick={() => removeTag(t)}
+                aria-label={`Remove tag ${t}`}
+              >×</button>
+            </span>
+          ))}
+          <input
+            ref={inputRef}
+            className="tags-input"
+            value={input}
+            placeholder={tags.length === 0 ? 'Add a tag…' : ''}
+            onChange={(e) => {
+              setInput(e.target.value.replace(',', ''));
+              setDropdownOpen(true);
+            }}
+            onFocus={() => setDropdownOpen(true)}
+            onKeyDown={handleKeyDown}
+            maxLength={50}
+          />
+        </div>
+        {dropdownOpen && suggestions.length > 0 && (
+          <ul className="tags-dropdown">
+            {suggestions.map((t) => (
+              <li key={t}>
+                <button
+                  className="tags-dropdown-item"
+                  onPointerDown={(e) => {
+                    e.preventDefault();
+                    addTag(t);
+                  }}
+                >
+                  {t}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/contacts/TagsSection.tsx
+++ b/src/renderer/src/contacts/TagsSection.tsx
@@ -90,7 +90,7 @@ export default function TagsSection({ contactId, tags, onChanged }: Props) {
             value={input}
             placeholder={tags.length === 0 ? 'Add a tag…' : ''}
             onChange={(e) => {
-              setInput(e.target.value.replace(',', ''));
+              setInput(e.target.value.replace(/,/g, ''));
               setDropdownOpen(true);
             }}
             onFocus={() => setDropdownOpen(true)}

--- a/src/renderer/src/contacts/TagsSection.tsx
+++ b/src/renderer/src/contacts/TagsSection.tsx
@@ -19,6 +19,12 @@ export default function TagsSection({ contactId, tags, onChanged }: Props) {
   }, [contactId]);
 
   useEffect(() => {
+    return window.sourcerer.onContactsChanged(() => {
+      window.sourcerer.listAllContactTags().then(setAllTags);
+    });
+  }, []);
+
+  useEffect(() => {
     if (!dropdownOpen) return;
     const onPointer = (e: PointerEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -112,6 +112,9 @@ declare global {
       getContactCount: () => Promise<number>;
       getContactInteractionCount: (contactId: string) => Promise<number>;
       validatePhone: (raw: string) => Promise<boolean>;
+      addContactTag: (contactId: string, tag: string) => Promise<void>;
+      removeContactTag: (contactId: string, tag: string) => Promise<void>;
+      listAllContactTags: () => Promise<string[]>;
 
       // Scratchpad
       listScratchpad: (contactId: string, projectId: string) => Promise<ScratchpadDraft[]>;

--- a/src/renderer/src/hooks/useProjectContacts.ts
+++ b/src/renderer/src/hooks/useProjectContacts.ts
@@ -88,6 +88,9 @@ export function useProjectContacts(
     if (filters.reporter.length > 0) {
       result = result.filter((r) => filters.reporter.includes(r.reporter_name));
     }
+    if (filters.tags.length > 0) {
+      result = result.filter((r) => filters.tags.some((t) => r.tags.includes(t)));
+    }
 
     if (sort.key) {
       const dir = sort.dir === 'asc' ? 1 : -1;

--- a/src/renderer/src/views/AllContacts.css
+++ b/src/renderer/src/views/AllContacts.css
@@ -122,9 +122,7 @@
 }
 
 .contact-tags-cell {
-  max-width: 180px;
   white-space: nowrap;
-  overflow: hidden;
 }
 
 .contact-tag-chip {
@@ -137,6 +135,14 @@
   color: var(--color-text-muted);
   padding: 1px 6px;
   margin-right: 3px;
+  white-space: nowrap;
+}
+
+.contact-tag-overflow {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  color: var(--color-text-dim);
   white-space: nowrap;
 }
 

--- a/src/renderer/src/views/AllContacts.css
+++ b/src/renderer/src/views/AllContacts.css
@@ -121,6 +121,25 @@
   white-space: nowrap;
 }
 
+.contact-tags-cell {
+  max-width: 180px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.contact-tag-chip {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  background: var(--color-surface-2);
+  color: var(--color-text-muted);
+  padding: 1px 6px;
+  margin-right: 3px;
+  white-space: nowrap;
+}
+
 /* Compact boolean cells (email, phone, notes) */
 .contact-bool-cell {
   text-align: center;

--- a/src/renderer/src/views/AllContacts.tsx
+++ b/src/renderer/src/views/AllContacts.tsx
@@ -154,6 +154,10 @@ export default function AllContacts({ projects, user, openContactId, onOpenConta
       result = result.filter((c) => c.projects.some((p) => p.id === filters.project));
     }
 
+    if (filters.tags.length > 0) {
+      result = result.filter((c) => filters.tags.some((t) => c.tags.includes(t)));
+    }
+
     if (sort.key) {
       const dir = sort.dir === 'asc' ? 1 : -1;
       result = [...result].sort((a, b) => {
@@ -271,6 +275,12 @@ export default function AllContacts({ projects, user, openContactId, onOpenConta
     setCheckedIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
     setDetailId(null);
   }
+
+  const tagFilterOptions = useMemo(() => {
+    const seen = new Set<string>();
+    for (const c of contacts) for (const t of c.tags) seen.add(t);
+    return [...seen].sort().map((t) => ({ value: t, label: t }));
+  }, [contacts]);
 
   const anyFilter = isFilterActive(filters);
 
@@ -431,6 +441,7 @@ export default function AllContacts({ projects, user, openContactId, onOpenConta
             selectAllRef={selectAllRef}
             user={user}
             projects={projects}
+            tagFilterOptions={tagFilterOptions}
             virtualize
             scrollContainerRef={tableAreaRef}
           />

--- a/src/renderer/src/views/ColumnHeader.css
+++ b/src/renderer/src/views/ColumnHeader.css
@@ -230,7 +230,7 @@
 
 .col-filter-search {
   width: 100%;
-  border: 1px solid rgba(26, 24, 21, 0.14);
+  border: 1px solid var(--color-border);
   background: var(--color-bg);
   font-family: var(--font-serif);
   font-size: 13px;

--- a/src/renderer/src/views/ColumnHeader.css
+++ b/src/renderer/src/views/ColumnHeader.css
@@ -230,7 +230,7 @@
 
 .col-filter-search {
   width: 100%;
-  border: none;
+  border: 1px solid var(--color-border);
   background: var(--color-bg);
   font-family: var(--font-serif);
   font-size: 13px;

--- a/src/renderer/src/views/ColumnHeader.css
+++ b/src/renderer/src/views/ColumnHeader.css
@@ -225,18 +225,17 @@
 }
 
 .col-filter-search-wrap {
-  padding: 4px 6px;
-  border-bottom: 1px solid var(--color-border);
+  padding: 4px 0;
 }
 
 .col-filter-search {
   width: 100%;
-  border: 1px solid var(--color-border);
+  border: none;
   background: var(--color-bg);
   font-family: var(--font-serif);
   font-size: 13px;
   color: var(--color-text);
-  padding: 3px 6px;
+  padding: 3px 8px;
   outline: none;
   box-sizing: border-box;
 }

--- a/src/renderer/src/views/ColumnHeader.css
+++ b/src/renderer/src/views/ColumnHeader.css
@@ -230,7 +230,7 @@
 
 .col-filter-search {
   width: 100%;
-  border: 1px solid var(--color-border);
+  border: 1px solid rgba(26, 24, 21, 0.14);
   background: var(--color-bg);
   font-family: var(--font-serif);
   font-size: 13px;

--- a/src/renderer/src/views/ColumnHeader.css
+++ b/src/renderer/src/views/ColumnHeader.css
@@ -224,6 +224,27 @@
   overflow-y: auto;
 }
 
+.col-filter-search-wrap {
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.col-filter-search {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  font-family: var(--font-serif);
+  font-size: 13px;
+  color: var(--color-text);
+  padding: 3px 6px;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.col-filter-search::placeholder {
+  color: var(--color-text-dim);
+}
+
 .col-filter-clear-all {
   display: block;
   width: 100%;

--- a/src/renderer/src/views/ColumnHeader.tsx
+++ b/src/renderer/src/views/ColumnHeader.tsx
@@ -184,13 +184,11 @@ export function MultiSelectFilter({
   const q = search.trim().toLowerCase();
 
   const selectedSet = new Set(selected);
-  const filtered = (q ? options.filter((o) => o.label.toLowerCase().includes(q)) : options)
-    .slice(0, MULTISELECT_MAX_VISIBLE);
-
-  const checkedFirst = [
-    ...filtered.filter((o) => selectedSet.has(o.value)),
-    ...filtered.filter((o) => !selectedSet.has(o.value)),
-  ];
+  const selectedItems = options.filter((o) => selectedSet.has(o.value));
+  const unselectedVisible = (q ? options.filter((o) => o.label.toLowerCase().includes(q)) : options)
+    .filter((o) => !selectedSet.has(o.value))
+    .slice(0, Math.max(0, MULTISELECT_MAX_VISIBLE - selectedItems.length));
+  const checkedFirst = [...selectedItems, ...unselectedVisible];
 
   return (
     <div className="col-filter-multiselect">

--- a/src/renderer/src/views/ColumnHeader.tsx
+++ b/src/renderer/src/views/ColumnHeader.tsx
@@ -162,6 +162,9 @@ export function PresetFilter({
   );
 }
 
+const MULTISELECT_SEARCH_THRESHOLD = 10;
+const MULTISELECT_MAX_VISIBLE = 50;
+
 export function MultiSelectFilter({
   options,
   selected,
@@ -171,9 +174,23 @@ export function MultiSelectFilter({
   selected: string[];
   onChange: (v: string[]) => void;
 }) {
+  const [search, setSearch] = useState('');
+
   function toggle(val: string) {
     onChange(selected.includes(val) ? selected.filter((v) => v !== val) : [...selected, val]);
   }
+
+  const showSearch = options.length > MULTISELECT_SEARCH_THRESHOLD;
+  const q = search.trim().toLowerCase();
+
+  const selectedSet = new Set(selected);
+  const filtered = (q ? options.filter((o) => o.label.toLowerCase().includes(q)) : options)
+    .slice(0, MULTISELECT_MAX_VISIBLE);
+
+  const checkedFirst = [
+    ...filtered.filter((o) => selectedSet.has(o.value)),
+    ...filtered.filter((o) => !selectedSet.has(o.value)),
+  ];
 
   return (
     <div className="col-filter-multiselect">
@@ -182,11 +199,23 @@ export function MultiSelectFilter({
           Clear all
         </button>
       )}
-      {options.map((opt) => (
+      {showSearch && (
+        <div className="col-filter-search-wrap">
+          <input
+            className="col-filter-search"
+            type="text"
+            placeholder="Search…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            autoFocus
+          />
+        </div>
+      )}
+      {checkedFirst.map((opt) => (
         <label key={opt.value} className="col-filter-option">
           <input
             type="checkbox"
-            checked={selected.includes(opt.value)}
+            checked={selectedSet.has(opt.value)}
             onChange={() => toggle(opt.value)}
           />
           {opt.label || '—'}

--- a/src/renderer/src/views/ColumnHeader.tsx
+++ b/src/renderer/src/views/ColumnHeader.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import './ColumnHeader.css';
 
@@ -175,6 +175,8 @@ export function MultiSelectFilter({
   onChange: (v: string[]) => void;
 }) {
   const [search, setSearch] = useState('');
+  const searchRef = useRef<HTMLInputElement>(null);
+  useEffect(() => { searchRef.current?.focus(); }, []);
 
   function toggle(val: string) {
     onChange(selected.includes(val) ? selected.filter((v) => v !== val) : [...selected, val]);
@@ -200,12 +202,12 @@ export function MultiSelectFilter({
       {showSearch && (
         <div className="col-filter-search-wrap">
           <input
+            ref={searchRef}
             className="col-filter-search"
             type="text"
             placeholder="Search…"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            autoFocus
           />
         </div>
       )}

--- a/src/renderer/src/views/ContactsTable.tsx
+++ b/src/renderer/src/views/ContactsTable.tsx
@@ -710,9 +710,14 @@ export default function ContactsTable(props: ContactsTableProps) {
                     {row.tags.length === 0 ? (
                       <span className="contact-cell-muted">—</span>
                     ) : (
-                      row.tags.map((t) => (
-                        <span key={t} className="contact-tag-chip">{t}</span>
-                      ))
+                      <>
+                        {row.tags.slice(0, 2).map((t) => (
+                          <span key={t} className="contact-tag-chip">{t}</span>
+                        ))}
+                        {row.tags.length > 2 && (
+                          <span className="contact-tag-overflow">+{row.tags.length - 2}</span>
+                        )}
+                      </>
                     )}
                   </td>
 

--- a/src/renderer/src/views/ContactsTable.tsx
+++ b/src/renderer/src/views/ContactsTable.tsx
@@ -29,6 +29,7 @@ export interface AllContactsFilters {
   dateAddedFrom: string; // ISO date string YYYY-MM-DD
   dateAddedTo: string;   // ISO date string YYYY-MM-DD
   project: string | null;
+  tags: string[];
 }
 
 export interface ProjectFilters {
@@ -46,6 +47,7 @@ export interface ProjectFilters {
   status: string[];
   priority: string[];
   reporter: string[];
+  tags: string[];
 }
 
 export const DEFAULT_ALL_CONTACTS_FILTERS: AllContactsFilters = {
@@ -60,6 +62,7 @@ export const DEFAULT_ALL_CONTACTS_FILTERS: AllContactsFilters = {
   dateAddedFrom: '',
   dateAddedTo: '',
   project: null,
+  tags: [],
 };
 
 export const DEFAULT_PROJECT_FILTERS: ProjectFilters = {
@@ -77,6 +80,7 @@ export const DEFAULT_PROJECT_FILTERS: ProjectFilters = {
   status: [],
   priority: [],
   reporter: [],
+  tags: [],
 };
 
 export function isAllContactsFilterActive(f: AllContactsFilters): boolean {
@@ -91,7 +95,8 @@ export function isAllContactsFilterActive(f: AllContactsFilters): boolean {
     f.dateLastContacted !== null ||
     f.dateAddedFrom !== '' ||
     f.dateAddedTo !== '' ||
-    f.project !== null
+    f.project !== null ||
+    f.tags.length > 0
   );
 }
 
@@ -110,7 +115,8 @@ export function isProjectFilterActive(f: ProjectFilters): boolean {
     f.dateAddedTo !== '' ||
     f.status.length > 0 ||
     f.priority.length > 0 ||
-    f.reporter.length > 0
+    f.reporter.length > 0 ||
+    f.tags.length > 0
   );
 }
 
@@ -154,6 +160,7 @@ interface AllContactsTableProps extends BaseTableProps {
   rows: ContactListItem[];
   filters: AllContactsFilters;
   projects: Project[];
+  tagFilterOptions: Array<{ value: string; label: string }>;
 }
 
 interface ProjectTableProps extends BaseTableProps {
@@ -164,6 +171,7 @@ interface ProjectTableProps extends BaseTableProps {
   statusFilterOptions: Array<{ value: string; label: string }>;
   priorityFilterOptions: Array<{ value: string; label: string }>;
   reporterOptions: Array<{ value: string; label: string }>;
+  tagFilterOptions: Array<{ value: string; label: string }>;
   userEmail?: string;
 }
 
@@ -253,7 +261,7 @@ export default function ContactsTable(props: ContactsTableProps) {
   const rowsToRender = virtualItems ? virtualItems.map((vi) => rows[vi.index]) : rows;
 
   const sd = (key: string) => (sort.key === key ? sort.dir : null);
-  const colSpan = isProject ? 13 : 10;
+  const colSpan = isProject ? 14 : 11;
 
   return (
     <table className="contacts-table">
@@ -497,6 +505,24 @@ export default function ContactsTable(props: ContactsTableProps) {
             />
           </th>
 
+          {/* ── Shared: Tags ── */}
+          <th>
+            <ColumnHeader
+              label="Tags"
+              filterable={(isProject ? (pp?.tagFilterOptions.length ?? 0) : (ap?.tagFilterOptions.length ?? 0)) > 0}
+              filterActive={(isProject ? (pf?.tags.length ?? 0) : (af?.tags.length ?? 0)) > 0}
+              filterOpen={openFilter === 'tags'}
+              onFilterToggle={() => toggleFilter('tags')}
+              filterContent={
+                <MultiSelectFilter
+                  options={isProject ? (pp?.tagFilterOptions ?? []) : (ap?.tagFilterOptions ?? [])}
+                  selected={isProject ? (pf?.tags ?? []) : (af?.tags ?? [])}
+                  onChange={(v) => setFilter('tags', v)}
+                />
+              }
+            />
+          </th>
+
           {/* ── Shared: First Contacted ── */}
           <th>
             <ColumnHeader
@@ -680,6 +706,16 @@ export default function ContactsTable(props: ContactsTableProps) {
                       <span className="contact-cell-muted">—</span>
                     )}
                   </td>
+                  <td className="contact-tags-cell">
+                    {row.tags.length === 0 ? (
+                      <span className="contact-cell-muted">—</span>
+                    ) : (
+                      row.tags.map((t) => (
+                        <span key={t} className="contact-tag-chip">{t}</span>
+                      ))
+                    )}
+                  </td>
+
                   <td className="contact-date-cell">
                     {row.date_first_contacted === null ? (
                       <span className="contact-cell-muted">—</span>

--- a/src/renderer/src/views/ProjectView.tsx
+++ b/src/renderer/src/views/ProjectView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Project, ProjectContactRow, StatusOption, PriorityOption, ImportResult, User } from '@shared/types';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { useSortFilter } from '../hooks/useSortFilter';
@@ -341,6 +341,12 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
     ...new Map(rows.map((r) => [r.reporter_name, { value: r.reporter_name, label: r.reporter_name }])).values(),
   ].sort((a, b) => a.label.localeCompare(b.label));
 
+  const tagFilterOptions = useMemo(() => {
+    const seen = new Set<string>();
+    for (const r of rows) for (const t of r.tags) seen.add(t);
+    return [...seen].sort().map((t) => ({ value: t, label: t }));
+  }, [rows]);
+
   const hasNullStatus = rows.some((r) => r.status === null);
   const statusFilterOptions = [
     ...statusOptions.map((o) => ({ value: o.label, label: o.label })),
@@ -549,6 +555,7 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
             statusFilterOptions={statusFilterOptions}
             priorityFilterOptions={priorityFilterOptions}
             reporterOptions={reporterOptions}
+            tagFilterOptions={tagFilterOptions}
             userEmail={user?.email}
           />
         </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -89,6 +89,7 @@ export interface ContactListItem {
   date_first_contacted: number | null;
   date_last_contacted: number | null;
   projects: Array<{ id: string; name: string }>;
+  tags: string[];
 }
 
 export interface ContactEmail {
@@ -160,6 +161,7 @@ export interface ContactDetail {
   links: ContactLink[];
   handles: ContactHandle[];
   projects: ContactProject[];
+  tags: string[];
 }
 
 export interface ContactLinkInput {
@@ -280,6 +282,7 @@ export interface ProjectContactRow {
   theme: string | null;
   priority: string | null;
   status: string | null;
+  tags: string[];
 }
 
 export interface CreateSharedProjectResult {

--- a/src/test/tags.test.ts
+++ b/src/test/tags.test.ts
@@ -1,0 +1,321 @@
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import Database from 'better-sqlite3-multiple-ciphers';
+import { createTestDb, insertContact, insertProject, TEST_REPORTER } from './vitest.setup';
+import { SHARED_SCHEMA_SQL } from '../main/database/shared-schema';
+import { syncProject } from '../main/sync/engine';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn(), on: vi.fn() },
+  BrowserWindow: { getAllWindows: vi.fn(() => []) },
+  net: { fetch: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp') },
+}));
+
+let testDb: ReturnType<typeof createTestDb>;
+vi.mock('../main/database', () => ({ getDatabase: () => testDb, isDatabaseOpen: () => true }));
+vi.mock('../main/sync/outreach-checker', () => ({ checkOutreachReminders: vi.fn() }));
+
+import { ipcMain } from 'electron';
+import { registerContactHandlers } from '../main/ipc/contacts';
+
+const handlers = new Map<string, (...args: unknown[]) => unknown>();
+
+beforeEach(() => {
+  testDb = createTestDb();
+  handlers.clear();
+  vi.mocked(ipcMain.handle).mockImplementation((channel: string, fn) => {
+    handlers.set(channel, fn as (...args: unknown[]) => unknown);
+    return ipcMain;
+  });
+  registerContactHandlers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function insertTag(db: Database.Database, contactId: string, tag: string): void {
+  db.prepare('INSERT INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)')
+    .run(uuidv4(), contactId, tag, Math.floor(Date.now() / 1000));
+}
+
+function getTags(db: Database.Database, contactId: string): string[] {
+  return (db.prepare('SELECT tag FROM contact_tags WHERE contact_id = ? ORDER BY tag').all(contactId) as { tag: string }[])
+    .map((r) => r.tag);
+}
+
+// ---------------------------------------------------------------------------
+// contacts:add-tag
+// ---------------------------------------------------------------------------
+
+describe('contacts:add-tag', () => {
+  it('adds a tag to a contact', async () => {
+    const contactId = insertContact(testDb, 'Alice');
+    await handlers.get('contacts:add-tag')!({}, { contactId, tag: 'source' });
+    expect(getTags(testDb, contactId)).toEqual(['source']);
+  });
+
+  it('normalises to lowercase and trims whitespace', async () => {
+    const contactId = insertContact(testDb, 'Alice');
+    await handlers.get('contacts:add-tag')!({}, { contactId, tag: '  WHISTLEBLOWER  ' });
+    expect(getTags(testDb, contactId)).toEqual(['whistleblower']);
+  });
+
+  it('ignores duplicate tags (INSERT OR IGNORE)', async () => {
+    const contactId = insertContact(testDb, 'Alice');
+    await handlers.get('contacts:add-tag')!({}, { contactId, tag: 'legal' });
+    await handlers.get('contacts:add-tag')!({}, { contactId, tag: 'legal' });
+    expect(getTags(testDb, contactId)).toHaveLength(1);
+  });
+
+  it('ignores empty tag strings', async () => {
+    const contactId = insertContact(testDb, 'Alice');
+    await handlers.get('contacts:add-tag')!({}, { contactId, tag: '   ' });
+    expect(getTags(testDb, contactId)).toHaveLength(0);
+  });
+
+  it('ignores tags exceeding 50 characters', async () => {
+    const contactId = insertContact(testDb, 'Alice');
+    const long = 'a'.repeat(51);
+    await handlers.get('contacts:add-tag')!({}, { contactId, tag: long });
+    expect(getTags(testDb, contactId)).toHaveLength(0);
+  });
+
+  it('allows a contact to have multiple distinct tags', async () => {
+    const contactId = insertContact(testDb, 'Alice');
+    await handlers.get('contacts:add-tag')!({}, { contactId, tag: 'source' });
+    await handlers.get('contacts:add-tag')!({}, { contactId, tag: 'legal' });
+    await handlers.get('contacts:add-tag')!({}, { contactId, tag: 'whistleblower' });
+    expect(getTags(testDb, contactId)).toEqual(['legal', 'source', 'whistleblower']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// contacts:remove-tag
+// ---------------------------------------------------------------------------
+
+describe('contacts:remove-tag', () => {
+  it('removes an existing tag', async () => {
+    const contactId = insertContact(testDb, 'Bob');
+    insertTag(testDb, contactId, 'source');
+    insertTag(testDb, contactId, 'legal');
+    await handlers.get('contacts:remove-tag')!({}, { contactId, tag: 'source' });
+    expect(getTags(testDb, contactId)).toEqual(['legal']);
+  });
+
+  it('is a no-op for a tag that does not exist', async () => {
+    const contactId = insertContact(testDb, 'Bob');
+    await handlers.get('contacts:remove-tag')!({}, { contactId, tag: 'ghost' });
+    expect(getTags(testDb, contactId)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// contacts:list-all-tags
+// ---------------------------------------------------------------------------
+
+describe('contacts:list-all-tags', () => {
+  it('returns all distinct tags across all contacts in alphabetical order', async () => {
+    const a = insertContact(testDb, 'Alice');
+    const b = insertContact(testDb, 'Bob');
+    insertTag(testDb, a, 'source');
+    insertTag(testDb, a, 'legal');
+    insertTag(testDb, b, 'source');
+    insertTag(testDb, b, 'whistleblower');
+
+    const result = await handlers.get('contacts:list-all-tags')!({}) as string[];
+    expect(result).toEqual(['legal', 'source', 'whistleblower']);
+  });
+
+  it('returns an empty array when no tags exist', async () => {
+    insertContact(testDb, 'Alice');
+    const result = await handlers.get('contacts:list-all-tags')!({}) as string[];
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// contacts:list — tags included
+// ---------------------------------------------------------------------------
+
+describe('contacts:list — tags field', () => {
+  it('returns an empty tags array for a contact with no tags', async () => {
+    insertContact(testDb, 'Alice');
+    const rows = await handlers.get('contacts:list')!({}) as { tags: string[] }[];
+    expect(rows[0].tags).toEqual([]);
+  });
+
+  it('returns tags sorted alphabetically', async () => {
+    const contactId = insertContact(testDb, 'Alice');
+    insertTag(testDb, contactId, 'zebra');
+    insertTag(testDb, contactId, 'alpha');
+    const rows = await handlers.get('contacts:list')!({}) as { tags: string[] }[];
+    expect(rows[0].tags).toEqual(['alpha', 'zebra']);
+  });
+
+  it('does not mix tags between contacts', async () => {
+    const a = insertContact(testDb, 'Alice');
+    const b = insertContact(testDb, 'Bob');
+    insertTag(testDb, a, 'source');
+    insertTag(testDb, b, 'legal');
+
+    const rows = await handlers.get('contacts:list')!({}) as { name: string; tags: string[] }[];
+    const alice = rows.find((r) => r.name === 'Alice')!;
+    const bob = rows.find((r) => r.name === 'Bob')!;
+    expect(alice.tags).toEqual(['source']);
+    expect(bob.tags).toEqual(['legal']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// contacts:get — tags included
+// ---------------------------------------------------------------------------
+
+describe('contacts:get — tags field', () => {
+  it('returns tags for a contact', async () => {
+    const contactId = insertContact(testDb, 'Alice');
+    insertTag(testDb, contactId, 'source');
+    insertTag(testDb, contactId, 'legal');
+    const detail = await handlers.get('contacts:get')!({}, contactId) as { tags: string[] };
+    expect(detail.tags).toEqual(['legal', 'source']);
+  });
+
+  it('returns an empty tags array when none exist', async () => {
+    const contactId = insertContact(testDb, 'Alice');
+    const detail = await handlers.get('contacts:get')!({}, contactId) as { tags: string[] };
+    expect(detail.tags).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// contacts:list-for-project — tags included
+// ---------------------------------------------------------------------------
+
+describe('contacts:list-for-project — tags field', () => {
+  it('returns tags for contacts in a project', async () => {
+    const contactId = insertContact(testDb, 'Alice');
+    const projectId = insertProject(testDb, 'Proj');
+    const now = Math.floor(Date.now() / 1000);
+    testDb.prepare(
+      'INSERT INTO project_memberships (id, contact_id, project_id, reporter_email, reporter_name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    ).run(uuidv4(), contactId, projectId, TEST_REPORTER.email, TEST_REPORTER.name, now, now);
+    insertTag(testDb, contactId, 'source');
+
+    const rows = await handlers.get('contacts:list-for-project')!({}, projectId) as { tags: string[] }[];
+    expect(rows[0].tags).toEqual(['source']);
+  });
+
+  it('returns an empty tags array when the contact has no tags', async () => {
+    const contactId = insertContact(testDb, 'Alice');
+    const projectId = insertProject(testDb, 'Proj');
+    const now = Math.floor(Date.now() / 1000);
+    testDb.prepare(
+      'INSERT INTO project_memberships (id, contact_id, project_id, reporter_email, reporter_name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    ).run(uuidv4(), contactId, projectId, TEST_REPORTER.email, TEST_REPORTER.name, now, now);
+
+    const rows = await handlers.get('contacts:list-for-project')!({}, projectId) as { tags: string[] }[];
+    expect(rows[0].tags).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sync engine — tags
+// ---------------------------------------------------------------------------
+
+const SYNC_NOW = Math.floor(Date.now() / 1000);
+
+function createSharedDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.exec(SHARED_SCHEMA_SQL);
+  return db;
+}
+
+function sharedInsertContact(db: Database.Database, id: string, name: string): void {
+  db.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(id, name, SYNC_NOW, SYNC_NOW);
+}
+
+function sharedInsertMembership(db: Database.Database, id: string, contactId: string): void {
+  db.prepare(
+    'INSERT INTO project_memberships (id, contact_id, reporter_email, reporter_name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+  ).run(id, contactId, 'r@r.com', 'Reporter', SYNC_NOW, SYNC_NOW);
+}
+
+function localInsertMembership(db: Database.Database, contactId: string, projectId: string): string {
+  const id = uuidv4();
+  const ts = SYNC_NOW - 10;
+  db.prepare(
+    'INSERT INTO project_memberships (id, contact_id, project_id, reporter_email, reporter_name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+  ).run(id, contactId, projectId, 'r@r.com', 'Reporter', ts, ts);
+  return id;
+}
+
+describe('syncProject — tags', () => {
+  it('pushes local tags to shared on sync', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Test');
+
+    // Insert contact with a fixed UUID so both sides share the same ID
+    const contactId = uuidv4();
+    const localTs = SYNC_NOW - 10;
+    localDb.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Alice', localTs, localTs);
+    localInsertMembership(localDb, contactId, projectId);
+    insertTag(localDb, contactId, 'source');
+    insertTag(localDb, contactId, 'legal');
+
+    sharedInsertContact(sharedDb, contactId, 'Alice');
+    sharedInsertMembership(sharedDb, uuidv4(), contactId);
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+
+    const sharedTags = (sharedDb.prepare('SELECT tag FROM contact_tags WHERE contact_id = ? ORDER BY tag').all(contactId) as { tag: string }[]).map((r) => r.tag);
+    expect(sharedTags).toEqual(['legal', 'source']);
+  });
+
+  it('pulls tags from shared into local on sync', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Test');
+
+    const contactId = uuidv4();
+    const localTs = SYNC_NOW - 10;
+    localDb.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Alice', localTs, localTs);
+    localInsertMembership(localDb, contactId, projectId);
+
+    sharedInsertContact(sharedDb, contactId, 'Alice');
+    sharedInsertMembership(sharedDb, uuidv4(), contactId);
+    sharedDb.prepare('INSERT INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)').run(uuidv4(), contactId, 'whistleblower', SYNC_NOW);
+    sharedDb.prepare('INSERT INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)').run(uuidv4(), contactId, 'source', SYNC_NOW);
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+
+    expect(getTags(localDb, contactId)).toEqual(['source', 'whistleblower']);
+  });
+
+  it('merges local-only and shared tags without duplicates', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Test');
+
+    const contactId = uuidv4();
+    const localTs = SYNC_NOW - 10;
+    localDb.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Alice', localTs, localTs);
+    localInsertMembership(localDb, contactId, projectId);
+    insertTag(localDb, contactId, 'local-only');
+    insertTag(localDb, contactId, 'shared-tag');
+
+    sharedInsertContact(sharedDb, contactId, 'Alice');
+    sharedInsertMembership(sharedDb, uuidv4(), contactId);
+    sharedDb.prepare('INSERT INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)').run(uuidv4(), contactId, 'shared-tag', SYNC_NOW);
+    sharedDb.prepare('INSERT INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)').run(uuidv4(), contactId, 'shared-only', SYNC_NOW);
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+
+    expect(getTags(localDb, contactId)).toEqual(['local-only', 'shared-only', 'shared-tag']);
+  });
+});

--- a/src/test/tags.test.ts
+++ b/src/test/tags.test.ts
@@ -255,21 +255,36 @@ function localInsertMembership(db: Database.Database, contactId: string, project
 describe('contacts:add-tag / contacts:remove-tag — bumps updated_at', () => {
   it('add-tag bumps contact updated_at so the sync engine will push', async () => {
     const contactId = insertContact(testDb, 'Alice');
-    const before = (testDb.prepare('SELECT updated_at FROM contacts WHERE id = ?').get(contactId) as { updated_at: number }).updated_at;
-    await new Promise((r) => setTimeout(r, 1100));
+    testDb.prepare('UPDATE contacts SET updated_at = 0 WHERE id = ?').run(contactId);
     await handlers.get('contacts:add-tag')!({}, { contactId, tag: 'source' });
-    const after = (testDb.prepare('SELECT updated_at FROM contacts WHERE id = ?').get(contactId) as { updated_at: number }).updated_at;
-    expect(after).toBeGreaterThan(before);
+    const { updated_at } = testDb.prepare('SELECT updated_at FROM contacts WHERE id = ?').get(contactId) as { updated_at: number };
+    expect(updated_at).toBeGreaterThan(0);
+  });
+
+  it('add-tag does not bump updated_at for a duplicate tag', async () => {
+    const contactId = insertContact(testDb, 'Alice');
+    await handlers.get('contacts:add-tag')!({}, { contactId, tag: 'source' });
+    testDb.prepare('UPDATE contacts SET updated_at = 0 WHERE id = ?').run(contactId);
+    await handlers.get('contacts:add-tag')!({}, { contactId, tag: 'source' });
+    const { updated_at } = testDb.prepare('SELECT updated_at FROM contacts WHERE id = ?').get(contactId) as { updated_at: number };
+    expect(updated_at).toBe(0);
   });
 
   it('remove-tag bumps contact updated_at so the sync engine will push', async () => {
     const contactId = insertContact(testDb, 'Alice');
     insertTag(testDb, contactId, 'source');
-    const before = (testDb.prepare('SELECT updated_at FROM contacts WHERE id = ?').get(contactId) as { updated_at: number }).updated_at;
-    await new Promise((r) => setTimeout(r, 1100));
+    testDb.prepare('UPDATE contacts SET updated_at = 0 WHERE id = ?').run(contactId);
     await handlers.get('contacts:remove-tag')!({}, { contactId, tag: 'source' });
-    const after = (testDb.prepare('SELECT updated_at FROM contacts WHERE id = ?').get(contactId) as { updated_at: number }).updated_at;
-    expect(after).toBeGreaterThan(before);
+    const { updated_at } = testDb.prepare('SELECT updated_at FROM contacts WHERE id = ?').get(contactId) as { updated_at: number };
+    expect(updated_at).toBeGreaterThan(0);
+  });
+
+  it('remove-tag does not bump updated_at when tag does not exist', async () => {
+    const contactId = insertContact(testDb, 'Alice');
+    testDb.prepare('UPDATE contacts SET updated_at = 0 WHERE id = ?').run(contactId);
+    await handlers.get('contacts:remove-tag')!({}, { contactId, tag: 'ghost' });
+    const { updated_at } = testDb.prepare('SELECT updated_at FROM contacts WHERE id = ?').get(contactId) as { updated_at: number };
+    expect(updated_at).toBe(0);
   });
 });
 

--- a/src/test/tags.test.ts
+++ b/src/test/tags.test.ts
@@ -35,9 +35,10 @@ beforeEach(() => {
 // Helpers
 // ---------------------------------------------------------------------------
 
+let _tagTs = Math.floor(Date.now() / 1000);
 function insertTag(db: Database.Database, contactId: string, tag: string): void {
   db.prepare('INSERT INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)')
-    .run(uuidv4(), contactId, tag, Math.floor(Date.now() / 1000));
+    .run(uuidv4(), contactId, tag, _tagTs++);
 }
 
 function getTags(db: Database.Database, contactId: string): string[] {
@@ -146,12 +147,12 @@ describe('contacts:list — tags field', () => {
     expect(rows[0].tags).toEqual([]);
   });
 
-  it('returns tags sorted alphabetically', async () => {
+  it('returns tags in insertion order', async () => {
     const contactId = insertContact(testDb, 'Alice');
     insertTag(testDb, contactId, 'zebra');
     insertTag(testDb, contactId, 'alpha');
     const rows = await handlers.get('contacts:list')!({}) as { tags: string[] }[];
-    expect(rows[0].tags).toEqual(['alpha', 'zebra']);
+    expect(rows[0].tags).toEqual(['zebra', 'alpha']);
   });
 
   it('does not mix tags between contacts', async () => {
@@ -173,12 +174,12 @@ describe('contacts:list — tags field', () => {
 // ---------------------------------------------------------------------------
 
 describe('contacts:get — tags field', () => {
-  it('returns tags for a contact', async () => {
+  it('returns tags in insertion order', async () => {
     const contactId = insertContact(testDb, 'Alice');
     insertTag(testDb, contactId, 'source');
     insertTag(testDb, contactId, 'legal');
     const detail = await handlers.get('contacts:get')!({}, contactId) as { tags: string[] };
-    expect(detail.tags).toEqual(['legal', 'source']);
+    expect(detail.tags).toEqual(['source', 'legal']);
   });
 
   it('returns an empty tags array when none exist', async () => {

--- a/src/test/tags.test.ts
+++ b/src/test/tags.test.ts
@@ -252,6 +252,27 @@ function localInsertMembership(db: Database.Database, contactId: string, project
   return id;
 }
 
+describe('contacts:add-tag / contacts:remove-tag — bumps updated_at', () => {
+  it('add-tag bumps contact updated_at so the sync engine will push', async () => {
+    const contactId = insertContact(testDb, 'Alice');
+    const before = (testDb.prepare('SELECT updated_at FROM contacts WHERE id = ?').get(contactId) as { updated_at: number }).updated_at;
+    await new Promise((r) => setTimeout(r, 1100));
+    await handlers.get('contacts:add-tag')!({}, { contactId, tag: 'source' });
+    const after = (testDb.prepare('SELECT updated_at FROM contacts WHERE id = ?').get(contactId) as { updated_at: number }).updated_at;
+    expect(after).toBeGreaterThan(before);
+  });
+
+  it('remove-tag bumps contact updated_at so the sync engine will push', async () => {
+    const contactId = insertContact(testDb, 'Alice');
+    insertTag(testDb, contactId, 'source');
+    const before = (testDb.prepare('SELECT updated_at FROM contacts WHERE id = ?').get(contactId) as { updated_at: number }).updated_at;
+    await new Promise((r) => setTimeout(r, 1100));
+    await handlers.get('contacts:remove-tag')!({}, { contactId, tag: 'source' });
+    const after = (testDb.prepare('SELECT updated_at FROM contacts WHERE id = ?').get(contactId) as { updated_at: number }).updated_at;
+    expect(after).toBeGreaterThan(before);
+  });
+});
+
 describe('syncProject — tags', () => {
   it('pushes local tags to shared on sync', () => {
     const localDb = createTestDb();


### PR DESCRIPTION
## Summary

- Free-form tags per contact, stored globally (one tag set per contact regardless of project)
- Selectize-style editor in the contact detail view: type to filter existing tags, Enter or comma to create a new one, × to remove
- Tags column in both AllContacts and ProjectView tables with a multi-select filter (OR semantics — show contacts that have any selected tag)
- Tags included in the sync engine's sub-table merge/push path so they propagate across shared projects

## What's new for users

You can now label contacts with one or more freeform tags (e.g. "whistleblower", "legal", "source") directly from the contact detail view. Tags autocomplete from existing ones across all your contacts. You can filter both the All Contacts list and any project view down to contacts that have a given tag.

## Test plan

- [x] Open a contact — a **Tags** section appears below Notes. Add a tag by typing and pressing Enter or comma; confirm it appears as a chip
- [x] Add the same tag twice — only one chip should appear
- [x] Type a partial tag name — the autocomplete dropdown filters to matching existing tags; clicking one adds it
- [x] Press Backspace on an empty input — removes the last tag
- [x] Click × on a chip — tag is removed immediately
- [x] Open **All Contacts** — a Tags column is visible. Contacts with tags show chips; contacts without show —
- [x] Click the Tags column filter — multi-select dropdown lists all tags in the vault; selecting one filters the table to contacts that have it
- [x] Select multiple tags in the filter — table shows contacts that have *any* of the selected tags (OR logic)
- [x] Same filter behaviour in a **Project view**
- [x] Tags persist after closing and reopening the app
- [x] (If you have a shared project) Add a tag on one client, sync — tag appears on the other client

## Implementation notes

- `contact_tags` table added to both local and shared schema (no migration needed — pre-production)
- Tags normalised to lowercase/trimmed on write; 50-char max; `UNIQUE(contact_id, tag)` enforces deduplication at the DB level
- `tags: string[]` added to `ContactListItem`, `ContactDetail`, and `ProjectContactRow`
- New IPC handlers: `contacts:add-tag`, `contacts:remove-tag`, `contacts:list-all-tags`
- 20 new tests covering all IPC handlers and sync behaviour

Closes #418