### PR TITLE
Fix orphaned screenshot files, UTC date-filter bug, and notification-checker nits

### DIFF
--- a/src/main/ipc/contacts.ts
+++ b/src/main/ipc/contacts.ts
@@ -1,10 +1,12 @@
 import { ipcMain, BrowserWindow, net } from 'electron';
 import { v4 as uuidv4 } from 'uuid';
+import fs from 'fs/promises';
 import type Database from 'better-sqlite3-multiple-ciphers';
 import { getDatabase, isDatabaseOpen } from '../database';
 import { normalizeEmail, normalizePhone, validateEmail, validateUrl } from '../sanitize';
 import { broadcastRemindersChanged } from './reminders';
 import { checkOutreachReminders } from '../sync/outreach-checker';
+import { safeScreenshotPath } from './screenshots';
 import type {
   ContactListItem,
   ContactDetail,
@@ -343,17 +345,25 @@ export function registerContactHandlers(): void {
     return { ...row, date_first_contacted: null, date_last_contacted: null, projects: [], tags: [] };
   });
 
-  ipcMain.handle('contacts:delete', (_, id: string): void => {
+  ipcMain.handle('contacts:delete', async (_, id: string): Promise<void> => {
     const db = getDatabase();
     const now = Math.floor(Date.now() / 1000);
+    const screenshotPaths = (
+      db.prepare('SELECT file_path FROM contact_screenshots WHERE contact_id = ?').all(id) as { file_path: string }[]
+    ).map((r) => r.file_path);
     // Tombstone + delete are one transaction so shared-project sync always sees
     // the deletion; contacts never in a shared project just get a tombstone that
-    // ages out with the 90-day GC.
+    // ages out with the 90-day GC. contact_screenshots rows cascade with the contact.
     db.transaction(() => {
       writeTombstone(db, 'contacts', id, now);
       db.prepare("DELETE FROM sync_pushed WHERE table_name = 'contacts' AND row_id = ?").run(id);
       db.prepare('DELETE FROM contacts WHERE id = ?').run(id);
     })();
+    for (const filePath of screenshotPaths) {
+      await fs.unlink(safeScreenshotPath(filePath)).catch((err) => {
+        if (err.code !== 'ENOENT') console.error('Failed to delete screenshot file for contact', id, err);
+      });
+    }
     runDedupScan();
     broadcastContactsChanged();
   });

--- a/src/main/ipc/screenshots.ts
+++ b/src/main/ipc/screenshots.ts
@@ -12,7 +12,7 @@ function screenshotsDir(): string {
   return getPaths().screenshotsPath;
 }
 
-function safeScreenshotPath(fileName: string): string {
+export function safeScreenshotPath(fileName: string): string {
   const dir = path.resolve(screenshotsDir());
   const resolved = path.resolve(path.join(dir, fileName));
   if (!resolved.startsWith(dir + path.sep)) throw new Error('Invalid screenshot path.');

--- a/src/main/sync/outreach-checker.ts
+++ b/src/main/sync/outreach-checker.ts
@@ -60,6 +60,8 @@ export function checkOutreachReminders(): void {
     )
     .all() as OutreachRow[];
 
+  let remindersChanged = false;
+
   for (const row of rows) {
     if (user.outreach_require_interaction && row.last_contacted === null) continue;
 
@@ -81,10 +83,10 @@ export function checkOutreachReminders(): void {
            (id, contact_id, project_id, membership_id, due_date, note, is_auto_outreach, created_at)
          VALUES (?, ?, ?, ?, ?, NULL, 1, ?)`,
       ).run(uuidv4(), row.contact_id, row.project_id, row.membership_id, dueDate, now);
-      broadcastRemindersChanged();
+      remindersChanged = true;
     } else if (existing.due_date !== dueDate) {
       db.prepare('UPDATE reminders SET due_date = ? WHERE id = ?').run(dueDate, existing.id);
-      broadcastRemindersChanged();
+      remindersChanged = true;
     }
 
     // OS notification: only when overdue, once per session.
@@ -104,6 +106,8 @@ export function checkOutreachReminders(): void {
     const notif = new Notification({ title: `Reach out to ${row.contact_name}`, body });
     notif.show();
   }
+
+  if (remindersChanged) broadcastRemindersChanged();
 }
 
 export function clearOutreachNotificationCache(): void {

--- a/src/main/sync/reminder-checker.ts
+++ b/src/main/sync/reminder-checker.ts
@@ -40,9 +40,8 @@ export function checkReminders(): void {
 
   for (const row of rows) {
     if (notifiedThisSession.has(row.id)) continue;
-    notifiedThisSession.add(row.id);
-
     if (!notificationsEnabled) continue;
+    notifiedThisSession.add(row.id);
 
     stamp.run(now, row.id);
 

--- a/src/renderer/src/hooks/useProjectContacts.ts
+++ b/src/renderer/src/hooks/useProjectContacts.ts
@@ -3,6 +3,7 @@ import type { ProjectContactRow, StatusOption, PriorityOption } from '@shared/ty
 import type { ProjectFilters as Filters } from '../views/ContactsTable';
 import { buildOrderMap } from '../views/ContactsTable';
 import type { SortState } from './useSortFilter';
+import { localDayBounds } from '../utils/fmtDate';
 
 type SortKey =
   | 'name'
@@ -72,11 +73,11 @@ export function useProjectContacts(
       );
     }
     if (filters.dateAddedFrom) {
-      const from = Math.floor(new Date(filters.dateAddedFrom).getTime() / 1000);
+      const { start: from } = localDayBounds(filters.dateAddedFrom);
       result = result.filter((r) => r.membership_created_at >= from);
     }
     if (filters.dateAddedTo) {
-      const to = Math.floor(new Date(filters.dateAddedTo).getTime() / 1000) + 86399;
+      const { end: to } = localDayBounds(filters.dateAddedTo);
       result = result.filter((r) => r.membership_created_at <= to);
     }
     if (filters.status.length > 0) {

--- a/src/renderer/src/utils/fmtDate.ts
+++ b/src/renderer/src/utils/fmtDate.ts
@@ -78,6 +78,17 @@ export function dateStrToUnix(dateStr: string): number {
 }
 
 /**
+ * Convert a YYYY-MM-DD date string to inclusive local-day Unix timestamp (seconds) bounds.
+ * Parses the parts directly rather than via `new Date(dateStr)`, which the JS spec
+ * parses as UTC midnight and would shift day boundaries by the local UTC offset.
+ */
+export function localDayBounds(dateStr: string): { start: number; end: number } {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const start = Math.floor(new Date(y, m - 1, d).getTime() / 1000);
+  return { start, end: start + 86399 };
+}
+
+/**
  * Format a Unix timestamp (seconds) as a full date always including the year.
  * Returns '—' when ts is null.
  *

--- a/src/renderer/src/views/AllContacts.tsx
+++ b/src/renderer/src/views/AllContacts.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ContactListItem, DuplicatePair, Project, User } from '@shared/types';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { useSortFilter } from '../hooks/useSortFilter';
+import { localDayBounds } from '../utils/fmtDate';
 import DedupModal from './DedupModal';
 import ContactDetail from '../contacts/ContactDetail';
 import Button from '../shell/Button';
@@ -139,12 +140,11 @@ export default function AllContacts({ projects, user, openContactId, onOpenConta
     }
 
     if (filters.dateAddedFrom) {
-      const from = Math.floor(new Date(filters.dateAddedFrom).getTime() / 1000);
+      const { start: from } = localDayBounds(filters.dateAddedFrom);
       result = result.filter((c) => c.created_at >= from);
     }
     if (filters.dateAddedTo) {
-      // include the full "to" day by adding 86399 seconds
-      const to = Math.floor(new Date(filters.dateAddedTo).getTime() / 1000) + 86399;
+      const { end: to } = localDayBounds(filters.dateAddedTo);
       result = result.filter((c) => c.created_at <= to);
     }
 

--- a/src/test/contacts.test.ts
+++ b/src/test/contacts.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { v4 as uuidv4 } from 'uuid';
+import fs from 'fs/promises';
+import path from 'path';
 import { createTestDb, insertContact, insertProject, TEST_REPORTER } from './vitest.setup';
 
 vi.mock('electron', () => ({
@@ -306,6 +308,27 @@ describe('contacts:delete', () => {
     expect(testDb.prepare('SELECT id FROM contact_phones WHERE contact_id = ?').all(id)).toHaveLength(0);
     expect(testDb.prepare('SELECT id FROM contact_handles WHERE contact_id = ?').all(id)).toHaveLength(0);
     expect(testDb.prepare('SELECT id FROM project_memberships WHERE contact_id = ?').all(id)).toHaveLength(0);
+  });
+
+  it('deletes the encrypted screenshot file on disk (#434)', async () => {
+    const id = insertContact(testDb, 'Screenshot Owner');
+    const screenshotsDir = path.join('/tmp', 'screenshots');
+    await fs.mkdir(screenshotsDir, { recursive: true });
+    const fileName = `${uuidv4()}.enc`;
+    const filePath = path.join(screenshotsDir, fileName);
+    await fs.writeFile(filePath, 'fake-encrypted-bytes');
+    testDb.prepare(
+      'INSERT INTO contact_screenshots (id, contact_id, tab_url, file_path, iv, captured_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run(uuidv4(), id, 'https://example.com', fileName, 'abcd', Math.floor(Date.now() / 1000));
+
+    await handlers.get('contacts:delete')!({}, id);
+
+    await expect(fs.access(filePath)).rejects.toThrow();
+  });
+
+  it('does not throw when the deleted contact has no screenshots', async () => {
+    const id = insertContact(testDb, 'No Screenshots');
+    await expect(handlers.get('contacts:delete')!({}, id)).resolves.toBeUndefined();
   });
 });
 

--- a/src/test/fmtDate.test.ts
+++ b/src/test/fmtDate.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { localDayBounds } from '../renderer/src/utils/fmtDate';
+
+// ---------------------------------------------------------------------------
+// localDayBounds (#439)
+// ---------------------------------------------------------------------------
+
+describe('localDayBounds', () => {
+  it('returns start/end timestamps that fall on the requested local calendar day', () => {
+    const { start, end } = localDayBounds('2026-07-01');
+
+    const startDate = new Date(start * 1000);
+    const endDate = new Date(end * 1000);
+    expect(startDate.getFullYear()).toBe(2026);
+    expect(startDate.getMonth()).toBe(6); // 0-indexed: July
+    expect(startDate.getDate()).toBe(1);
+    expect(startDate.getHours()).toBe(0);
+    expect(startDate.getMinutes()).toBe(0);
+    expect(startDate.getSeconds()).toBe(0);
+
+    expect(endDate.getDate()).toBe(1);
+    expect(end - start).toBe(86399);
+  });
+
+  it('does not shift to UTC midnight the way `new Date(dateStr)` would', () => {
+    // `new Date('2026-07-01')` parses as UTC midnight; converting straight to a
+    // Unix timestamp would land on June 30 local time in any timezone west of UTC.
+    // localDayBounds must always resolve to local midnight of the requested day.
+    const { start } = localDayBounds('2026-07-01');
+    const localMidnight = new Date(2026, 6, 1).getTime() / 1000;
+    expect(start).toBe(localMidnight);
+  });
+});

--- a/src/test/outreach-checker.test.ts
+++ b/src/test/outreach-checker.test.ts
@@ -177,6 +177,21 @@ describe('checkOutreachReminders — first run', () => {
     expect(broadcast).toHaveBeenCalledOnce();
   });
 
+  it('calls broadcastRemindersChanged once even when multiple memberships get new reminders in one run (#438)', () => {
+    insertUser();
+    const { projId, contactId: contactA } = insertProjectAndContact();
+    const contactB = insertContact(testDb, 'Second Contact');
+    const now = Math.floor(Date.now() / 1000);
+    const membA = insertMembership(contactA, projId, 14);
+    const membB = insertMembership(contactB, projId, 14);
+    insertInteractionLog(membA, now - 3 * 86400);
+    insertInteractionLog(membB, now - 3 * 86400);
+
+    checkOutreachReminders();
+
+    expect(broadcast).toHaveBeenCalledOnce();
+  });
+
   it('due_date equals last_contacted + interval_days * 86400 (adjusted for weekends)', () => {
     insertUser();
     const { projId, contactId } = insertProjectAndContact();

--- a/src/test/reminder-checker.test.ts
+++ b/src/test/reminder-checker.test.ts
@@ -102,6 +102,20 @@ describe('checkReminders', () => {
     expect(row.last_notified_at).toBeNull();
   });
 
+  it('surfaces a reminder once notifications are re-enabled, even if it came due while disabled (#438)', () => {
+    insertUser({ reminder_notifications_enabled: 0 });
+    const cid = insertContact(testDb, 'Mona Lisa');
+    const pid = insertProject(testDb, 'Mu');
+    insertReminder(cid, pid);
+
+    checkReminders(); // due while disabled — must not be marked as handled
+
+    insertUser({ reminder_notifications_enabled: 1 });
+    checkReminders();
+
+    expect(MockNotification).toHaveBeenCalledOnce();
+  });
+
   it('does not fire for a completed reminder', () => {
     insertUser();
     const cid = insertContact(testDb, 'Carol White');


### PR DESCRIPTION
## Summary
Three small, independent bug fixes from the pre-1.0 audit, grouped into one PR since each is a quick, well-scoped change.

- **#434 — Deleting a contact orphans its encrypted screenshot files on disk.** `contacts:delete` now selects the contact's `contact_screenshots.file_path` values before the delete transaction and unlinks them afterwards, mirroring the pattern already used by the single-screenshot `screenshots:delete` handler (exported `safeScreenshotPath` from `screenshots.ts` so both handlers share the same path-traversal-safe resolution).
- **#439 — Date-added filters parse dates as UTC midnight but compare against local timestamps.** `new Date('YYYY-MM-DD')` is parsed as UTC midnight per spec, which shifted the From/To day boundaries by the local UTC offset in `AllContacts.tsx` and `useProjectContacts.ts`. Added a shared `localDayBounds()` helper in `utils/fmtDate.ts` that parses the date parts directly into local-midnight bounds, and pointed both filter call sites at it.
- **#438 — Notification checkers: reminders due while notifications are disabled never fire; outreach checker broadcasts per row.**
  - `checkReminders` no longer adds a due reminder to the session's "already notified" cache when notifications are disabled — previously a reminder due while notifications were off would be silently marked as handled and wouldn't resurface even after re-enabling notifications.
  - `checkOutreachReminders` now calls `broadcastRemindersChanged()` once per run (after the loop) instead of once per created/updated reminder, avoiding redundant IPC spam when many memberships come due at once.

Closes #434
Closes #438
Closes #439

## Test plan
- [x] `npm run rebuild:node && npm test` — full suite passes (508 tests)
- [x] Added `contacts:delete` tests: unlinks the screenshot file on disk; no-op (doesn't throw) when the contact has no screenshots
- [x] Added `localDayBounds` tests in `src/test/fmtDate.test.ts`: resolves to local midnight of the requested day rather than shifting via UTC parsing
- [x] Added a `checkReminders` regression test: a reminder due while notifications are disabled still fires once notifications are re-enabled
- [x] Added a `checkOutreachReminders` regression test: a single run with multiple memberships getting new reminders calls `broadcastRemindersChanged` exactly once
- [x] `npx tsc --noEmit` clean on both `tsconfig.node.json` and `tsconfig.web.json`
- [x] `npx eslint` clean on all changed files
- [x] `npm run rebuild` — restored Electron-targeted native binaries after testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)