### PR TITLE
Sync fidelity: preserve handle created_at; don't discard sync data on conflict-copy cleanup

### DIFF
--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -475,10 +475,10 @@ export function registerContactHandlers(): void {
       const existingLinkCreatedAt = new Map(existingLinkRows.map((r) => [r.url.trim(), r.created_at]));
       const existingLinkIdMap = new Map(existingLinkRows.map((r) => [r.url.trim(), r.id]));
 
-      const existingHandleIdMap = new Map(
-        (stmt(db, 'SELECT id, type, handle FROM contact_handles WHERE contact_id = ?').all(data.id) as { id: string; type: string; handle: string }[])
-          .map((r) => [`${r.type}:${r.handle}`, r.id])
-      );
+      const existingHandleRows = stmt(db, 'SELECT id, type, handle, created_at FROM contact_handles WHERE contact_id = ?')
+        .all(data.id) as { id: string; type: string; handle: string; created_at: number }[];
+      const existingHandleCreatedAt = new Map(existingHandleRows.map((r) => [`${r.type}:${r.handle}`, r.created_at]));
+      const existingHandleIdMap = new Map(existingHandleRows.map((r) => [`${r.type}:${r.handle}`, r.id]));
 
       const tombstone = stmt(db, 'INSERT INTO sync_tombstones (table_name, row_id, deleted_at) VALUES (?, ?, ?) ON CONFLICT(table_name, row_id) DO UPDATE SET deleted_at = MAX(deleted_at, excluded.deleted_at)');
 
@@ -532,7 +532,7 @@ export function registerContactHandlers(): void {
       handles.forEach((h: ContactHandleInput, i: number) => {
         stmt(db,
           'INSERT INTO contact_handles (id, contact_id, type, handle, sort_order, created_at) VALUES (?, ?, ?, ?, ?, ?)',
-        ).run(uuidv4(), data.id, h.type.trim(), h.handle.trim(), i, now);
+        ).run(uuidv4(), data.id, h.type.trim(), h.handle.trim(), i, existingHandleCreatedAt.get(`${h.type.trim()}:${h.handle.trim()}`) ?? now);
       });
       const keptHandles = new Set(handles.map((h: ContactHandleInput) => `${h.type.trim()}:${h.handle.trim()}`));
       for (const [key, id] of existingHandleIdMap) {

--- a/src/main/sync/poller.ts
+++ b/src/main/sync/poller.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { BrowserWindow } from 'electron';
+import Database from 'better-sqlite3-multiple-ciphers';
 import { getDatabase, isDatabaseOpen } from '../database';
 import { openSharedDb, closeSharedDb } from '../database/shared-db';
 import { syncProject } from './engine';
@@ -98,7 +99,7 @@ export function syncOne(projectId: string, filePath: string, keyBytes: Buffer): 
     // Close after each sync so the file handle is released and Dropbox/OneDrive
     // can detect the change and upload it promptly.
     closeSharedDb(projectId);
-    deleteConflictCopies(filePath).catch(() => {});
+    deleteConflictCopies(localDb, projectId, filePath).catch(() => {});
 
     const project = localDb
       .prepare('SELECT shared_pending_writes FROM projects WHERE id = ?')
@@ -137,21 +138,28 @@ export function syncOne(projectId: string, filePath: string, keyBytes: Buffer): 
   return result;
 }
 
-async function deleteConflictCopies(filePath: string): Promise<void> {
+export async function deleteConflictCopies(localDb: Database.Database, projectId: string, filePath: string): Promise<void> {
   const dir = path.dirname(filePath);
   const ext = path.extname(filePath);
   const base = path.basename(filePath, ext);
   try {
     const files = await fs.readdir(dir);
-    for (const file of files) {
-      if (
+    const conflictFiles = files.filter(
+      (file) =>
         file !== path.basename(filePath) &&
         file.startsWith(base) &&
         file.endsWith(ext) &&
-        /conflicted copy/i.test(file)
-      ) {
-        try { await fs.unlink(path.join(dir, file)); } catch { /* best-effort */ }
-      }
+        /conflicted copy/i.test(file),
+    );
+    if (conflictFiles.length > 0) {
+      // A conflict copy may contain pushes from another client that this client's
+      // local sync_pushed rows claim are already synced. Clear them so the next
+      // sync re-pushes everything (all push paths are idempotent upserts) rather
+      // than silently losing rows that only ever landed in the deleted copy.
+      try { localDb.prepare('DELETE FROM sync_pushed WHERE project_id = ?').run(projectId); } catch { /* best-effort */ }
+    }
+    for (const file of conflictFiles) {
+      try { await fs.unlink(path.join(dir, file)); } catch { /* best-effort */ }
     }
   } catch { /* best-effort */ }
 }

--- a/src/test/contacts.test.ts
+++ b/src/test/contacts.test.ts
@@ -179,6 +179,24 @@ describe('contacts:update', () => {
     expect(updatedCreatedAt).toBe(originalCreatedAt);
   });
 
+  it('preserves handle created_at across update', async () => {
+    const id = insertContact(testDb, 'Alice Smith', { handles: [{ type: 'twitter', handle: '@alice' }] });
+    const staleCreatedAt = Math.floor(Date.now() / 1000) - 100;
+    testDb.prepare('UPDATE contact_handles SET created_at = ? WHERE contact_id = ?').run(staleCreatedAt, id);
+
+    await handlers.get('contacts:update')!({}, {
+      id,
+      name: 'Alice Smith',
+      emails: [],
+      phones: [],
+      links: [],
+      handles: [{ type: 'twitter', handle: '@alice' }],
+    });
+
+    const updatedCreatedAt = (testDb.prepare('SELECT created_at FROM contact_handles WHERE contact_id = ?').get(id) as { created_at: number }).created_at;
+    expect(updatedCreatedAt).toBe(staleCreatedAt);
+  });
+
   it('advances updated_at after update (timestamp advancement)', async () => {
     const id = insertContact(testDb, 'Alice Smith');
     const staleTs = Math.floor(Date.now() / 1000) - 100;

--- a/src/test/poller.test.ts
+++ b/src/test/poller.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { v4 as uuidv4 } from 'uuid';
+import { createTestDb } from './vitest.setup';
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '') },
+  ipcMain: { handle: vi.fn() },
+  BrowserWindow: { getAllWindows: vi.fn(() => []) },
+  Notification: vi.fn(function (this: { show: ReturnType<typeof vi.fn> }) {
+    this.show = vi.fn();
+  }),
+}));
+
+vi.mock('../main/database', () => ({
+  getDatabase: () => {
+    throw new Error('not used by deleteConflictCopies tests');
+  },
+  isDatabaseOpen: () => false,
+}));
+
+import { deleteConflictCopies } from '../main/sync/poller';
+
+// ---------------------------------------------------------------------------
+// deleteConflictCopies (#436)
+// ---------------------------------------------------------------------------
+
+describe('deleteConflictCopies', () => {
+  let dir: string;
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function insertPushedRow(db: ReturnType<typeof createTestDb>, projectId: string): void {
+    db.prepare(
+      'INSERT INTO sync_pushed (project_id, table_name, row_id, pushed_at) VALUES (?, ?, ?, ?)',
+    ).run(projectId, 'contacts', uuidv4(), Math.floor(Date.now() / 1000));
+  }
+
+  it('clears sync_pushed for the project and deletes the conflict copy when one is found', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'sourcerer-conflict-'));
+    const filePath = join(dir, 'shared.db');
+    const conflictPath = join(dir, 'shared (conflicted copy).db');
+    writeFileSync(filePath, 'main');
+    writeFileSync(conflictPath, 'conflict');
+
+    const testDb = createTestDb();
+    const projectId = uuidv4();
+    const otherProjectId = uuidv4();
+    insertPushedRow(testDb, projectId);
+    insertPushedRow(testDb, otherProjectId);
+
+    await deleteConflictCopies(testDb, projectId, filePath);
+
+    expect(existsSync(conflictPath)).toBe(false);
+    expect(existsSync(filePath)).toBe(true);
+
+    const remaining = testDb.prepare('SELECT project_id FROM sync_pushed').all() as { project_id: string }[];
+    expect(remaining.map((r) => r.project_id)).toEqual([otherProjectId]);
+  });
+
+  it('leaves sync_pushed untouched when no conflict copy is present', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'sourcerer-conflict-'));
+    const filePath = join(dir, 'shared.db');
+    writeFileSync(filePath, 'main');
+
+    const testDb = createTestDb();
+    const projectId = uuidv4();
+    insertPushedRow(testDb, projectId);
+
+    await deleteConflictCopies(testDb, projectId, filePath);
+
+    const remaining = testDb.prepare('SELECT project_id FROM sync_pushed').all() as { project_id: string }[];
+    expect(remaining).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- **contacts:update** now preserves `contact_handles.created_at` across the delete+re-insert on every contact update, mirroring the existing pattern already used for emails/phones/links in the same transaction. Previously handles were re-stamped with `now` every time, churning their sync-merge ordering across clients.
- **`deleteConflictCopies`** (sync poller) now clears the project's `sync_pushed` rows before deleting a detected cloud-provider "conflicted copy" file. Per the follow-up in #436 after the #449 replication-state redesign, this is the modern equivalent of the original fix sketch: marking the project's rows dirty forces a full re-push next sync (all push paths are idempotent upserts), so rows that only ever landed in the discarded conflict copy aren't silently lost.

Closes #435
Closes #436

## Test plan
- [x] `npm run rebuild:node && npm test` — full suite passes (502 tests)
- [x] Added `preserves handle created_at across update` test in `src/test/contacts.test.ts` (backdates, then asserts preservation across update)
- [x] Added `src/test/poller.test.ts` covering `deleteConflictCopies`: clears `sync_pushed` for the affected project only (leaves other projects' rows alone) when a conflict copy is found and deleted; leaves `sync_pushed` untouched when no conflict copy exists
- [x] `npx tsc --noEmit -p tsconfig.node.json` — clean
- [x] `npm run rebuild` — restored Electron-targeted native binaries after testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)