### PR TITLE
chore: v0.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sourcerer",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sourcerer",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcerer",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "description": "Encrypted source management for journalists",
   "author": "Tom Cardoso",


### PR DESCRIPTION
## What's new

**Contact tags.** You can now label contacts with freeform tags (e.g. "source", "legal", "whistleblower") directly from the contact detail view. Tags autocomplete from existing ones across all your contacts, and you can filter both the All Contacts list and any project view down to contacts with a given tag. Tags sync across shared projects.

**Light, dark, and system themes.** A new Appearance section in Settings lets you choose between light, dark, or system (follows your OS preference). The dark theme uses the same warm, paper-toned palette as the light theme — no cold greys.

**Sync now respects explicit deletions.** Previously, if you removed a tag, phone number, email address, link, or social handle from a contact on one device and synced, the deleted item could silently reappear on your next sync from another device. This has been fixed: each deletion is recorded and propagated to all clients, so deletions stick. Records are automatically cleaned up after 90 days.

This release also includes a dependency security update (CVE-2026-44705 in `tmp`).

<details>
<summary>Full commit list</summary>

- Add sync tombstones to propagate sub-table deletions across clients (#424)
- Upgrade tmp to 0.2.7 (CVE-2026-44705) (#423)
- Add contact tags (#421)
- Add light / dark / system theme toggle (#420)

</details>

Closes #422