### PR TITLE
Sync: explicit replication state — per-project push tracking, full-scan pull, deletion tombstones

### DIFF
--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -40,8 +40,7 @@ export const LOCAL_SCHEMA_DDL_SQL = `
     notes        TEXT,
     default_membership_id TEXT REFERENCES project_memberships(id) ON DELETE SET NULL,
     created_at   INTEGER NOT NULL,
-    updated_at   INTEGER NOT NULL,
-    synced_at    INTEGER
+    updated_at   INTEGER NOT NULL
   );
 
   CREATE TABLE IF NOT EXISTS dedup_dismissed_pairs (
@@ -58,8 +57,7 @@ export const LOCAL_SCHEMA_DDL_SQL = `
     email      TEXT    NOT NULL,
     label      TEXT,
     sort_order INTEGER NOT NULL DEFAULT 0,
-    created_at INTEGER NOT NULL DEFAULT 0,
-    synced_at  INTEGER
+    created_at INTEGER NOT NULL DEFAULT 0
   );
 
   CREATE TABLE IF NOT EXISTS contact_phones (
@@ -68,8 +66,7 @@ export const LOCAL_SCHEMA_DDL_SQL = `
     phone      TEXT    NOT NULL,
     label      TEXT,
     sort_order INTEGER NOT NULL DEFAULT 0,
-    created_at INTEGER NOT NULL DEFAULT 0,
-    synced_at  INTEGER
+    created_at INTEGER NOT NULL DEFAULT 0
   );
 
   CREATE TABLE IF NOT EXISTS contact_links (
@@ -80,8 +77,7 @@ export const LOCAL_SCHEMA_DDL_SQL = `
     url        TEXT    NOT NULL,
     wayback_url TEXT,
     sort_order INTEGER NOT NULL DEFAULT 0,
-    created_at INTEGER NOT NULL DEFAULT 0,
-    synced_at  INTEGER
+    created_at INTEGER NOT NULL DEFAULT 0
   );
 
   CREATE TABLE IF NOT EXISTS contact_handles (
@@ -90,8 +86,7 @@ export const LOCAL_SCHEMA_DDL_SQL = `
     type       TEXT    NOT NULL,
     handle     TEXT    NOT NULL,
     sort_order INTEGER NOT NULL DEFAULT 0,
-    created_at INTEGER NOT NULL DEFAULT 0,
-    synced_at  INTEGER
+    created_at INTEGER NOT NULL DEFAULT 0
   );
 
   CREATE TABLE IF NOT EXISTS contact_alert_rss (
@@ -99,8 +94,7 @@ export const LOCAL_SCHEMA_DDL_SQL = `
     contact_id     TEXT    NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
     rss_url        TEXT    NOT NULL,
     last_polled_at INTEGER,
-    is_invalid     INTEGER NOT NULL DEFAULT 0,
-    synced_at      INTEGER
+    is_invalid     INTEGER NOT NULL DEFAULT 0
   );
 
   CREATE TABLE IF NOT EXISTS contact_alert_mentions (
@@ -112,8 +106,7 @@ export const LOCAL_SCHEMA_DDL_SQL = `
     fetched_at  INTEGER NOT NULL,
     guid        TEXT    NOT NULL,
     seen        INTEGER NOT NULL DEFAULT 0,
-    dismissed   INTEGER NOT NULL DEFAULT 0,
-    synced_at   INTEGER
+    dismissed   INTEGER NOT NULL DEFAULT 0
   );
 
   CREATE TABLE IF NOT EXISTS projects (
@@ -154,7 +147,6 @@ export const LOCAL_SCHEMA_DDL_SQL = `
     reporter_conflict           INTEGER NOT NULL DEFAULT 0,
     created_at                  INTEGER NOT NULL,
     updated_at                  INTEGER NOT NULL,
-    synced_at                   INTEGER,
     UNIQUE(contact_id, project_id)
   );
 
@@ -172,8 +164,7 @@ export const LOCAL_SCHEMA_DDL_SQL = `
     reporter_email TEXT    NOT NULL,
     reporter_name  TEXT    NOT NULL,
     body           TEXT    NOT NULL,
-    created_at     INTEGER NOT NULL,
-    synced_at      INTEGER
+    created_at     INTEGER NOT NULL
   );
 
   CREATE TABLE IF NOT EXISTS interaction_projects (
@@ -242,6 +233,17 @@ export const LOCAL_SCHEMA_DDL_SQL = `
     row_id     TEXT    NOT NULL,
     deleted_at INTEGER NOT NULL,
     PRIMARY KEY (table_name, row_id)
+  );
+
+  -- Per-(project, row) push tracking for shared-project sync. A row is pushed to a
+  -- project's shared DB when it has no entry here, or when updated_at > pushed_at.
+  -- Keyed by project so a row can be synced to project A but not yet project B.
+  CREATE TABLE IF NOT EXISTS sync_pushed (
+    project_id TEXT    NOT NULL,
+    table_name TEXT    NOT NULL,
+    row_id     TEXT    NOT NULL,
+    pushed_at  INTEGER NOT NULL,
+    PRIMARY KEY (project_id, table_name, row_id)
   );
 
   CREATE INDEX IF NOT EXISTS idx_contact_tags_contact_id ON contact_tags(contact_id);

--- a/src/main/dedup.ts
+++ b/src/main/dedup.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import type Database from 'better-sqlite3-multiple-ciphers';
 import type { DedupContact, DuplicatePair } from '@shared/types';
 import { normalizeEmail } from './sanitize';
+import { writeTombstone } from './sync/engine';
 
 export function loadDedupContacts(db: Database.Database): DedupContact[] {
   const contacts = db
@@ -348,6 +349,13 @@ export function mergeContacts(
       }
     }
 
+    // Snapshot the loser's log entry and mention IDs before they're remapped to
+    // the winner below. Their shared-DB copies still hang off the loser and get
+    // cascade-deleted when the loser's tombstone is applied there, so their push
+    // records must be cleared for them to re-push under the winner's contact_id.
+    const loserLogEntryIds = (db.prepare('SELECT id FROM interaction_log_entries WHERE contact_id = ?').all(loserId) as Array<{ id: string }>).map((r) => r.id);
+    const loserMentionIds = (db.prepare('SELECT id FROM contact_alert_mentions WHERE contact_id = ?').all(loserId) as Array<{ id: string }>).map((r) => r.id);
+
     const loserMemberships = db
       .prepare('SELECT id, project_id FROM project_memberships WHERE contact_id = ?')
       .all(loserId) as Array<{ id: string; project_id: string }>;
@@ -406,6 +414,21 @@ export function mergeContacts(
       winnerId,
       loserId,
     );
+
+    // Tombstone the loser so shared-project sync deletes it (and, via CASCADE,
+    // its shared sub-rows) instead of resurrecting it on the next pull.
+    writeTombstone(db, 'contacts', loserId, now);
+
+    // Clear push records so everything absorbed by the winner re-pushes: the
+    // winner itself (wholesale, for all projects), the remapped log entries and
+    // mentions, and the loser's memberships (remapped ones re-push under the
+    // winner; deleted ones are cascade-cleaned in shared by the tombstone).
+    const clearPush = db.prepare('DELETE FROM sync_pushed WHERE table_name = ? AND row_id = ?');
+    clearPush.run('contacts', winnerId);
+    clearPush.run('contacts', loserId);
+    for (const id of loserLogEntryIds) clearPush.run('interaction_log_entries', id);
+    for (const id of loserMentionIds) clearPush.run('contact_alert_mentions', id);
+    for (const m of loserMemberships) clearPush.run('project_memberships', m.id);
 
     db.prepare('DELETE FROM contacts WHERE id = ?').run(loserId);
   });

--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -27,6 +27,7 @@ import type {
   User,
 } from '@shared/types';
 import { loadDedupContacts, findDuplicatePairs, mergeContacts as mergeContactsDb, loadDismissedPairs, dismissPair } from '../dedup';
+import { writeTombstone } from '../sync/engine';
 import type { DuplicatePair } from '@shared/types';
 
 let cachedPairs: DuplicatePair[] = [];
@@ -343,7 +344,16 @@ export function registerContactHandlers(): void {
   });
 
   ipcMain.handle('contacts:delete', (_, id: string): void => {
-    getDatabase().prepare('DELETE FROM contacts WHERE id = ?').run(id);
+    const db = getDatabase();
+    const now = Math.floor(Date.now() / 1000);
+    // Tombstone + delete are one transaction so shared-project sync always sees
+    // the deletion; contacts never in a shared project just get a tombstone that
+    // ages out with the 90-day GC.
+    db.transaction(() => {
+      writeTombstone(db, 'contacts', id, now);
+      db.prepare("DELETE FROM sync_pushed WHERE table_name = 'contacts' AND row_id = ?").run(id);
+      db.prepare('DELETE FROM contacts WHERE id = ?').run(id);
+    })();
     runDedupScan();
     broadcastContactsChanged();
   });
@@ -379,10 +389,15 @@ export function registerContactHandlers(): void {
       // Read + conditional clear + delete are in a single transaction to close
       // the TOCTOU window where another write could change default_membership_id
       // between the read and the conditional update (fixes #189).
+      const now = Math.floor(Date.now() / 1000);
       db.transaction(() => {
         const membership = db
           .prepare('SELECT id FROM project_memberships WHERE contact_id = ? AND project_id = ?')
           .get(contactId, projectId) as { id: string } | undefined;
+        if (membership) {
+          writeTombstone(db, 'project_memberships', membership.id, now);
+          db.prepare("DELETE FROM sync_pushed WHERE table_name = 'project_memberships' AND row_id = ?").run(membership.id);
+        }
         db.prepare('DELETE FROM project_memberships WHERE contact_id = ? AND project_id = ?').run(contactId, projectId);
         if (membership) {
           db.prepare(
@@ -767,10 +782,13 @@ export function registerContactHandlers(): void {
     const db = getDatabase();
     // Collect affected memberships and delete in one transaction to close the
     // TOCTOU window between the SELECT and DELETE.
+    const now = Math.floor(Date.now() / 1000);
     const membershipIds = db.transaction(() => {
       const ids = (
         db.prepare('SELECT membership_id FROM interaction_projects WHERE interaction_id = ?').all(interactionId) as Array<{ membership_id: string }>
       ).map((r) => r.membership_id);
+      writeTombstone(db, 'interaction_log_entries', interactionId, now);
+      db.prepare("DELETE FROM sync_pushed WHERE table_name = 'interaction_log_entries' AND row_id = ?").run(interactionId);
       db.prepare('DELETE FROM interaction_log_entries WHERE id = ?').run(interactionId);
       return ids;
     })();

--- a/src/main/ipc/projects.ts
+++ b/src/main/ipc/projects.ts
@@ -276,17 +276,9 @@ export function registerProjectHandlers(): void {
             'UPDATE projects SET is_shared = 1, shared_db_path = ?, shared_db_key = ? WHERE id = ?',
           ).run(filePath, keyBytes, projectId);
 
-          // Reset synced_at so all existing contacts/memberships are treated as
-          // unsynced and get pushed to the new shared file on the first sync.
-          const memberContactIds = (db
-            .prepare('SELECT contact_id FROM project_memberships WHERE project_id = ?')
-            .all(projectId) as { contact_id: string }[])
-            .map((r) => r.contact_id);
-          if (memberContactIds.length > 0) {
-            const ph = memberContactIds.map(() => '?').join(',');
-            db.prepare(`UPDATE contacts SET synced_at = NULL WHERE id IN (${ph})`).run(...memberContactIds);
-          }
-          db.prepare('UPDATE project_memberships SET synced_at = NULL WHERE project_id = ?').run(projectId);
+          // Clear any stale push records so all existing contacts/memberships are
+          // treated as unsynced and get pushed to the new shared file on the first sync.
+          db.prepare('DELETE FROM sync_pushed WHERE project_id = ?').run(projectId);
         })();
       } catch (localErr) {
         // Best-effort compensating action: evict the shared DB connection and
@@ -346,21 +338,13 @@ export function registerProjectHandlers(): void {
         project.description,
       );
 
-      // Update local project record and reset synced_at atomically.
+      // Update local project record and reset push state atomically — the fresh
+      // shared file starts empty, so every row must be treated as unsynced.
       db.transaction(() => {
         db.prepare(
           'UPDATE projects SET shared_db_path = ?, shared_db_key = ? WHERE id = ?',
         ).run(filePath, keyBytes, projectId);
-
-        const memberContactIds = (db
-          .prepare('SELECT contact_id FROM project_memberships WHERE project_id = ?')
-          .all(projectId) as { contact_id: string }[])
-          .map((r) => r.contact_id);
-        if (memberContactIds.length > 0) {
-          const ph = memberContactIds.map(() => '?').join(',');
-          db.prepare(`UPDATE contacts SET synced_at = NULL WHERE id IN (${ph})`).run(...memberContactIds);
-        }
-        db.prepare('UPDATE project_memberships SET synced_at = NULL WHERE project_id = ?').run(projectId);
+        db.prepare('DELETE FROM sync_pushed WHERE project_id = ?').run(projectId);
       })();
 
       // Push all local project data to the fresh shared file
@@ -426,9 +410,14 @@ export function registerProjectHandlers(): void {
   ipcMain.handle('projects:unshare', (_, id: string): Project => {
     closeSharedDb(id);
     const db = getDatabase();
-    db.prepare(
-      'UPDATE projects SET is_shared = 0, shared_db_path = NULL, shared_db_key = NULL, shared_pending_writes = 0 WHERE id = ?',
-    ).run(id);
+    db.transaction(() => {
+      db.prepare(
+        'UPDATE projects SET is_shared = 0, shared_db_path = NULL, shared_db_key = NULL, shared_pending_writes = 0 WHERE id = ?',
+      ).run(id);
+      // Stale push records would wrongly mark rows as already synced if the
+      // project is ever re-shared to a fresh file.
+      db.prepare('DELETE FROM sync_pushed WHERE project_id = ?').run(id);
+    })();
     return db.prepare('SELECT * FROM projects WHERE id = ?').get(id) as Project;
   });
 
@@ -444,7 +433,12 @@ export function registerProjectHandlers(): void {
 
   ipcMain.handle('projects:delete', (_, id: string): void => {
     closeSharedDb(id);
-    getDatabase().prepare('DELETE FROM projects WHERE id = ?').run(id);
+    const db = getDatabase();
+    db.transaction(() => {
+      db.prepare('DELETE FROM projects WHERE id = ?').run(id);
+      // sync_pushed has no FK to projects — clean up its rows explicitly.
+      db.prepare('DELETE FROM sync_pushed WHERE project_id = ?').run(id);
+    })();
   });
 
   ipcMain.handle('projects:list-reporters', (_, projectId: string): Array<{ email: string; name: string }> => {

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -12,17 +12,34 @@ export interface SyncResult {
 /**
  * Bidirectional sync between local and shared DBs for a single project.
  *
+ * Replication state:
+ *   - Push tracking lives in the local sync_pushed table, keyed by
+ *     (project_id, table_name, row_id). A row is pushed when it has no entry
+ *     for this project, or when its updated_at is newer than pushed_at.
+ *   - Deletions propagate through sync_tombstones. Sub-table rows
+ *     (emails/phones/links/handles/tags) are filtered during the union merge;
+ *     contacts, project_memberships, and interaction_log_entries tombstones
+ *     are applied directly: matching rows are deleted on both sides.
+ *     Conflict rule: for contacts and memberships, an edit with
+ *     updated_at > deleted_at beats the tombstone (the row survives and the
+ *     tombstone is dropped); otherwise the delete wins, including ties.
+ *     Log entries are immutable, so their tombstones always win.
+ *
  * Pull strategy:
- *   - Contacts + their sub-tables (emails/phones/links/alert_rss): LWW by contact.updated_at.
- *     When shared contact is newer, replace the contact row AND all its sub-tables.
+ *   - Contacts + their sub-tables (emails/phones/links/alert_rss): LWW by
+ *     contact.updated_at. When shared contact is newer, replace the contact row
+ *     AND all its sub-tables.
  *   - project_memberships: LWW by membership.updated_at.
- *   - contact_alert_mentions, interaction_log_entries:
- *     append-only — insert rows not yet present locally.
+ *   - contact_alert_mentions, interaction_log_entries: append-only — full-table
+ *     scan with INSERT OR IGNORE. No watermarks: rows arrive in the shared file
+ *     in sync order, not timestamp order (an offline client can upload old rows
+ *     long after newer ones exist locally), so any timestamp cutoff can skip
+ *     rows permanently.
  *
  * Push strategy:
- *   - Contacts where local.updated_at > local.synced_at: push to shared + replace sub-tables.
- *   - project_memberships where local.updated_at > local.synced_at: push to shared.
- *   - append-only tables where local.synced_at IS NULL: push to shared.
+ *   - Contacts / memberships: push when sync_pushed has no fresh record for
+ *     this project (see above), then replace sub-tables wholesale.
+ *   - Append-only tables: push rows with no sync_pushed record for this project.
  */
 export function syncProject(
   localDb: Database.Database,
@@ -35,23 +52,22 @@ export function syncProject(
   //   1. Read everything needed from both DBs (outside any transaction).
   //   2. Write pull results to localDb in one transaction.
   //   3. Write push results to sharedDb in one transaction.
-  //   4. Stamp localDb metadata (last_synced_at) in a final local transaction.
+  //   4. Stamp localDb push records (sync_pushed) in a final local transaction.
   // (fixes #224)
   try {
     const now = Math.floor(Date.now() / 1000);
 
-    // Phase 1: reads happen inside the pull/push helpers themselves; no outer
-    // transaction is needed for reads.
-
     // Phase 2: pull from shared → local
     localDb.transaction(() => {
       pullTombstones(localDb, sharedDb);
-      pullContacts(localDb, sharedDb);
-      pullMemberships(localDb, sharedDb, projectId, now);
-      pullAppendOnly(localDb, sharedDb);
+      const tombstones = loadLocalTombstones(localDb);
+      applyTombstonesLocal(localDb, tombstones);
+      pullContacts(localDb, sharedDb, tombstones);
+      pullMemberships(localDb, sharedDb, projectId, now, tombstones);
+      pullAppendOnly(localDb, sharedDb, projectId, tombstones);
     })();
 
-    // Phase 3: push from local → shared (pure sharedDb writes; synced_at stamps deferred to phase 4)
+    // Phase 3: push from local → shared (pure sharedDb writes; sync_pushed stamps deferred to phase 4)
     const memberRows = localDb
       .prepare('SELECT id, contact_id FROM project_memberships WHERE project_id = ?')
       .all(projectId) as { id: string; contact_id: string }[];
@@ -63,25 +79,29 @@ export function syncProject(
     let pushedMentionIds: string[];
     let pushedLogEntryIds: string[];
 
+    // Reload — the pull phase can add tombstones from shared and drop ones that
+    // lost to a newer edit.
+    const tombstones = loadLocalTombstones(localDb);
+
     sharedDb.transaction(() => {
       pushTombstones(localDb, sharedDb, now);
-      pushedContactIds = pushContacts(localDb, sharedDb, contactIds);
+      applyTombstonesShared(sharedDb, tombstones);
+      pushedContactIds = pushContacts(localDb, sharedDb, projectId, contactIds);
       pushedMembershipIds = pushMemberships(localDb, sharedDb, projectId);
       ({ mentionIds: pushedMentionIds, logEntryIds: pushedLogEntryIds } =
-        pushAppendOnly(localDb, sharedDb, contactIds, membershipIds));
+        pushAppendOnly(localDb, sharedDb, projectId, contactIds, membershipIds));
     })();
 
-    // Phase 4: stamp synced_at on all successfully-pushed local rows, plus project metadata.
-    // Runs after sharedDb.transaction() commits so stamps only apply when the push succeeded.
-    const stmtContactSynced = localDb.prepare('UPDATE contacts SET synced_at = ? WHERE id = ?');
-    const stmtMembershipSynced = localDb.prepare('UPDATE project_memberships SET synced_at = ? WHERE id = ?');
-    const stmtMentionSynced = localDb.prepare('UPDATE contact_alert_mentions SET synced_at = ? WHERE id = ?');
-    const stmtLogEntrySynced = localDb.prepare('UPDATE interaction_log_entries SET synced_at = ? WHERE id = ?');
+    // Phase 4: record push state for all successfully-pushed rows, plus project metadata.
+    // Runs after sharedDb.transaction() commits so records only apply when the push succeeded.
+    const stampPushed = localDb.prepare(
+      'INSERT OR REPLACE INTO sync_pushed (project_id, table_name, row_id, pushed_at) VALUES (?, ?, ?, ?)',
+    );
     localDb.transaction(() => {
-      for (const id of pushedContactIds!) stmtContactSynced.run(now, id);
-      for (const id of pushedMembershipIds!) stmtMembershipSynced.run(now, id);
-      for (const id of pushedMentionIds!) stmtMentionSynced.run(now, id);
-      for (const id of pushedLogEntryIds!) stmtLogEntrySynced.run(now, id);
+      for (const id of pushedContactIds!) stampPushed.run(projectId, 'contacts', id, now);
+      for (const id of pushedMembershipIds!) stampPushed.run(projectId, 'project_memberships', id, now);
+      for (const id of pushedMentionIds!) stampPushed.run(projectId, 'contact_alert_mentions', id, now);
+      for (const id of pushedLogEntryIds!) stampPushed.run(projectId, 'interaction_log_entries', id, now);
       localDb.prepare('UPDATE projects SET shared_pending_writes = 0, last_synced_at = ? WHERE id = ?').run(now, projectId);
       localDb.prepare('DELETE FROM sync_tombstones WHERE deleted_at < ?').run(now - TOMBSTONE_TTL_SECONDS);
     })();
@@ -100,6 +120,9 @@ export function syncProject(
 // ---------------------------------------------------------------------------
 // Tombstone helpers
 // ---------------------------------------------------------------------------
+
+// table_name → (row_id → deleted_at)
+type TombstoneMap = Map<string, Map<string, number>>;
 
 function pullTombstones(local: Database.Database, shared: Database.Database): void {
   const rows = shared.prepare('SELECT table_name, row_id, deleted_at FROM sync_tombstones').all() as {
@@ -124,14 +147,75 @@ function pushTombstones(local: Database.Database, shared: Database.Database, now
   shared.prepare('DELETE FROM sync_tombstones WHERE deleted_at < ?').run(now - TOMBSTONE_TTL_SECONDS);
 }
 
-function loadLocalTombstones(local: Database.Database): Map<string, Set<string>> {
-  const map = new Map<string, Set<string>>();
-  for (const { table_name, row_id } of local.prepare('SELECT table_name, row_id FROM sync_tombstones').all() as { table_name: string; row_id: string }[]) {
-    let s = map.get(table_name);
-    if (!s) { s = new Set<string>(); map.set(table_name, s); }
-    s.add(row_id);
+function loadLocalTombstones(local: Database.Database): TombstoneMap {
+  const map: TombstoneMap = new Map();
+  for (const { table_name, row_id, deleted_at } of local.prepare('SELECT table_name, row_id, deleted_at FROM sync_tombstones').all() as { table_name: string; row_id: string; deleted_at: number }[]) {
+    let m = map.get(table_name);
+    if (!m) { m = new Map<string, number>(); map.set(table_name, m); }
+    m.set(row_id, deleted_at);
   }
   return map;
+}
+
+/**
+ * Deletes locally-present rows that have an active tombstone. Mutates the
+ * passed map when a tombstone loses to a newer edit so later pull steps see
+ * the same view as the database.
+ */
+function applyTombstonesLocal(local: Database.Database, tombstones: TombstoneMap): void {
+  const dropTombstone = local.prepare('DELETE FROM sync_tombstones WHERE table_name = ? AND row_id = ?');
+  const dropPushRecords = local.prepare('DELETE FROM sync_pushed WHERE table_name = ? AND row_id = ?');
+
+  for (const table of ['contacts', 'project_memberships'] as const) {
+    const idCol = 'id';
+    for (const [rowId, deletedAt] of tombstones.get(table) ?? []) {
+      const row = local.prepare(`SELECT updated_at FROM "${table}" WHERE "${idCol}" = ?`).get(rowId) as
+        | { updated_at: number }
+        | undefined;
+      if (!row) continue;
+      if (row.updated_at > deletedAt) {
+        // Edit is newer than the delete — the row survives everywhere.
+        dropTombstone.run(table, rowId);
+        tombstones.get(table)!.delete(rowId);
+      } else {
+        local.prepare(`DELETE FROM "${table}" WHERE "${idCol}" = ?`).run(rowId);
+        dropPushRecords.run(table, rowId);
+      }
+    }
+  }
+
+  // Log entries are immutable — tombstones always win.
+  for (const [rowId] of tombstones.get('interaction_log_entries') ?? []) {
+    local.prepare('DELETE FROM interaction_log_entries WHERE id = ?').run(rowId);
+    dropPushRecords.run('interaction_log_entries', rowId);
+  }
+}
+
+/**
+ * Deletes shared rows covered by an active local tombstone. When the shared row
+ * is newer than the tombstone the row is left in place — the pull side resolves
+ * that case by dropping the tombstone and re-pulling the row.
+ */
+function applyTombstonesShared(shared: Database.Database, tombstones: TombstoneMap): void {
+  for (const table of ['contacts', 'project_memberships'] as const) {
+    for (const [rowId, deletedAt] of tombstones.get(table) ?? []) {
+      const row = shared.prepare(`SELECT updated_at FROM "${table}" WHERE id = ?`).get(rowId) as
+        | { updated_at: number }
+        | undefined;
+      if (!row) continue;
+      if (row.updated_at > deletedAt) continue;
+      shared.prepare(`DELETE FROM "${table}" WHERE id = ?`).run(rowId);
+    }
+  }
+  for (const [rowId] of tombstones.get('interaction_log_entries') ?? []) {
+    shared.prepare('DELETE FROM interaction_log_entries WHERE id = ?').run(rowId);
+  }
+}
+
+// Returns true when the tombstone should suppress a row with the given
+// updated_at (delete wins on ties). Mutating cleanup happens at the call sites.
+function tombstoneWins(deletedAt: number | undefined, updatedAt: number): boolean {
+  return deletedAt !== undefined && deletedAt >= updatedAt;
 }
 
 // ---------------------------------------------------------------------------
@@ -144,13 +228,13 @@ function loadLocalTombstones(local: Database.Database): Map<string, Set<string>>
 function adoptSharedUuid(local: Database.Database, fromId: string, toId: string): void {
   const c = local.prepare('SELECT * FROM contacts WHERE id = ?').get(fromId) as {
     name: string; organization: string | null; title: string | null; dob: string | null;
-    notes: string | null; created_at: number; updated_at: number; synced_at: number | null;
+    notes: string | null; default_membership_id: string | null; created_at: number; updated_at: number;
   };
   local
     .prepare(
-      'INSERT INTO contacts (id, name, organization, title, dob, notes, created_at, updated_at, synced_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      'INSERT INTO contacts (id, name, organization, title, dob, notes, default_membership_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
     )
-    .run(toId, c.name, c.organization, c.title ?? null, c.dob ?? null, c.notes, c.created_at, c.updated_at, null);
+    .run(toId, c.name, c.organization, c.title ?? null, c.dob ?? null, c.notes, c.default_membership_id ?? null, c.created_at, c.updated_at);
   // Remap every table with a FK pointing at contacts — derived at runtime so new tables are never missed.
   const allTableNames = (local.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as { name: string }[]).map((r) => r.name);
   for (const table of allTableNames) {
@@ -172,11 +256,13 @@ function adoptSharedUuid(local: Database.Database, fromId: string, toId: string)
     const [a, b] = rawA < rawB ? [rawA, rawB] : [rawB, rawA];
     local.prepare('INSERT OR IGNORE INTO dedup_dismissed_pairs (contact_a_id, contact_b_id, dismissed_at) VALUES (?, ?, ?)').run(a, b, row.dismissed_at);
   }
+  // Push records for the abandoned UUID are meaningless; the adopted UUID's
+  // records are cleared by the caller so the merged contact re-pushes everywhere.
+  local.prepare("DELETE FROM sync_pushed WHERE table_name = 'contacts' AND row_id = ?").run(fromId);
   local.prepare('DELETE FROM contacts WHERE id = ?').run(fromId);
 }
 
-function pullContacts(local: Database.Database, shared: Database.Database): void {
-  const tombstones = loadLocalTombstones(local);
+function pullContacts(local: Database.Database, shared: Database.Database, tombstones: TombstoneMap): void {
   const sharedContacts = shared.prepare('SELECT id, name, organization, title, dob, notes, created_at, updated_at FROM contacts').all() as {
     id: string;
     name: string;
@@ -192,6 +278,12 @@ function pullContacts(local: Database.Database, shared: Database.Database): void
     (local.prepare('SELECT id, updated_at FROM contacts').all() as { id: string; updated_at: number }[])
       .map((r) => [r.id, r.updated_at]),
   );
+
+  const contactTombstones = tombstones.get('contacts') ?? new Map<string, number>();
+  const dropTombstone = local.prepare("DELETE FROM sync_tombstones WHERE table_name = 'contacts' AND row_id = ?");
+  // Clearing a contact's push records marks it dirty for every project, so the
+  // merged union propagates everywhere (this replaces the old synced_at = 0 trick).
+  const markDirty = local.prepare("DELETE FROM sync_pushed WHERE table_name = 'contacts' AND row_id = ?");
 
   // Identity indexes: email/phone → Set of local contact_ids.
   // Using a Set per key so that if two local contacts share an identifier, both are
@@ -213,6 +305,15 @@ function pullContacts(local: Database.Database, shared: Database.Database): void
   const adoptedIds = new Set<string>();
 
   for (const sc of sharedContacts) {
+    // Deletion vs edit: the tombstone wins unless the shared row was edited
+    // after the delete, in which case the edit revives the contact.
+    const deletedAt = contactTombstones.get(sc.id);
+    if (deletedAt !== undefined) {
+      if (tombstoneWins(deletedAt, sc.updated_at)) continue;
+      dropTombstone.run(sc.id);
+      contactTombstones.delete(sc.id);
+    }
+
     const localUpdatedAt = localMap.get(sc.id);
 
     if (localUpdatedAt !== undefined) {
@@ -220,16 +321,17 @@ function pullContacts(local: Database.Database, shared: Database.Database): void
       if (sc.updated_at > localUpdatedAt) {
         local
           .prepare(
-            `INSERT INTO contacts (id, name, organization, title, dob, notes, created_at, updated_at, synced_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `INSERT INTO contacts (id, name, organization, title, dob, notes, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(id) DO UPDATE SET
                name = excluded.name, organization = excluded.organization,
                title = excluded.title, dob = excluded.dob, notes = excluded.notes,
-               updated_at = excluded.updated_at, synced_at = excluded.synced_at`,
+               updated_at = excluded.updated_at`,
           )
-          .run(sc.id, sc.name, sc.organization, sc.title ?? null, sc.dob ?? null, sc.notes, sc.created_at, sc.updated_at, 0);
+          .run(sc.id, sc.name, sc.organization, sc.title ?? null, sc.dob ?? null, sc.notes, sc.created_at, sc.updated_at);
 
         mergeSubTablesFromShared(local, shared, sc.id, tombstones);
+        markDirty.run(sc.id);
       }
     } else {
       // No local contact with this UUID — check for an identity match by email/phone
@@ -266,26 +368,28 @@ function pullContacts(local: Database.Database, shared: Database.Database): void
         if (sc.updated_at > matchedUpdatedAt) {
           local
             .prepare(
-              `UPDATE contacts SET name = ?, organization = ?, title = ?, dob = ?, notes = ?, updated_at = ?, synced_at = ?
+              `UPDATE contacts SET name = ?, organization = ?, title = ?, dob = ?, notes = ?, updated_at = ?
                WHERE id = ?`,
             )
-            .run(sc.name, sc.organization, sc.title ?? null, sc.dob ?? null, sc.notes, sc.updated_at, 0, sc.id);
+            .run(sc.name, sc.organization, sc.title ?? null, sc.dob ?? null, sc.notes, sc.updated_at, sc.id);
         }
         mergeSubTablesFromShared(local, shared, sc.id, tombstones);
+        markDirty.run(sc.id);
       } else {
         // Genuinely new contact (or ambiguous multi-match / already-adopted local contact)
         local
           .prepare(
-            `INSERT INTO contacts (id, name, organization, title, dob, notes, created_at, updated_at, synced_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `INSERT INTO contacts (id, name, organization, title, dob, notes, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(id) DO UPDATE SET
                name = excluded.name, organization = excluded.organization,
                title = excluded.title, dob = excluded.dob, notes = excluded.notes,
-               updated_at = excluded.updated_at, synced_at = excluded.synced_at`,
+               updated_at = excluded.updated_at`,
           )
-          .run(sc.id, sc.name, sc.organization, sc.title ?? null, sc.dob ?? null, sc.notes, sc.created_at, sc.updated_at, 0);
+          .run(sc.id, sc.name, sc.organization, sc.title ?? null, sc.dob ?? null, sc.notes, sc.created_at, sc.updated_at);
 
         mergeSubTablesFromShared(local, shared, sc.id, tombstones);
+        markDirty.run(sc.id);
       }
 
       // Keep identity indexes current so later iterations in this sync see updated state
@@ -307,7 +411,7 @@ function mergeSubTablesFromShared(
   local: Database.Database,
   shared: Database.Database,
   contactId: string,
-  tombstones: Map<string, Set<string>>,
+  tombstones: TombstoneMap,
 ): void {
   // Sub-table merge strategy: union of shared rows + local-only rows (rows that
   // exist locally but not in shared). Local-only rows whose IDs appear in the local
@@ -322,7 +426,7 @@ function mergeSubTablesFromShared(
     .prepare('SELECT * FROM contact_emails WHERE contact_id = ? ORDER BY sort_order')
     .all(contactId) as { id: string; email: string; label: string | null; sort_order: number; created_at: number }[];
 
-  const emailTombstones = tombstones.get('contact_emails') ?? new Set<string>();
+  const emailTombstones = tombstones.get('contact_emails') ?? new Map<string, number>();
   const filteredSharedEmails = sharedEmails.filter((e) => !emailTombstones.has(e.id));
   const sharedEmailValues = new Set(filteredSharedEmails.map((e) => e.email));
   const localOnlyEmails = localEmails.filter((e) => !sharedEmailValues.has(e.email) && !emailTombstones.has(e.id));
@@ -346,7 +450,7 @@ function mergeSubTablesFromShared(
     .prepare('SELECT * FROM contact_phones WHERE contact_id = ? ORDER BY sort_order')
     .all(contactId) as { id: string; phone: string; label: string | null; sort_order: number; created_at: number }[];
 
-  const phoneTombstones = tombstones.get('contact_phones') ?? new Set<string>();
+  const phoneTombstones = tombstones.get('contact_phones') ?? new Map<string, number>();
   const filteredSharedPhones = sharedPhones.filter((p) => !phoneTombstones.has(p.id));
   const sharedPhoneValues = new Set(filteredSharedPhones.map((p) => p.phone));
   const localOnlyPhones = localPhones.filter((p) => !sharedPhoneValues.has(p.phone) && !phoneTombstones.has(p.id));
@@ -370,7 +474,7 @@ function mergeSubTablesFromShared(
     .all(contactId) as { id: string; type: string; label: string | null; url: string; wayback_url: string | null; sort_order: number; created_at: number }[];
 
   const localWaybacks = new Map(localLinks.filter((l) => l.wayback_url).map((l) => [l.url.trim(), l.wayback_url]));
-  const linkTombstones = tombstones.get('contact_links') ?? new Set<string>();
+  const linkTombstones = tombstones.get('contact_links') ?? new Map<string, number>();
   const filteredSharedLinks = sharedLinks.filter((l) => !linkTombstones.has(l.id));
   const sharedUrlValues = new Set(filteredSharedLinks.map((l) => l.url.trim()));
   const localOnlyLinks = localLinks.filter((l) => !sharedUrlValues.has(l.url.trim()) && !linkTombstones.has(l.id));
@@ -396,7 +500,7 @@ function mergeSubTablesFromShared(
     .prepare('SELECT * FROM contact_handles WHERE contact_id = ? ORDER BY sort_order')
     .all(contactId) as { id: string; type: string; handle: string; sort_order: number; created_at: number }[];
 
-  const handleTombstones = tombstones.get('contact_handles') ?? new Set<string>();
+  const handleTombstones = tombstones.get('contact_handles') ?? new Map<string, number>();
   const filteredSharedHandles = sharedHandles.filter((h) => !handleTombstones.has(h.id));
   const sharedHandleKeys = new Set(filteredSharedHandles.map((h) => `${h.type}:${h.handle}`));
   const localOnlyHandles = localHandles.filter((h) => !sharedHandleKeys.has(`${h.type}:${h.handle}`) && !handleTombstones.has(h.id));
@@ -441,7 +545,7 @@ function mergeSubTablesFromShared(
     .prepare('SELECT * FROM contact_tags WHERE contact_id = ?')
     .all(contactId) as { id: string; tag: string; created_at: number }[];
 
-  const tagTombstones = tombstones.get('contact_tags') ?? new Set<string>();
+  const tagTombstones = tombstones.get('contact_tags') ?? new Map<string, number>();
   const filteredSharedTags = sharedTags.filter((t) => !tagTombstones.has(t.id));
   const sharedTagValues = new Set(filteredSharedTags.map((t) => t.tag));
   const localOnlyTags = localTags.filter((t) => !sharedTagValues.has(t.tag) && !tagTombstones.has(t.id));
@@ -459,6 +563,7 @@ function pullMemberships(
   shared: Database.Database,
   projectId: string,
   now: number,
+  tombstones: TombstoneMap,
 ): void {
   const CONFLICT_WINDOW_SECS = 24 * 3600;
 
@@ -487,7 +592,30 @@ function pullMemberships(
       .map((r) => r.email),
   );
 
+  const membershipTombstones = tombstones.get('project_memberships') ?? new Map<string, number>();
+  const contactTombstones = tombstones.get('contacts') ?? new Map<string, number>();
+  const dropTombstone = local.prepare("DELETE FROM sync_tombstones WHERE table_name = 'project_memberships' AND row_id = ?");
+  // Pulled memberships are stamped as pushed so they don't echo straight back.
+  const stampPushed = local.prepare(
+    "INSERT OR REPLACE INTO sync_pushed (project_id, table_name, row_id, pushed_at) VALUES (?, 'project_memberships', ?, ?)",
+  );
+
   for (const sm of sharedMemberships) {
+    // Membership deleted locally (or on another client): tombstone wins unless
+    // the shared membership was edited after the delete.
+    const deletedAt = membershipTombstones.get(sm.id);
+    if (deletedAt !== undefined) {
+      if (tombstoneWins(deletedAt, sm.updated_at)) continue;
+      dropTombstone.run(sm.id);
+      membershipTombstones.delete(sm.id);
+    }
+    // Never resurrect a membership whose contact is tombstoned — the FK insert
+    // would fail anyway once the contact row is gone.
+    if (tombstoneWins(contactTombstones.get(sm.contact_id), sm.updated_at)) continue;
+    // The contact may legitimately be absent locally (e.g. skipped by an active
+    // tombstone in pullContacts) — skip rather than violate the FK.
+    if (!local.prepare('SELECT 1 FROM contacts WHERE id = ?').get(sm.contact_id)) continue;
+
     const lm = localMembershipMap.get(sm.id);
 
     if (!lm || sm.updated_at > lm.updated_at) {
@@ -521,13 +649,13 @@ function pullMemberships(
         .prepare(
           `INSERT INTO project_memberships
              (id, contact_id, project_id, reporter_email, reporter_name, theme, priority,
-              status, first_outreach_at, created_at, updated_at, synced_at, reporter_conflict)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              status, first_outreach_at, created_at, updated_at, reporter_conflict)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(id) DO UPDATE SET
              reporter_email = excluded.reporter_email, reporter_name = excluded.reporter_name,
              theme = excluded.theme, priority = excluded.priority, status = excluded.status,
              first_outreach_at = excluded.first_outreach_at,
-             updated_at = excluded.updated_at, synced_at = excluded.synced_at,
+             updated_at = excluded.updated_at,
              reporter_conflict = CASE WHEN excluded.reporter_conflict = 1 THEN 1 ELSE reporter_conflict END`,
         )
         .run(
@@ -542,9 +670,9 @@ function pullMemberships(
           sm.first_outreach_at,
           sm.created_at,
           sm.updated_at,
-          now,
           hasConflict,
         );
+      stampPushed.run(projectId, sm.id, now);
 
       // Re-attach children that were cascade-deleted with conflicting membership
       if (conflicting) {
@@ -574,19 +702,14 @@ function pullMemberships(
 function pullAppendOnly(
   local: Database.Database,
   shared: Database.Database,
+  projectId: string,
+  tombstones: TombstoneMap,
 ): void {
-  // Use high-watermarks to avoid loading entire shared tables on every sync.
-  // INSERT OR IGNORE is idempotent so re-fetching rows we already have is safe;
-  // the watermark merely avoids the memory cost of loading them all upfront.
-
-  const maxFetchedAt = (local
-    .prepare('SELECT COALESCE(MAX(fetched_at), 0) AS m FROM contact_alert_mentions')
-    .get() as { m: number }).m;
-
-  // Subtract a 30-second overlap window so rows that arrive late (due to clock
-  // skew between clients) are always eventually reconciled. Duplicates are safe
-  // because the INSERT below uses OR IGNORE.
-  const fetchedAtWatermark = Math.max(0, maxFetchedAt - 30);
+  // Full-table scan with INSERT OR IGNORE — no watermarks. Rows land in the
+  // shared file in sync order, not timestamp order (an offline client can
+  // upload old rows long after newer ones exist locally), so any timestamp
+  // cutoff can skip rows permanently. The scan is O(shared rows) per sync,
+  // which is fine at this application's scale.
 
   // Only import append-only rows for contacts that are members of some project.
   // Contacts pulled from shared without any membership are ignored here — they
@@ -595,9 +718,20 @@ function pullAppendOnly(
     (local.prepare('SELECT DISTINCT contact_id FROM project_memberships').all() as { contact_id: string }[]).map((r) => r.contact_id),
   );
 
-  for (const sm of shared.prepare(
-    'SELECT * FROM contact_alert_mentions WHERE fetched_at >= ?',
-  ).all(fetchedAtWatermark) as {
+  const logTombstones = tombstones.get('interaction_log_entries') ?? new Map<string, number>();
+
+  // Rows we pulled are stamped as pushed for this project so they don't echo
+  // straight back on the next push. Stamp only on actual insert (changes > 0):
+  // rows we already had keep whatever push state they carry.
+  const stampMention = local.prepare(
+    "INSERT OR REPLACE INTO sync_pushed (project_id, table_name, row_id, pushed_at) VALUES (?, 'contact_alert_mentions', ?, ?)",
+  );
+  const stampLogEntry = local.prepare(
+    "INSERT OR REPLACE INTO sync_pushed (project_id, table_name, row_id, pushed_at) VALUES (?, 'interaction_log_entries', ?, ?)",
+  );
+  const now = Math.floor(Date.now() / 1000);
+
+  for (const sm of shared.prepare('SELECT * FROM contact_alert_mentions').all() as {
     id: string;
     contact_id: string;
     headline: string;
@@ -608,25 +742,17 @@ function pullAppendOnly(
     seen: number;
   }[]) {
     if (!localContactIds.has(sm.contact_id)) continue;
-    local
+    const { changes } = local
       .prepare(
         `INSERT OR IGNORE INTO contact_alert_mentions
            (id, contact_id, headline, source_url, published_at, fetched_at, guid, seen)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(sm.id, sm.contact_id, sm.headline, sm.source_url, sm.published_at, sm.fetched_at, sm.guid, sm.seen);
+    if (changes > 0) stampMention.run(projectId, sm.id, now);
   }
 
-  const maxCreatedAt = (local
-    .prepare('SELECT COALESCE(MAX(created_at), 0) AS m FROM interaction_log_entries')
-    .get() as { m: number }).m;
-
-  // Same 30-second overlap window as above.
-  const createdAtWatermark = Math.max(0, maxCreatedAt - 30);
-
-  for (const se of shared.prepare(
-    'SELECT * FROM interaction_log_entries WHERE created_at >= ?',
-  ).all(createdAtWatermark) as {
+  for (const se of shared.prepare('SELECT * FROM interaction_log_entries').all() as {
     id: string;
     contact_id: string;
     reporter_email: string;
@@ -635,26 +761,30 @@ function pullAppendOnly(
     created_at: number;
   }[]) {
     if (!localContactIds.has(se.contact_id)) continue;
-    local
+    if (logTombstones.has(se.id)) continue;
+    const { changes } = local
       .prepare(
         `INSERT OR IGNORE INTO interaction_log_entries
            (id, contact_id, reporter_email, reporter_name, body, created_at)
          VALUES (?, ?, ?, ?, ?, ?)`,
       )
       .run(se.id, se.contact_id, se.reporter_email, se.reporter_name, se.body, se.created_at);
+    if (changes > 0) stampLogEntry.run(projectId, se.id, now);
   }
 
-  for (const sip of shared.prepare(
-    `SELECT ip.* FROM interaction_projects ip
-     JOIN interaction_log_entries ile ON ile.id = ip.interaction_id
-     WHERE ile.created_at >= ?`,
-  ).all(createdAtWatermark) as {
+  // Guard both FK targets: the entry may have been skipped above (non-member
+  // contact or tombstoned) and the membership may be tombstoned/absent locally.
+  const insertIp = local.prepare(
+    `INSERT OR IGNORE INTO interaction_projects (interaction_id, membership_id)
+     SELECT ?, ?
+     WHERE EXISTS (SELECT 1 FROM interaction_log_entries WHERE id = ?)
+       AND EXISTS (SELECT 1 FROM project_memberships WHERE id = ?)`,
+  );
+  for (const sip of shared.prepare('SELECT interaction_id, membership_id FROM interaction_projects').all() as {
     interaction_id: string;
     membership_id: string;
   }[]) {
-    local
-      .prepare('INSERT OR IGNORE INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)')
-      .run(sip.interaction_id, sip.membership_id);
+    insertIp.run(sip.interaction_id, sip.membership_id, sip.interaction_id, sip.membership_id);
   }
 }
 
@@ -665,9 +795,13 @@ function pullAppendOnly(
 function pushContacts(
   local: Database.Database,
   shared: Database.Database,
+  projectId: string,
   contactIds: string[],
 ): string[] {
   const pushed: string[] = [];
+  const getPushRecord = local.prepare(
+    "SELECT pushed_at FROM sync_pushed WHERE project_id = ? AND table_name = 'contacts' AND row_id = ?",
+  );
   for (const contactId of contactIds) {
     const lc = local.prepare('SELECT * FROM contacts WHERE id = ?').get(contactId) as
       | {
@@ -679,12 +813,12 @@ function pushContacts(
           notes: string | null;
           created_at: number;
           updated_at: number;
-          synced_at: number | null;
         }
       | undefined;
     if (!lc) continue;
 
-    if (!lc.synced_at || lc.updated_at > lc.synced_at) {
+    const rec = getPushRecord.get(projectId, contactId) as { pushed_at: number } | undefined;
+    if (!rec || lc.updated_at > rec.pushed_at) {
       shared
         .prepare(
           `INSERT INTO contacts (id, name, organization, title, dob, notes, created_at, updated_at)
@@ -787,6 +921,9 @@ function pushMemberships(
   projectId: string,
 ): string[] {
   const pushed: string[] = [];
+  const getPushRecord = local.prepare(
+    "SELECT pushed_at FROM sync_pushed WHERE project_id = ? AND table_name = 'project_memberships' AND row_id = ?",
+  );
   const memberships = local
     .prepare('SELECT * FROM project_memberships WHERE project_id = ?')
     .all(projectId) as {
@@ -800,11 +937,11 @@ function pushMemberships(
     first_outreach_at: number | null;
     created_at: number;
     updated_at: number;
-    synced_at: number | null;
   }[];
 
   for (const m of memberships) {
-    if (!m.synced_at || m.updated_at > m.synced_at) {
+    const rec = getPushRecord.get(projectId, m.id) as { pushed_at: number } | undefined;
+    if (!rec || m.updated_at > rec.pushed_at) {
       shared
         .prepare(
           `INSERT INTO project_memberships
@@ -837,6 +974,7 @@ function pushMemberships(
 function pushAppendOnly(
   local: Database.Database,
   shared: Database.Database,
+  projectId: string,
   contactIds: string[],
   membershipIds: string[],
 ): { mentionIds: string[]; logEntryIds: string[] } {
@@ -848,15 +986,20 @@ function pushAppendOnly(
   const mentionIds: string[] = [];
   const logEntryIds: string[] = [];
   if (contactIds.length > 0) {
-    // Alert mentions
+    // Alert mentions: rows with no push record for this project.
     for (let i = 0; i < contactIds.length; i += CHUNK) {
       const chunk = contactIds.slice(i, i + CHUNK);
       const cPlaceholders = chunk.map(() => '?').join(',');
       for (const m of local
         .prepare(
-          `SELECT * FROM contact_alert_mentions WHERE contact_id IN (${cPlaceholders}) AND synced_at IS NULL`,
+          `SELECT m.* FROM contact_alert_mentions m
+           WHERE m.contact_id IN (${cPlaceholders})
+             AND NOT EXISTS (
+               SELECT 1 FROM sync_pushed sp
+               WHERE sp.project_id = ? AND sp.table_name = 'contact_alert_mentions' AND sp.row_id = m.id
+             )`,
         )
-        .all(...chunk) as {
+        .all(...chunk, projectId) as {
         id: string;
         contact_id: string;
         headline: string;
@@ -879,7 +1022,8 @@ function pushAppendOnly(
   }
 
   if (membershipIds.length > 0) {
-    // Interaction log entries (push entries not yet synced that are linked to these memberships)
+    // Interaction log entries: entries linked to this project's memberships with
+    // no push record for this project.
     const seenEntryIds = new Set<string>();
     for (let i = 0; i < membershipIds.length; i += CHUNK) {
       const chunk = membershipIds.slice(i, i + CHUNK);
@@ -889,9 +1033,13 @@ function pushAppendOnly(
           `SELECT DISTINCT ile.id, ile.contact_id, ile.reporter_email, ile.reporter_name, ile.body, ile.created_at
            FROM interaction_log_entries ile
            JOIN interaction_projects ip ON ip.interaction_id = ile.id
-           WHERE ip.membership_id IN (${mPlaceholders}) AND ile.synced_at IS NULL`,
+           WHERE ip.membership_id IN (${mPlaceholders})
+             AND NOT EXISTS (
+               SELECT 1 FROM sync_pushed sp
+               WHERE sp.project_id = ? AND sp.table_name = 'interaction_log_entries' AND sp.row_id = ile.id
+             )`,
         )
-        .all(...chunk) as {
+        .all(...chunk, projectId) as {
         id: string;
         contact_id: string;
         reporter_email: string;
@@ -949,4 +1097,13 @@ export function getMembershipIds(local: Database.Database, projectId: string): s
       .prepare('SELECT id FROM project_memberships WHERE project_id = ?')
       .all(projectId) as { id: string }[]
   ).map((r) => r.id);
+}
+
+/** Writes a deletion tombstone. Callers must run this inside the same
+ *  transaction as the DELETE itself so the two can never diverge. */
+export function writeTombstone(db: Database.Database, tableName: string, rowId: string, deletedAt: number): void {
+  db.prepare(
+    `INSERT INTO sync_tombstones (table_name, row_id, deleted_at) VALUES (?, ?, ?)
+     ON CONFLICT(table_name, row_id) DO UPDATE SET deleted_at = MAX(deleted_at, excluded.deleted_at)`,
+  ).run(tableName, rowId, deletedAt);
 }

--- a/src/test/sync-engine.test.ts
+++ b/src/test/sync-engine.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import Database from 'better-sqlite3-multiple-ciphers';
 import { v4 as uuidv4 } from 'uuid';
 import { SHARED_SCHEMA_SQL } from '../main/database/shared-schema';
-import { syncProject } from '../main/sync/engine';
+import { syncProject, writeTombstone } from '../main/sync/engine';
 import { createTestDb, insertProject, insertContact } from './vitest.setup';
 
 const NOW = Math.floor(Date.now() / 1000);
@@ -295,7 +295,8 @@ describe('syncProject — push path', () => {
     // Overwrite the shared contact name directly to detect if a second push happens
     sharedDb.prepare('UPDATE contacts SET name = ? WHERE id = ?').run('Modified By Other', localContactId);
 
-    // Second sync: the contact's synced_at >= updated_at so it should NOT be pushed again
+    // Second sync: the contact's push record is fresh (pushed_at >= updated_at)
+    // so it should NOT be pushed again
     syncProject(localDb, sharedDb, projectId);
 
     const sharedContact = sharedDb.prepare('SELECT name FROM contacts WHERE id = ?').get(localContactId) as { name: string };
@@ -306,11 +307,11 @@ describe('syncProject — push path', () => {
 });
 
 // ---------------------------------------------------------------------------
-// pullAppendOnly — overlap window reconciliation
+// pullAppendOnly — full-scan pull (no watermarks)
 // ---------------------------------------------------------------------------
 
-describe('pullAppendOnly — overlap window', () => {
-  it('pulls a late-arriving log entry whose created_at falls within the 30s overlap window', () => {
+describe('pullAppendOnly — full-scan pull', () => {
+  it('pulls a late-arriving log entry with a created_at slightly older than the local max', () => {
     const localDb = createTestDb();
     const sharedDb = createSharedDb();
     const projectId = insertProject(localDb, 'Overlap Test');
@@ -328,12 +329,12 @@ describe('pullAppendOnly — overlap window', () => {
     ).run(membershipId, contactId, projectId, 'r@r.com', 'Reporter', NOW, NOW);
     sharedInsertMembership(sharedDb, membershipId, contactId);
 
-    // Existing local entry at NOW establishes the high-watermark.
+    // Existing local entry at NOW is newer than the shared entry below.
     localDb.prepare(
       'INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)',
     ).run(uuidv4(), contactId, 'r@r.com', 'Reporter', 'existing', NOW);
 
-    // Shared entry at NOW - 25 is below the local max but within the 30s overlap window.
+    // Shared entry at NOW - 25 is below the local max.
     const lateEntryId = uuidv4();
     sharedDb.prepare(
       'INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)',
@@ -366,7 +367,6 @@ describe('syncProject — last-write-wins (LWW)', () => {
 
     // Insert contact in both DBs with the same ID but different names and timestamps
     localDb.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Local Name', localTs, localTs);
-    localDb.prepare('UPDATE contacts SET synced_at = ? WHERE id = ?').run(localTs, contactId);
     sharedInsertContact(sharedDb, contactId, 'Shared Name', { updatedAt: sharedTs });
     localInsertMembership(localDb, contactId, projectId);
     sharedInsertMembership(sharedDb, uuidv4(), contactId);
@@ -389,7 +389,7 @@ describe('syncProject — last-write-wins (LWW)', () => {
     const sharedTs = NOW - 200;
 
     localDb.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Local Name', localTs, localTs);
-    // synced_at is NULL so push will fire
+    // No push record exists so push will fire
     sharedInsertContact(sharedDb, contactId, 'Shared Name', { updatedAt: sharedTs });
     localInsertMembership(localDb, contactId, projectId);
     sharedInsertMembership(sharedDb, uuidv4(), contactId);
@@ -460,11 +460,11 @@ describe('pullAppendOnly — orphan contact_id filter (#217)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Push path: synced_at only stamped after sharedDb transaction commits (#288)
+// Push path: push record only stamped after sharedDb transaction commits (#288)
 // ---------------------------------------------------------------------------
 
-describe('syncProject — deferred synced_at stamp (#288)', () => {
-  it('does not stamp synced_at when the shared push transaction fails', () => {
+describe('syncProject — deferred push-record stamp (#288)', () => {
+  it('does not record a push when the shared push transaction fails', () => {
     const localDb = createTestDb();
     const sharedDb = createSharedDb();
     const projectId = insertProject(localDb, 'Deferred Stamp Test');
@@ -480,9 +480,9 @@ describe('syncProject — deferred synced_at stamp (#288)', () => {
     const result = syncProject(localDb, sharedDb, projectId);
     expect(result.success).toBe(false);
 
-    // synced_at must remain null — the push transaction rolled back before phase 4
-    const row = localDb.prepare('SELECT synced_at FROM contacts WHERE id = ?').get(contactId) as { synced_at: number | null };
-    expect(row.synced_at).toBeNull();
+    // No push record may exist — the push transaction rolled back before phase 4
+    const rec = localDb.prepare("SELECT 1 FROM sync_pushed WHERE table_name = 'contacts' AND row_id = ?").get(contactId);
+    expect(rec).toBeUndefined();
   });
 });
 
@@ -588,7 +588,7 @@ describe('syncProject — push path: sub-tables, memberships, log entries', () =
 
     // Remove one email locally and bump updated_at to trigger a re-push
     localDb.prepare('DELETE FROM contact_emails WHERE contact_id = ? AND email = ?').run(contactId, 'b@example.com');
-    localDb.prepare('UPDATE contacts SET updated_at = ?, synced_at = NULL WHERE id = ?').run(NOW + 10, contactId);
+    localDb.prepare('UPDATE contacts SET updated_at = ? WHERE id = ?').run(NOW + 10, contactId);
 
     syncProject(localDb, sharedDb, projectId);
 
@@ -628,16 +628,17 @@ describe('syncProject — push path: sub-tables, memberships, log entries', () =
 
     expect(sharedDb.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(logId)).toBeDefined();
 
-    // Verify synced_at was stamped
-    const stamped = localDb.prepare('SELECT synced_at FROM interaction_log_entries WHERE id = ?').get(logId) as { synced_at: number | null };
-    expect(stamped.synced_at).not.toBeNull();
+    // Verify the push was recorded
+    const stamped = localDb.prepare("SELECT 1 FROM sync_pushed WHERE table_name = 'interaction_log_entries' AND row_id = ?").get(logId);
+    expect(stamped).toBeDefined();
 
-    // Delete from shared to detect a re-push
+    // Delete from shared to detect a re-push (also remove it from the shared
+    // side entirely so the full-scan pull doesn't bring it back)
     sharedDb.prepare('DELETE FROM interaction_log_entries WHERE id = ?').run(logId);
 
     syncProject(localDb, sharedDb, projectId);
 
-    // Should NOT be re-pushed (synced_at is set, so it won't be pushed again)
+    // Should NOT be re-pushed (push record exists, so it won't be pushed again)
     expect(sharedDb.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(logId)).toBeUndefined();
   });
 });
@@ -647,7 +648,7 @@ describe('syncProject — push path: sub-tables, memberships, log entries', () =
 // ---------------------------------------------------------------------------
 
 describe('syncProject — re-push after contact update', () => {
-  it('re-pushes a contact when updated_at advances past synced_at', () => {
+  it('re-pushes a contact when updated_at advances past its push record', () => {
     const localDb = createTestDb();
     const sharedDb = createSharedDb();
     const projectId = insertProject(localDb, 'Re-push Test');
@@ -659,7 +660,7 @@ describe('syncProject — re-push after contact update', () => {
     syncProject(localDb, sharedDb, projectId);
 
     // Locally update Alice's name
-    localDb.prepare('UPDATE contacts SET name = ?, updated_at = ?, synced_at = NULL WHERE id = ?').run('Re-push Alice Updated', NOW + 10, contactId);
+    localDb.prepare('UPDATE contacts SET name = ?, updated_at = ? WHERE id = ?').run('Re-push Alice Updated', NOW + 10, contactId);
 
     // Second sync: should push the updated name
     syncProject(localDb, sharedDb, projectId);
@@ -726,17 +727,19 @@ describe('syncProject — idempotency', () => {
     syncProject(localDb, sharedDb, projectId);
 
     // Snapshot state after first sync
-    const contactAfterFirst = localDb.prepare('SELECT name, synced_at FROM contacts WHERE id = ?').get(contactId) as { name: string; synced_at: number | null };
+    const contactAfterFirst = localDb.prepare('SELECT name FROM contacts WHERE id = ?').get(contactId) as { name: string };
+    const pushedAfterFirst = localDb.prepare("SELECT pushed_at FROM sync_pushed WHERE table_name = 'contacts' AND row_id = ?").get(contactId) as { pushed_at: number };
     const sharedEmailsAfterFirst = (sharedDb.prepare('SELECT email FROM contact_emails WHERE contact_id = ?').all(contactId) as { email: string }[]).map((r) => r.email);
 
     syncProject(localDb, sharedDb, projectId);
 
     // State should be identical after second sync
-    const contactAfterSecond = localDb.prepare('SELECT name, synced_at FROM contacts WHERE id = ?').get(contactId) as { name: string; synced_at: number | null };
+    const contactAfterSecond = localDb.prepare('SELECT name FROM contacts WHERE id = ?').get(contactId) as { name: string };
+    const pushedAfterSecond = localDb.prepare("SELECT pushed_at FROM sync_pushed WHERE table_name = 'contacts' AND row_id = ?").get(contactId) as { pushed_at: number };
     const sharedEmailsAfterSecond = (sharedDb.prepare('SELECT email FROM contact_emails WHERE contact_id = ?').all(contactId) as { email: string }[]).map((r) => r.email);
 
     expect(contactAfterSecond.name).toBe(contactAfterFirst.name);
-    expect(contactAfterSecond.synced_at).toBe(contactAfterFirst.synced_at);
+    expect(pushedAfterSecond.pushed_at).toBe(pushedAfterFirst.pushed_at);
     expect(sharedEmailsAfterSecond).toEqual(sharedEmailsAfterFirst);
   });
 });
@@ -766,11 +769,12 @@ describe('sub-table deletion self-healing', () => {
 
     const contactId = uuidv4();
 
-    // Both clients start with the same base contact (no sub-tables), synced_at set
-    // so the push guard fires only for their own edits.
-    for (const db of [localA, localB]) {
-      db.prepare('INSERT INTO contacts (id, name, created_at, updated_at, synced_at) VALUES (?, ?, ?, ?, ?)').run(contactId, 'Alice', T1 - 10, T1 - 10, T1 - 10);
-    }
+    // Both clients start with the same base contact (no sub-tables), with a fresh
+    // push record so the push guard fires only for their own edits.
+    localA.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Alice', T1 - 10, T1 - 10);
+    localB.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Alice', T1 - 10, T1 - 10);
+    localA.prepare("INSERT INTO sync_pushed (project_id, table_name, row_id, pushed_at) VALUES (?, 'contacts', ?, ?)").run(projectId_A, contactId, T1 - 10);
+    localB.prepare("INSERT INTO sync_pushed (project_id, table_name, row_id, pushed_at) VALUES (?, 'contacts', ?, ?)").run(projectId_B, contactId, T1 - 10);
     localInsertMembership(localA, contactId, projectId_A);
     localInsertMembership(localB, contactId, projectId_B);
 
@@ -921,8 +925,8 @@ describe('sync_tombstones — propagation and resurrection prevention', () => {
     const localB = createTestDb();
     for (const db of [localA, localB]) {
       db.prepare('INSERT INTO projects (id, name, is_shared, created_at) VALUES (?, ?, 1, ?)').run(projectId, 'Shared', T0);
-      db.prepare('INSERT INTO contacts (id, name, created_at, updated_at, synced_at) VALUES (?, ?, ?, ?, ?)').run(contactId, 'Alice', T0, T0, T0);
-      db.prepare('INSERT INTO project_memberships (id, contact_id, project_id, reporter_email, reporter_name, created_at, updated_at, synced_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)').run(uuidv4(), contactId, projectId, 'r@r.com', 'Reporter', T0, T0, T0);
+      db.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Alice', T0, T0);
+      db.prepare('INSERT INTO project_memberships (id, contact_id, project_id, reporter_email, reporter_name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)').run(uuidv4(), contactId, projectId, 'r@r.com', 'Reporter', T0, T0);
       db.prepare('INSERT INTO contact_tags (id, contact_id, tag, created_at) VALUES (?, ?, ?, ?)').run(tagId, contactId, 'source', T0);
     }
     sharedDb.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Alice', T0, T0);
@@ -956,8 +960,8 @@ describe('sync_tombstones — propagation and resurrection prevention', () => {
     const localB = createTestDb();
     for (const db of [localA, localB]) {
       db.prepare('INSERT INTO projects (id, name, is_shared, created_at) VALUES (?, ?, 1, ?)').run(projectId, 'Shared', T0);
-      db.prepare('INSERT INTO contacts (id, name, created_at, updated_at, synced_at) VALUES (?, ?, ?, ?, ?)').run(contactId, 'Alice', T0, T0, T0);
-      db.prepare('INSERT INTO project_memberships (id, contact_id, project_id, reporter_email, reporter_name, created_at, updated_at, synced_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)').run(uuidv4(), contactId, projectId, 'r@r.com', 'Reporter', T0, T0, T0);
+      db.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Alice', T0, T0);
+      db.prepare('INSERT INTO project_memberships (id, contact_id, project_id, reporter_email, reporter_name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)').run(uuidv4(), contactId, projectId, 'r@r.com', 'Reporter', T0, T0);
       db.prepare('INSERT INTO contact_emails (id, contact_id, email, sort_order, created_at) VALUES (?, ?, ?, 0, ?)').run(emailId, contactId, 'alice@wapo.com', T0);
     }
     sharedDb.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Alice', T0, T0);
@@ -994,7 +998,7 @@ describe('sync_tombstones — propagation and resurrection prevention', () => {
     const emailId = uuidv4();
     const T0 = NOW - 100;
 
-    localDb.prepare('INSERT INTO contacts (id, name, created_at, updated_at, synced_at) VALUES (?, ?, ?, ?, ?)').run(contactId, 'Alice', T0, T0, T0);
+    localDb.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Alice', T0, T0);
     localInsertMembership(localDb, contactId, projectId);
     // Old row with known ID, then tombstoned
     localDb.prepare('INSERT INTO contact_emails (id, contact_id, email, sort_order, created_at) VALUES (?, ?, ?, 0, ?)').run(emailId, contactId, 'alice@example.com', T0);
@@ -1073,5 +1077,268 @@ describe('sync_tombstones — propagation and resurrection prevention', () => {
     // After pushTombstones, shared should also have the newer deleted_at (it already did; upsert is idempotent)
     const shared = sharedDb.prepare('SELECT deleted_at FROM sync_tombstones WHERE row_id = ?').get(rowId) as { deleted_at: number } | undefined;
     expect(shared?.deleted_at).toBe(newerTs);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deletion propagation for contacts / memberships / log entries (#429)
+//
+// These simulate what the IPC handlers (contacts:delete, memberships:remove,
+// interaction-log:delete) do: tombstone + delete + clear push records in one
+// transaction, via writeTombstone.
+// ---------------------------------------------------------------------------
+
+function deleteContactLikeHandler(db: Database.Database, contactId: string, at: number): void {
+  db.transaction(() => {
+    writeTombstone(db, 'contacts', contactId, at);
+    db.prepare("DELETE FROM sync_pushed WHERE table_name = 'contacts' AND row_id = ?").run(contactId);
+    db.prepare('DELETE FROM contacts WHERE id = ?').run(contactId);
+  })();
+}
+
+describe('deletion propagation (#429)', () => {
+  function twoClientSetup() {
+    const sharedDb = createSharedDb();
+    const projectId = uuidv4();
+    const localA = createTestDb();
+    const localB = createTestDb();
+    for (const db of [localA, localB]) {
+      db.prepare('INSERT INTO projects (id, name, is_shared, created_at) VALUES (?, ?, 1, ?)').run(projectId, 'Shared', NOW - 100);
+    }
+    return { sharedDb, projectId, localA, localB };
+  }
+
+  it('a deleted contact does not resurrect on the deleting client\'s next sync', () => {
+    const { sharedDb, projectId, localA } = twoClientSetup();
+    const contactId = insertContact(localA, 'Doomed', { emails: ['doomed@example.com'] });
+    localInsertMembership(localA, contactId, projectId);
+
+    // Push the contact to shared, then delete it locally
+    expect(syncProject(localA, sharedDb, projectId).success).toBe(true);
+    expect(sharedDb.prepare('SELECT id FROM contacts WHERE id = ?').get(contactId)).toBeDefined();
+    deleteContactLikeHandler(localA, contactId, NOW + 5);
+
+    // Next sync must not pull the contact back, and must delete it from shared
+    expect(syncProject(localA, sharedDb, projectId).success).toBe(true);
+    expect(localA.prepare('SELECT id FROM contacts WHERE id = ?').get(contactId)).toBeUndefined();
+    expect(sharedDb.prepare('SELECT id FROM contacts WHERE id = ?').get(contactId)).toBeUndefined();
+  });
+
+  it('a contact deleted on client A is deleted on client B after B syncs', () => {
+    const { sharedDb, projectId, localA, localB } = twoClientSetup();
+    const contactId = insertContact(localA, 'Shared Sam', { emails: ['sam@example.com'] });
+    localInsertMembership(localA, contactId, projectId);
+
+    // A pushes; B pulls
+    expect(syncProject(localA, sharedDb, projectId).success).toBe(true);
+    expect(syncProject(localB, sharedDb, projectId).success).toBe(true);
+    expect(localB.prepare('SELECT id FROM contacts WHERE id = ?').get(contactId)).toBeDefined();
+
+    // A deletes + syncs; B syncs and must lose the contact
+    deleteContactLikeHandler(localA, contactId, NOW + 5);
+    expect(syncProject(localA, sharedDb, projectId).success).toBe(true);
+    expect(syncProject(localB, sharedDb, projectId).success).toBe(true);
+    expect(localB.prepare('SELECT id FROM contacts WHERE id = ?').get(contactId)).toBeUndefined();
+  });
+
+  it('an edit newer than the delete revives the contact everywhere (LWW)', () => {
+    const { sharedDb, projectId, localA, localB } = twoClientSetup();
+    const contactId = insertContact(localA, 'Lazarus', { emails: ['laz@example.com'] });
+    localInsertMembership(localA, contactId, projectId);
+    expect(syncProject(localA, sharedDb, projectId).success).toBe(true);
+    expect(syncProject(localB, sharedDb, projectId).success).toBe(true);
+
+    // A deletes at T1; B edits at T2 > T1 before seeing the tombstone
+    const T1 = NOW + 5;
+    const T2 = NOW + 10;
+    deleteContactLikeHandler(localA, contactId, T1);
+    expect(syncProject(localA, sharedDb, projectId).success).toBe(true);
+    localB.prepare('UPDATE contacts SET name = ?, updated_at = ? WHERE id = ?').run('Lazarus Lives', T2, contactId);
+
+    // B syncs: its newer edit beats the tombstone; B keeps and re-pushes the contact
+    expect(syncProject(localB, sharedDb, projectId).success).toBe(true);
+    expect(localB.prepare('SELECT id FROM contacts WHERE id = ?').get(contactId)).toBeDefined();
+    expect(sharedDb.prepare('SELECT id FROM contacts WHERE id = ?').get(contactId)).toBeDefined();
+
+    // A syncs: the revived contact comes back
+    expect(syncProject(localA, sharedDb, projectId).success).toBe(true);
+    const revived = localA.prepare('SELECT name FROM contacts WHERE id = ?').get(contactId) as { name: string } | undefined;
+    expect(revived?.name).toBe('Lazarus Lives');
+  });
+
+  it('a membership removed on client A is removed on client B (contact survives)', () => {
+    const { sharedDb, projectId, localA, localB } = twoClientSetup();
+    const contactId = insertContact(localA, 'Member Mary', { emails: ['mary@example.com'] });
+    const membershipId = localInsertMembership(localA, contactId, projectId);
+    expect(syncProject(localA, sharedDb, projectId).success).toBe(true);
+    expect(syncProject(localB, sharedDb, projectId).success).toBe(true);
+    expect(localB.prepare('SELECT id FROM project_memberships WHERE id = ?').get(membershipId)).toBeDefined();
+
+    // Simulate memberships:remove on A
+    localA.transaction(() => {
+      writeTombstone(localA, 'project_memberships', membershipId, NOW + 5);
+      localA.prepare("DELETE FROM sync_pushed WHERE table_name = 'project_memberships' AND row_id = ?").run(membershipId);
+      localA.prepare('DELETE FROM project_memberships WHERE id = ?').run(membershipId);
+    })();
+
+    expect(syncProject(localA, sharedDb, projectId).success).toBe(true);
+    expect(sharedDb.prepare('SELECT id FROM project_memberships WHERE id = ?').get(membershipId)).toBeUndefined();
+    expect(syncProject(localB, sharedDb, projectId).success).toBe(true);
+    expect(localB.prepare('SELECT id FROM project_memberships WHERE id = ?').get(membershipId)).toBeUndefined();
+    // The contact itself survives on both clients
+    expect(localB.prepare('SELECT id FROM contacts WHERE id = ?').get(contactId)).toBeDefined();
+  });
+
+  it('a deleted log entry does not resurrect and is removed from other clients', () => {
+    const { sharedDb, projectId, localA, localB } = twoClientSetup();
+    const contactId = insertContact(localA, 'Log Lucy', { emails: ['lucy@example.com'] });
+    const membershipId = localInsertMembership(localA, contactId, projectId);
+    const logId = uuidv4();
+    localA.prepare('INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)').run(logId, contactId, 'r@r.com', 'Reporter', 'Sensitive note', NOW);
+    localA.prepare('INSERT INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)').run(logId, membershipId);
+
+    expect(syncProject(localA, sharedDb, projectId).success).toBe(true);
+    expect(syncProject(localB, sharedDb, projectId).success).toBe(true);
+    expect(localB.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(logId)).toBeDefined();
+
+    // Simulate interaction-log:delete on A
+    localA.transaction(() => {
+      writeTombstone(localA, 'interaction_log_entries', logId, NOW + 5);
+      localA.prepare("DELETE FROM sync_pushed WHERE table_name = 'interaction_log_entries' AND row_id = ?").run(logId);
+      localA.prepare('DELETE FROM interaction_log_entries WHERE id = ?').run(logId);
+    })();
+
+    expect(syncProject(localA, sharedDb, projectId).success).toBe(true);
+    // Not resurrected on A, deleted from shared
+    expect(localA.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(logId)).toBeUndefined();
+    expect(sharedDb.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(logId)).toBeUndefined();
+    // Removed from B on its next sync
+    expect(syncProject(localB, sharedDb, projectId).success).toBe(true);
+    expect(localB.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(logId)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full-scan pull: offline client's old rows are never skipped (#430)
+// ---------------------------------------------------------------------------
+
+describe('pullAppendOnly — offline client reconciliation (#430)', () => {
+  it('pulls an old log entry that arrived in shared after newer local entries existed', () => {
+    const sharedDb = createSharedDb();
+    const projectId = uuidv4();
+    const contactId = uuidv4();
+    const membershipId = uuidv4();
+
+    const localA = createTestDb();
+    const localB = createTestDb();
+    for (const db of [localA, localB]) {
+      db.prepare('INSERT INTO projects (id, name, is_shared, created_at) VALUES (?, ?, 1, ?)').run(projectId, 'Shared', NOW - 10 * 86400);
+      db.prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(contactId, 'Alice', NOW - 10 * 86400, NOW - 10 * 86400);
+      db.prepare('INSERT INTO project_memberships (id, contact_id, project_id, reporter_email, reporter_name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)').run(membershipId, contactId, projectId, 'r@r.com', 'Reporter', NOW - 10 * 86400, NOW - 10 * 86400);
+    }
+    sharedInsertContact(sharedDb, contactId, 'Alice', { updatedAt: NOW - 10 * 86400 });
+    sharedInsertMembership(sharedDb, membershipId, contactId, { updatedAt: NOW - 10 * 86400 });
+
+    const MONDAY = NOW - 3 * 86400;
+    const TUESDAY = NOW - 2 * 86400;
+
+    // B (offline) writes a log entry Monday. A writes one Tuesday and syncs.
+    const mondayEntry = uuidv4();
+    localB.prepare('INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)').run(mondayEntry, contactId, 'b@b.com', 'B', 'Monday note', MONDAY);
+    localB.prepare('INSERT INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)').run(mondayEntry, membershipId);
+
+    const tuesdayEntry = uuidv4();
+    localA.prepare('INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)').run(tuesdayEntry, contactId, 'a@a.com', 'A', 'Tuesday note', TUESDAY);
+    localA.prepare('INSERT INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)').run(tuesdayEntry, membershipId);
+    expect(syncProject(localA, sharedDb, projectId).success).toBe(true);
+
+    // Wednesday: B comes online and syncs — its Monday entry lands in shared
+    expect(syncProject(localB, sharedDb, projectId).success).toBe(true);
+    expect(sharedDb.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(mondayEntry)).toBeDefined();
+
+    // Thursday: A syncs. With the old watermark (local MAX(created_at) − 30s =
+    // Tuesday − 30s) the Monday entry would be skipped forever. The full scan
+    // must pull it.
+    expect(syncProject(localA, sharedDb, projectId).success).toBe(true);
+    expect(localA.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(mondayEntry)).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-project push tracking: rows reach every shared project (#431)
+// ---------------------------------------------------------------------------
+
+describe('per-project push tracking (#431)', () => {
+  it('a log entry linked to memberships in two shared projects reaches both shared DBs', () => {
+    const localDb = createTestDb();
+    const sharedA = createSharedDb();
+    const sharedB = createSharedDb();
+    const projectA = insertProject(localDb, 'Project A');
+    const projectB = insertProject(localDb, 'Project B');
+
+    const contactId = insertContact(localDb, 'Multi Alice', { emails: ['multi@example.com'] });
+    const membershipA = localInsertMembership(localDb, contactId, projectA);
+    const membershipB = localInsertMembership(localDb, contactId, projectB);
+
+    const logId = uuidv4();
+    localDb.prepare('INSERT INTO interaction_log_entries (id, contact_id, reporter_email, reporter_name, body, created_at) VALUES (?, ?, ?, ?, ?, ?)').run(logId, contactId, 'r@r.com', 'Reporter', 'Cross-project note', NOW);
+    localDb.prepare('INSERT INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)').run(logId, membershipA);
+    localDb.prepare('INSERT INTO interaction_projects (interaction_id, membership_id) VALUES (?, ?)').run(logId, membershipB);
+
+    // Sync project A first — with the old global synced_at this stamped the
+    // entry and made it invisible to project B's push forever.
+    expect(syncProject(localDb, sharedA, projectA).success).toBe(true);
+    expect(syncProject(localDb, sharedB, projectB).success).toBe(true);
+
+    expect(sharedA.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(logId)).toBeDefined();
+    expect(sharedB.prepare('SELECT id FROM interaction_log_entries WHERE id = ?').get(logId)).toBeDefined();
+    // And each shared DB has the link for its own membership
+    expect(sharedA.prepare('SELECT 1 FROM interaction_projects WHERE interaction_id = ? AND membership_id = ?').get(logId, membershipA)).toBeDefined();
+    expect(sharedB.prepare('SELECT 1 FROM interaction_projects WHERE interaction_id = ? AND membership_id = ?').get(logId, membershipB)).toBeDefined();
+  });
+
+  it('an alert mention for a contact in two shared projects reaches both shared DBs', () => {
+    const localDb = createTestDb();
+    const sharedA = createSharedDb();
+    const sharedB = createSharedDb();
+    const projectA = insertProject(localDb, 'Project A');
+    const projectB = insertProject(localDb, 'Project B');
+
+    const contactId = insertContact(localDb, 'Mention Mike', { emails: ['mike@example.com'] });
+    localInsertMembership(localDb, contactId, projectA);
+    localInsertMembership(localDb, contactId, projectB);
+
+    const mentionId = uuidv4();
+    localDb.prepare('INSERT INTO contact_alert_mentions (id, contact_id, headline, source_url, fetched_at, guid, seen) VALUES (?, ?, ?, ?, ?, ?, 0)').run(mentionId, contactId, 'Headline', 'http://x.com', NOW, 'guid-multi');
+
+    expect(syncProject(localDb, sharedA, projectA).success).toBe(true);
+    expect(syncProject(localDb, sharedB, projectB).success).toBe(true);
+
+    expect(sharedA.prepare('SELECT id FROM contact_alert_mentions WHERE id = ?').get(mentionId)).toBeDefined();
+    expect(sharedB.prepare('SELECT id FROM contact_alert_mentions WHERE id = ?').get(mentionId)).toBeDefined();
+  });
+
+  it('a contact edited after syncing to project A still pushes the edit to project B', () => {
+    const localDb = createTestDb();
+    const sharedA = createSharedDb();
+    const sharedB = createSharedDb();
+    const projectA = insertProject(localDb, 'Project A');
+    const projectB = insertProject(localDb, 'Project B');
+
+    const contactId = insertContact(localDb, 'Edit Emma', { emails: ['emma@example.com'] });
+    localInsertMembership(localDb, contactId, projectA);
+    localInsertMembership(localDb, contactId, projectB);
+
+    // Sync A, then edit, then sync B — B must get the edited name.
+    expect(syncProject(localDb, sharedA, projectA).success).toBe(true);
+    localDb.prepare('UPDATE contacts SET name = ?, updated_at = ? WHERE id = ?').run('Edit Emma II', NOW + 10, contactId);
+    expect(syncProject(localDb, sharedB, projectB).success).toBe(true);
+    const inB = sharedB.prepare('SELECT name FROM contacts WHERE id = ?').get(contactId) as { name: string };
+    expect(inB.name).toBe('Edit Emma II');
+
+    // And A gets it on its next sync too.
+    expect(syncProject(localDb, sharedA, projectA).success).toBe(true);
+    const inA = sharedA.prepare('SELECT name FROM contacts WHERE id = ?').get(contactId) as { name: string };
+    expect(inA.name).toBe('Edit Emma II');
   });
 });


### PR DESCRIPTION
Implements the #445 umbrella design, resolving the three interlocking sync bugs in one coherent change rather than three flag-patches.

## What changed

**Push (#431):** a new local `sync_pushed (project_id, table_name, row_id, pushed_at)` table replaces the per-row `synced_at` columns. A row is pushed to a project when it has no record for *that* project, or when `updated_at > pushed_at`. Log entries and mentions linked to multiple shared projects now reach every one of them. Since we're pre-production, the `synced_at` columns are removed from the schema outright — no migration (DB_VERSION stays 1).

**Pull (#430):** the append-only pull is now a full-table `INSERT OR IGNORE` scan. Rows arrive in the shared file in *sync* order, not timestamp order, so the old `MAX(created_at) − 30s` watermark could permanently skip an offline client's rows. The scan is O(shared rows) per sync — cheap at this app's scale, and categorically immune to the ordering problem. Pulled rows are stamped as pushed for that project so they don't echo straight back.

**Deletions (#429):** `contacts:delete`, `memberships:remove`, and `interaction-log:delete` now write tombstones (same table, LWW-max upsert, and 90-day GC as the existing sub-table tombstones) in the same transaction as the delete. The engine applies them on both sides: tombstoned rows are deleted from the shared DB during push and skipped during pull. Conflict rule: for contacts and memberships, an edit with `updated_at > deleted_at` beats the tombstone and revives the row everywhere; ties go to the delete. Log entries are immutable, so their tombstones always win. `mergeContacts` tombstones the loser and clears push records so the merged winner re-propagates to every shared project.

Also fixed in passing: `adoptSharedUuid` now preserves `default_membership_id` (the remaining half of #435), and `projects:unshare`/`projects:delete` clean up push state so re-sharing starts fresh.

## Tests

9 new regression tests pin the exact failure scenarios from the issues:
- **#429:** delete-no-resurrect on the deleting client, cross-client contact/membership/log-entry deletion propagation, and edit-after-delete revival (LWW)
- **#430:** the offline-client scenario (B writes Monday, A writes Tuesday, B uploads Wednesday, A must still pull Monday's entry Thursday)
- **#431:** log entry + mention reaching two shared projects; contact edit after syncing to A still reaching B

Existing suite updated to the new model. **494 tests pass** (25 files); typecheck clean.

Closes #445
Closes #429
Closes #430
Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)