### PR TITLE
Fix dev builds colliding with production database

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,9 @@
 import { app, BrowserWindow, Menu, shell, nativeImage } from 'electron';
 
-app.name = 'Sourcerer';
+// Dev builds get a distinct app name so `app.getPath('userData')` resolves to a
+// separate directory — otherwise a dev launch and a production install both
+// point at the same userData folder and their databases collide (issue #426).
+app.name = app.isPackaged ? 'Sourcerer' : 'Sourcerer (Dev)';
 import { join } from 'path';
 import { is } from '@electron-toolkit/utils';
 import { registerSetupHandlers } from './ipc/setup';


### PR DESCRIPTION
## Summary
- `app.name` was hardcoded to `'Sourcerer'` regardless of dev vs. packaged build, so `app.getPath('userData')` resolved to the same directory in both cases
- A dev launch (`npm run dev`) would therefore read/write the exact same `sourcerer.db`, `sourcerer.salt`, and `vault.json` as a production install, causing the two to "merge"
- Dev builds now use `'Sourcerer (Dev)'` as the app name, which isolates the whole userData folder (DB, salt, screenshots, backups, vault config) from production — no changes needed to `getPaths()` or any IPC handler

Closes #426

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — 478 tests pass
- [x] Verified empirically: launching unpackaged via `electron` resolves `userData` to `.../Sourcerer (Dev)`, distinct from the packaged app's `.../Sourcerer`
- [x] Confirmed no effect on existing production data — `app.isPackaged` is `true` for packaged/production builds, so their app name and userData path are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)