### PR TITLE
Upgrade tmp to 0.2.7 (CVE-2026-44705)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7628,9 +7628,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "git+ssh://git@github.com/raszi/node-tmp.git#efa4a06f24374797ae32ab2b6ae39b7a611ae429",
-      "integrity": "sha512-s54nhz2bVzm+SVfXr0e2SI6UZJ+wxvhE6xhsm/6FtHXBFAI8J9x5oUaCGSt98ruDY+v/Smnlbh11TcRRLd27+A==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "overrides": {
     "tar": "7.5.15",
     "@tootallnate/once": "3.0.1",
-    "tmp": "github:raszi/node-tmp#efa4a06f24374797ae32ab2b6ae39b7a611ae429",
+    "tmp": "0.2.7",
     "exceljs": {
       "uuid": "11.1.1"
     }


### PR DESCRIPTION
## Summary

Switches the `tmp` override from a GitHub commit reference to the published `0.2.7` release, resolving Dependabot alert #30.

The fix commit (`efa4a06`) was already pinned via the GitHub reference so the vulnerability was not exploitable in practice. This change just points to the proper npm release so Dependabot recognises it as resolved and the dependency is easier to audit going forward.

Closes #30 (Dependabot alert)