### PR TITLE
Fix SQLite variable limit in exports; extract shared-project creation flow

### DIFF
--- a/src/main/ipc/export.ts
+++ b/src/main/ipc/export.ts
@@ -63,6 +63,83 @@ interface AllContactsRow {
   'Interaction log': string;
 }
 
+// SQLite's SQLITE_LIMIT_VARIABLE_NUMBER defaults to 999. Chunk IN-clause lookups
+// to stay safely below that limit; concatenates results across chunks.
+const SQLITE_IN_CHUNK_SIZE = 500;
+
+function chunkedIn<T>(ids: string[], runQuery: (chunk: string[]) => T[]): T[] {
+  const results: T[] = [];
+  for (let i = 0; i < ids.length; i += SQLITE_IN_CHUNK_SIZE) {
+    results.push(...runQuery(ids.slice(i, i + SQLITE_IN_CHUNK_SIZE)));
+  }
+  return results;
+}
+
+function groupByContactId<Row extends { contact_id: string }, V>(rows: Row[], pick: (r: Row) => V): Map<string, V[]> {
+  const map = new Map<string, V[]>();
+  for (const r of rows) {
+    const arr = map.get(r.contact_id) ?? [];
+    arr.push(pick(r));
+    map.set(r.contact_id, arr);
+  }
+  return map;
+}
+
+interface ContactSubTables {
+  emails: Map<string, string[]>;
+  phones: Map<string, string[]>;
+  links: Map<string, { type: string; url: string }[]>;
+  handles: Map<string, { type: string; handle: string }[]>;
+}
+
+function fetchContactSubTables(db: import('better-sqlite3-multiple-ciphers').Database, contactIds: string[]): ContactSubTables {
+  const ph = (chunk: string[]) => chunk.map(() => '?').join(',');
+
+  const emailRows = chunkedIn(contactIds, (chunk) =>
+    db.prepare(`SELECT contact_id, email FROM contact_emails WHERE contact_id IN (${ph(chunk)}) ORDER BY sort_order`).all(...chunk) as { contact_id: string; email: string }[],
+  );
+  const phoneRows = chunkedIn(contactIds, (chunk) =>
+    db.prepare(`SELECT contact_id, phone FROM contact_phones WHERE contact_id IN (${ph(chunk)}) ORDER BY sort_order`).all(...chunk) as { contact_id: string; phone: string }[],
+  );
+  const linkRows = chunkedIn(contactIds, (chunk) =>
+    db.prepare(`SELECT contact_id, type, url FROM contact_links WHERE contact_id IN (${ph(chunk)}) ORDER BY sort_order`).all(...chunk) as { contact_id: string; type: string; url: string }[],
+  );
+  const handleRows = chunkedIn(contactIds, (chunk) =>
+    db.prepare(`SELECT contact_id, type, handle FROM contact_handles WHERE contact_id IN (${ph(chunk)}) ORDER BY sort_order`).all(...chunk) as { contact_id: string; type: string; handle: string }[],
+  );
+
+  return {
+    emails: groupByContactId(emailRows, (r) => r.email),
+    phones: groupByContactId(phoneRows, (r) => r.phone),
+    links: groupByContactId(linkRows, (r) => ({ type: r.type, url: r.url })),
+    handles: groupByContactId(handleRows, (r) => ({ type: r.type, handle: r.handle })),
+  };
+}
+
+// Writes rows to a temp file next to the target path, then atomically renames it
+// into place. Shared by every "export contacts to a spreadsheet" handler.
+async function writeExportRows<T extends object>(rows: T[], filePath: string, isXlsx: boolean): Promise<{ success: boolean; error?: string }> {
+  const tmpPath = path.join(path.dirname(filePath), `.tmp-export-${randomUUID()}`);
+  try {
+    const wb = new ExcelJS.Workbook();
+    const ws = wb.addWorksheet('Contacts');
+    if (rows.length > 0) {
+      ws.columns = (Object.keys(rows[0]) as (keyof T)[]).map((k) => ({ header: String(k), key: String(k) }));
+    }
+    ws.addRows(rows);
+    if (isXlsx) {
+      await wb.xlsx.writeFile(tmpPath);
+    } else {
+      await wb.csv.writeFile(tmpPath);
+    }
+    await atomicRename(tmpPath, filePath);
+    return { success: true };
+  } catch (err) {
+    await unlink(tmpPath).catch(() => {});
+    return { success: false, error: String(err) };
+  }
+}
+
 function fetchProjectsByInteraction(
   db: import('better-sqlite3-multiple-ciphers').Database,
   interactionIds: string[],
@@ -128,10 +205,10 @@ export function registerExportHandlers(): void {
       const filePath = saveResult.filePath;
       const isXlsx = filePath.endsWith('.xlsx');
 
-      const selectionClause = filterIds?.length
-        ? `AND c.id IN (${filterIds.map(() => '?').join(',')})`
-        : '';
-      const memberships = db
+      // filterIds can be arbitrarily large (e.g. "export all selected" over a big
+      // table), so it isn't safe to fold into a SQL IN clause — filter in JS instead.
+      const filterSet = filterIds?.length ? new Set(filterIds) : null;
+      let memberships = db
         .prepare(
           `SELECT pm.id AS membership_id, pm.reporter_name, pm.theme, pm.priority, pm.status,
                   (SELECT MIN(ile.created_at) FROM interaction_log_entries ile
@@ -140,10 +217,10 @@ export function registerExportHandlers(): void {
                   c.id AS contact_id, c.name, c.organization, c.title, c.dob, c.notes
            FROM project_memberships pm
            JOIN contacts c ON c.id = pm.contact_id
-           WHERE pm.project_id = ? ${selectionClause}
+           WHERE pm.project_id = ?
            ORDER BY c.name COLLATE NOCASE ASC`,
         )
-        .all(projectId, ...(filterIds ?? [])) as {
+        .all(projectId) as {
         membership_id: string;
         reporter_name: string;
         theme: string | null;
@@ -157,33 +234,11 @@ export function registerExportHandlers(): void {
         dob: string | null;
         notes: string | null;
       }[];
+      if (filterSet) memberships = memberships.filter((m) => filterSet.has(m.contact_id));
 
       const contactIds = memberships.map((m) => m.contact_id);
       const ph = (arr: unknown[]) => arr.map(() => '?').join(',');
-
-      const bulkEmails = contactIds.length
-        ? (db.prepare(`SELECT contact_id, email FROM contact_emails WHERE contact_id IN (${ph(contactIds)}) ORDER BY sort_order`).all(...contactIds) as { contact_id: string; email: string }[])
-        : [];
-      const emailsByContact = new Map<string, string[]>();
-      for (const r of bulkEmails) { const a = emailsByContact.get(r.contact_id) ?? []; a.push(r.email); emailsByContact.set(r.contact_id, a); }
-
-      const bulkPhones = contactIds.length
-        ? (db.prepare(`SELECT contact_id, phone FROM contact_phones WHERE contact_id IN (${ph(contactIds)}) ORDER BY sort_order`).all(...contactIds) as { contact_id: string; phone: string }[])
-        : [];
-      const phonesByContact = new Map<string, string[]>();
-      for (const r of bulkPhones) { const a = phonesByContact.get(r.contact_id) ?? []; a.push(r.phone); phonesByContact.set(r.contact_id, a); }
-
-      const bulkLinks = contactIds.length
-        ? (db.prepare(`SELECT contact_id, type, url FROM contact_links WHERE contact_id IN (${ph(contactIds)}) ORDER BY sort_order`).all(...contactIds) as { contact_id: string; type: string; url: string }[])
-        : [];
-      const linksByContact = new Map<string, { type: string; url: string }[]>();
-      for (const r of bulkLinks) { const a = linksByContact.get(r.contact_id) ?? []; a.push({ type: r.type, url: r.url }); linksByContact.set(r.contact_id, a); }
-
-      const bulkHandles = contactIds.length
-        ? (db.prepare(`SELECT contact_id, type, handle FROM contact_handles WHERE contact_id IN (${ph(contactIds)}) ORDER BY sort_order`).all(...contactIds) as { contact_id: string; type: string; handle: string }[])
-        : [];
-      const handlesByContact = new Map<string, { type: string; handle: string }[]>();
-      for (const r of bulkHandles) { const a = handlesByContact.get(r.contact_id) ?? []; a.push({ type: r.type, handle: r.handle }); handlesByContact.set(r.contact_id, a); }
+      const { emails: emailsByContact, phones: phonesByContact, links: linksByContact, handles: handlesByContact } = fetchContactSubTables(db, contactIds);
 
       type LogRow = { id: string; membership_id: string; reporter_name: string; body: string; created_at: number };
       const rows: ExportRow[] = [];
@@ -254,25 +309,7 @@ export function registerExportHandlers(): void {
         }
       }
 
-      const tmpPath = path.join(path.dirname(filePath), `.tmp-export-${randomUUID()}`);
-      try {
-        const wb = new ExcelJS.Workbook();
-        const ws = wb.addWorksheet('Contacts');
-        if (rows.length > 0) {
-          ws.columns = (Object.keys(rows[0]) as (keyof ExportRow)[]).map((k) => ({ header: k, key: k }));
-        }
-        ws.addRows(rows);
-        if (isXlsx) {
-          await wb.xlsx.writeFile(tmpPath);
-        } else {
-          await wb.csv.writeFile(tmpPath);
-        }
-        await atomicRename(tmpPath, filePath);
-        return { success: true };
-      } catch (err) {
-        await unlink(tmpPath).catch(() => {});
-        return { success: false, error: String(err) };
-      }
+      return writeExportRows(rows, filePath, isXlsx);
     },
   );
 
@@ -295,39 +332,17 @@ export function registerExportHandlers(): void {
       const filePath = saveResult.filePath;
       const isXlsx = filePath.endsWith('.xlsx');
 
-      const selectionClause2 = filterIds?.length
-        ? `WHERE id IN (${filterIds.map(() => '?').join(',')})`
-        : '';
-      const contacts = db
-        .prepare(`SELECT id, name, organization, title, dob, notes FROM contacts ${selectionClause2} ORDER BY name COLLATE NOCASE`)
-        .all(...(filterIds ?? [])) as { id: string; name: string; organization: string | null; title: string | null; dob: string | null; notes: string | null }[];
+      // filterIds can be arbitrarily large (e.g. "export all selected" over a big
+      // table), so it isn't safe to fold into a SQL IN clause — filter in JS instead.
+      const filterSet2 = filterIds?.length ? new Set(filterIds) : null;
+      let contacts = db
+        .prepare('SELECT id, name, organization, title, dob, notes FROM contacts ORDER BY name COLLATE NOCASE')
+        .all() as { id: string; name: string; organization: string | null; title: string | null; dob: string | null; notes: string | null }[];
+      if (filterSet2) contacts = contacts.filter((c) => filterSet2.has(c.id));
 
       const allContactIds = contacts.map((c) => c.id);
       const ph2 = (arr: unknown[]) => arr.map(() => '?').join(',');
-
-      const allEmails2 = allContactIds.length
-        ? (db.prepare(`SELECT contact_id, email FROM contact_emails WHERE contact_id IN (${ph2(allContactIds)}) ORDER BY sort_order`).all(...allContactIds) as { contact_id: string; email: string }[])
-        : [];
-      const emailsById = new Map<string, string[]>();
-      for (const r of allEmails2) { const a = emailsById.get(r.contact_id) ?? []; a.push(r.email); emailsById.set(r.contact_id, a); }
-
-      const allPhones2 = allContactIds.length
-        ? (db.prepare(`SELECT contact_id, phone FROM contact_phones WHERE contact_id IN (${ph2(allContactIds)}) ORDER BY sort_order`).all(...allContactIds) as { contact_id: string; phone: string }[])
-        : [];
-      const phonesById = new Map<string, string[]>();
-      for (const r of allPhones2) { const a = phonesById.get(r.contact_id) ?? []; a.push(r.phone); phonesById.set(r.contact_id, a); }
-
-      const allLinks2 = allContactIds.length
-        ? (db.prepare(`SELECT contact_id, type, url FROM contact_links WHERE contact_id IN (${ph2(allContactIds)}) ORDER BY sort_order`).all(...allContactIds) as { contact_id: string; type: string; url: string }[])
-        : [];
-      const linksById = new Map<string, { type: string; url: string }[]>();
-      for (const r of allLinks2) { const a = linksById.get(r.contact_id) ?? []; a.push({ type: r.type, url: r.url }); linksById.set(r.contact_id, a); }
-
-      const allHandles2 = allContactIds.length
-        ? (db.prepare(`SELECT contact_id, type, handle FROM contact_handles WHERE contact_id IN (${ph2(allContactIds)}) ORDER BY sort_order`).all(...allContactIds) as { contact_id: string; type: string; handle: string }[])
-        : [];
-      const handlesById = new Map<string, { type: string; handle: string }[]>();
-      for (const r of allHandles2) { const a = handlesById.get(r.contact_id) ?? []; a.push({ type: r.type, handle: r.handle }); handlesById.set(r.contact_id, a); }
+      const { emails: emailsById, phones: phonesById, links: linksById, handles: handlesById } = fetchContactSubTables(db, allContactIds);
 
       type LogRow2 = { id: string; contact_id: string; reporter_name: string; body: string; created_at: number };
       const rows: AllContactsRow[] = [];
@@ -385,25 +400,7 @@ export function registerExportHandlers(): void {
         }
       }
 
-      const tmpPath2 = path.join(path.dirname(filePath), `.tmp-export-${randomUUID()}`);
-      try {
-        const wb = new ExcelJS.Workbook();
-        const ws = wb.addWorksheet('Contacts');
-        if (rows.length > 0) {
-          ws.columns = (Object.keys(rows[0]) as (keyof AllContactsRow)[]).map((k) => ({ header: k, key: k }));
-        }
-        ws.addRows(rows);
-        if (isXlsx) {
-          await wb.xlsx.writeFile(tmpPath2);
-        } else {
-          await wb.csv.writeFile(tmpPath2);
-        }
-        await atomicRename(tmpPath2, filePath);
-        return { success: true };
-      } catch (err) {
-        await unlink(tmpPath2).catch(() => {});
-        return { success: false, error: String(err) };
-      }
+      return writeExportRows(rows, filePath, isXlsx);
     },
   );
 
@@ -450,12 +447,12 @@ export function registerExportHandlers(): void {
   ipcMain.handle('export:vcard-all-contacts', async (event, { contactIds: filterIds }: { contactIds?: string[] } = {}): Promise<void> => {
     const win = BrowserWindow.fromWebContents(event.sender);
     const db = getDatabase();
-    const selectionClause = filterIds?.length
-      ? `WHERE id IN (${filterIds.map(() => '?').join(',')})`
-      : '';
-    const contactIds = (
-      db.prepare(`SELECT id FROM contacts ${selectionClause} ORDER BY name COLLATE NOCASE`).all(...(filterIds ?? [])) as { id: string }[]
+    // filterIds can be arbitrarily large, so it isn't safe to fold into a SQL IN clause.
+    const filterSet = filterIds?.length ? new Set(filterIds) : null;
+    let contactIds = (
+      db.prepare('SELECT id FROM contacts ORDER BY name COLLATE NOCASE').all() as { id: string }[]
     ).map((r) => r.id);
+    if (filterSet) contactIds = contactIds.filter((id) => filterSet.has(id));
 
     const cards = contactIds.map((id) => buildVCard(db, id)).filter(Boolean).join('\r\n');
     if (!cards) return;

--- a/src/main/ipc/projects.ts
+++ b/src/main/ipc/projects.ts
@@ -9,6 +9,42 @@ import { syncProject } from '../sync/engine';
 import { broadcastRemindersChanged } from './reminders';
 import type { Project, User, TimelineEntry, TimelineEntryProject, JoinSharedProjectResult } from '@shared/types';
 
+// True cross-DB atomicity is not possible with two separate SQLite files.
+// Writes to the shared DB first (harder to undo), then runs `writeLocal` for the
+// local-DB half of the flow. If either step fails, evicts the shared DB connection
+// and removes the on-disk file so no handle or orphaned file is left behind, then
+// re-throws (fixes #176; the compensating cleanup on `writeLocal` failure was
+// previously missing from projects:regenerateShared — fixes #442).
+function createSharedProjectFile(
+  filePath: string,
+  keyHex: string,
+  projectId: string,
+  name: string,
+  description: string | null,
+  writeLocal: () => void,
+): ReturnType<typeof createSharedDb> {
+  let sharedDb: ReturnType<typeof createSharedDb>;
+  try {
+    sharedDb = createSharedDb(filePath, keyHex, projectId);
+    sharedDb.prepare('INSERT INTO project_meta (name, description) VALUES (?, ?)').run(name, description);
+  } catch (sharedErr) {
+    try { closeSharedDb(projectId); } catch { /* ignore */ }
+    try { unlinkSync(filePath); } catch { /* ignore */ }
+    throw sharedErr;
+  }
+
+  try {
+    writeLocal();
+  } catch (localErr) {
+    try { sharedDb.prepare('DELETE FROM project_meta').run(); } catch { /* ignore */ }
+    try { closeSharedDb(projectId); } catch { /* ignore */ }
+    try { unlinkSync(filePath); } catch { /* ignore */ }
+    throw localErr;
+  }
+
+  return sharedDb;
+}
+
 export function registerProjectHandlers(): void {
   ipcMain.handle('projects:list', (): Project[] => {
     return getDatabase()
@@ -56,28 +92,9 @@ export function registerProjectHandlers(): void {
       const trimmedName = name.trim();
       const trimmedDesc = description?.trim() || null;
 
-      // True cross-DB atomicity is not possible with two separate SQLite files.
-      // To minimise inconsistency we write to the shared DB first (harder to undo)
-      // and to the local DB second.  If the local write fails we attempt a
-      // compensating delete on the shared DB and re-throw (fixes #176).
-
-      // 2. Create the shared DB file and write project metadata.
-      // Guard shared-DB creation separately so a failure here also cleans up.
-      let sharedDb: ReturnType<typeof createSharedDb>;
-      try {
-        sharedDb = createSharedDb(filePath, keyHex, id);
-        sharedDb.prepare('INSERT INTO project_meta (name, description) VALUES (?, ?)').run(
-          trimmedName,
-          trimmedDesc,
-        );
-      } catch (sharedErr) {
-        try { closeSharedDb(id); } catch { /* ignore */ }
-        try { unlinkSync(filePath); } catch { /* ignore */ }
-        throw sharedErr;
-      }
-
-      // 3. Create the local project record + reporter row in a single transaction.
-      try {
+      // 2 & 3. Create the shared DB file + project metadata, then the local
+      // project record + reporter row, with compensating cleanup on either failure.
+      createSharedProjectFile(filePath, keyHex, id, trimmedName, trimmedDesc, () => {
         db.transaction(() => {
           db.prepare(
             `INSERT INTO projects (id, name, description, is_shared, shared_db_path, shared_db_key, created_at)
@@ -94,15 +111,7 @@ export function registerProjectHandlers(): void {
             user.email,
           );
         })();
-      } catch (localErr) {
-        // Best-effort compensating action: evict the shared DB connection and
-        // remove both the in-file record and the on-disk file so no handle or
-        // orphaned file is left behind.
-        try { sharedDb.prepare('DELETE FROM project_meta').run(); } catch { /* ignore */ }
-        try { closeSharedDb(id); } catch { /* ignore */ }
-        try { unlinkSync(filePath); } catch { /* ignore */ }
-        throw localErr;
-      }
+      });
 
       const project = db.prepare('SELECT * FROM projects WHERE id = ?').get(id) as Project;
       const payload = encodePayload(trimmedName, trimmedDesc, filePath, keyBytes);
@@ -239,27 +248,9 @@ export function registerProjectHandlers(): void {
       const keyHex = keyBytes.toString('hex');
       const user = db.prepare('SELECT * FROM users WHERE id = 1').get() as User;
 
-      // True cross-DB atomicity is not possible with two separate SQLite files.
-      // Write to the shared DB first (harder to undo), then update the local DB.
-      // If the local write fails, attempt a compensating delete on the shared DB
-      // and re-throw (fixes #176).
-
-      // Create shared DB and write project metadata.
-      // Guard shared-DB creation separately so a failure here also cleans up.
-      let sharedDb: ReturnType<typeof createSharedDb>;
-      try {
-        sharedDb = createSharedDb(filePath, keyHex, projectId);
-        sharedDb.prepare('INSERT INTO project_meta (name, description) VALUES (?, ?)').run(
-          project.name,
-          project.description,
-        );
-      } catch (sharedErr) {
-        try { closeSharedDb(projectId); } catch { /* ignore */ }
-        try { unlinkSync(filePath); } catch { /* ignore */ }
-        throw sharedErr;
-      }
-
-      try {
+      // Create shared DB + project metadata, then upgrade the local project record,
+      // with compensating cleanup on either failure.
+      const sharedDb = createSharedProjectFile(filePath, keyHex, projectId, project.name, project.description, () => {
         db.transaction(() => {
           // Add self as a reporter (local projects don't have this row yet)
           db.prepare(
@@ -280,15 +271,7 @@ export function registerProjectHandlers(): void {
           // treated as unsynced and get pushed to the new shared file on the first sync.
           db.prepare('DELETE FROM sync_pushed WHERE project_id = ?').run(projectId);
         })();
-      } catch (localErr) {
-        // Best-effort compensating action: evict the shared DB connection and
-        // remove both the in-file record and the on-disk file so no handle or
-        // orphaned file is left behind.
-        try { sharedDb.prepare('DELETE FROM project_meta').run(); } catch { /* ignore */ }
-        try { closeSharedDb(projectId); } catch { /* ignore */ }
-        try { unlinkSync(filePath); } catch { /* ignore */ }
-        throw localErr;
-      }
+      });
 
       // Push all existing local data to the shared file
       try {
@@ -331,21 +314,17 @@ export function registerProjectHandlers(): void {
       // Close old shared connection
       closeSharedDb(projectId);
 
-      // Create new shared DB and write project metadata
-      const sharedDb = createSharedDb(filePath, keyHex, projectId);
-      sharedDb.prepare('INSERT INTO project_meta (name, description) VALUES (?, ?)').run(
-        project.name,
-        project.description,
-      );
-
-      // Update local project record and reset push state atomically — the fresh
-      // shared file starts empty, so every row must be treated as unsynced.
-      db.transaction(() => {
-        db.prepare(
-          'UPDATE projects SET shared_db_path = ?, shared_db_key = ? WHERE id = ?',
-        ).run(filePath, keyBytes, projectId);
-        db.prepare('DELETE FROM sync_pushed WHERE project_id = ?').run(projectId);
-      })();
+      // Create the new shared DB + project metadata, then update the local project
+      // record and reset push state atomically — the fresh shared file starts empty,
+      // so every row must be treated as unsynced. Compensating cleanup on either failure.
+      const sharedDb = createSharedProjectFile(filePath, keyHex, projectId, project.name, project.description, () => {
+        db.transaction(() => {
+          db.prepare(
+            'UPDATE projects SET shared_db_path = ?, shared_db_key = ? WHERE id = ?',
+          ).run(filePath, keyBytes, projectId);
+          db.prepare('DELETE FROM sync_pushed WHERE project_id = ?').run(projectId);
+        })();
+      });
 
       // Push all local project data to the fresh shared file
       try {

--- a/src/test/export.test.ts
+++ b/src/test/export.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { v4 as uuidv4 } from 'uuid';
+import { createTestDb, insertContact, insertProject, TEST_REPORTER } from './vitest.setup';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn(), on: vi.fn() },
+  BrowserWindow: { fromWebContents: vi.fn(() => null), getFocusedWindow: vi.fn(() => ({})) },
+  dialog: { showSaveDialog: vi.fn() },
+}));
+
+let testDb: ReturnType<typeof createTestDb>;
+vi.mock('../main/database', () => ({ getDatabase: () => testDb }));
+
+import { ipcMain, dialog } from 'electron';
+import { registerExportHandlers } from '../main/ipc/export';
+
+const handlers = new Map<string, (...args: unknown[]) => unknown>();
+
+let dir: string;
+
+function addMembership(contactId: string, projectId: string): void {
+  const now = Math.floor(Date.now() / 1000);
+  testDb.prepare(
+    'INSERT INTO project_memberships (id, contact_id, project_id, reporter_email, reporter_name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+  ).run(uuidv4(), contactId, projectId, TEST_REPORTER.email, TEST_REPORTER.name, now, now);
+}
+
+beforeEach(() => {
+  testDb = createTestDb();
+  handlers.clear();
+  vi.mocked(ipcMain.handle).mockImplementation((channel: string, fn) => {
+    handlers.set(channel, fn as (...args: unknown[]) => unknown);
+    return ipcMain;
+  });
+  registerExportHandlers();
+  dir = mkdtempSync(join(tmpdir(), 'sourcerer-export-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// SQLite variable limit (#433)
+// ---------------------------------------------------------------------------
+
+describe('export:all-contacts — SQLite variable limit (#433)', () => {
+  it('exports more than 999 contacts without hitting "too many SQL variables"', async () => {
+    const CONTACT_COUNT = 1200;
+    for (let i = 0; i < CONTACT_COUNT; i++) {
+      insertContact(testDb, `Contact ${i}`, { emails: [`c${i}@example.com`] });
+    }
+    const filePath = join(dir, 'export.csv');
+    vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath } as unknown as Awaited<ReturnType<typeof dialog.showSaveDialog>>);
+
+    const result = await handlers.get('export:all-contacts')!({ sender: {} }, {}) as { success: boolean; error?: string };
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+    const lines = readFileSync(filePath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(CONTACT_COUNT + 1); // header + one row per contact
+  });
+
+  it('exports a filtered selection of more than 999 contact IDs without hitting the variable limit', async () => {
+    const selectedIds: string[] = [];
+    for (let i = 0; i < 1100; i++) {
+      selectedIds.push(insertContact(testDb, `Selected ${i}`));
+    }
+    insertContact(testDb, 'Excluded Contact');
+
+    const filePath = join(dir, 'selected.csv');
+    vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath } as unknown as Awaited<ReturnType<typeof dialog.showSaveDialog>>);
+
+    const result = await handlers.get('export:all-contacts')!({ sender: {} }, { contactIds: selectedIds }) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content.trim().split('\n')).toHaveLength(1101); // header + 1100 selected
+    expect(content).not.toContain('Excluded Contact');
+  });
+});
+
+describe('export:project — SQLite variable limit (#433)', () => {
+  it('exports a project with more than 999 members without hitting the variable limit', async () => {
+    const projId = insertProject(testDb, 'Big Project');
+    const MEMBER_COUNT = 1200;
+    for (let i = 0; i < MEMBER_COUNT; i++) {
+      const contactId = insertContact(testDb, `Member ${i}`, { emails: [`m${i}@example.com`] });
+      addMembership(contactId, projId);
+    }
+    const filePath = join(dir, 'project.csv');
+    vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath } as unknown as Awaited<ReturnType<typeof dialog.showSaveDialog>>);
+
+    const result = await handlers.get('export:project')!({ sender: {} }, { projectId: projId, mode: 'sanitized' }) as { success: boolean; error?: string };
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+    const lines = readFileSync(filePath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(MEMBER_COUNT + 1);
+  });
+
+  it('exports a filtered selection of more than 999 members without hitting the variable limit', async () => {
+    const projId = insertProject(testDb, 'Big Project 2');
+    const selectedIds: string[] = [];
+    for (let i = 0; i < 1050; i++) {
+      const contactId = insertContact(testDb, `Selected Member ${i}`);
+      addMembership(contactId, projId);
+      selectedIds.push(contactId);
+    }
+    const excludedId = insertContact(testDb, 'Excluded Member');
+    addMembership(excludedId, projId);
+
+    const filePath = join(dir, 'project-selected.csv');
+    vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath } as unknown as Awaited<ReturnType<typeof dialog.showSaveDialog>>);
+
+    const result = await handlers.get('export:project')!(
+      { sender: {} },
+      { projectId: projId, mode: 'sanitized', contactIds: selectedIds },
+    ) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content.trim().split('\n')).toHaveLength(1051);
+    expect(content).not.toContain('Excluded Member');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sub-table data fidelity, after the fetchContactSubTables extraction (#442)
+// ---------------------------------------------------------------------------
+
+describe('export:all-contacts — sub-table data (#442 refactor)', () => {
+  it('includes emails, phones, links, and handles for each contact', async () => {
+    insertContact(testDb, 'Alice Smith', {
+      emails: ['alice@example.com'],
+      phones: ['+12025550100'],
+      handles: [{ type: 'signal', handle: '@alice' }],
+    });
+    const filePath = join(dir, 'fidelity.csv');
+    vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath } as unknown as Awaited<ReturnType<typeof dialog.showSaveDialog>>);
+
+    const result = await handlers.get('export:all-contacts')!({ sender: {} }, {}) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content).toContain('alice@example.com');
+    expect(content).toContain('+12025550100');
+    expect(content).toContain('signal: @alice');
+  });
+});

--- a/src/test/projects.test.ts
+++ b/src/test/projects.test.ts
@@ -4,9 +4,14 @@ import { createTestDb, insertContact, insertProject, TEST_REPORTER } from './vit
 
 vi.mock('electron', () => ({
   ipcMain: { handle: vi.fn(), on: vi.fn() },
-  BrowserWindow: { getAllWindows: vi.fn(() => []) },
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => []),
+    fromWebContents: vi.fn(() => null),
+    getFocusedWindow: vi.fn(() => ({})),
+  },
   dialog: { showSaveDialog: vi.fn() },
 }));
+vi.mock('fs', () => ({ unlinkSync: vi.fn() }));
 
 let testDb: ReturnType<typeof createTestDb>;
 vi.mock('../main/database', () => ({ getDatabase: () => testDb }));
@@ -23,12 +28,15 @@ vi.mock('../main/sync/payload', () => ({
 }));
 vi.mock('../main/ipc/reminders', () => ({ broadcastRemindersChanged: vi.fn() }));
 
-import { ipcMain } from 'electron';
+import { ipcMain, dialog } from 'electron';
+import { unlinkSync } from 'fs';
+import { createSharedDb, closeSharedDb } from '../main/database/shared-db';
 import { registerProjectHandlers } from '../main/ipc/projects';
 
 const handlers = new Map<string, (...args: unknown[]) => unknown>();
 
 beforeEach(() => {
+  vi.clearAllMocks();
   testDb = createTestDb();
   handlers.clear();
   vi.mocked(ipcMain.handle).mockImplementation((channel: string, fn) => {
@@ -57,6 +65,107 @@ describe('projects:create', () => {
   it('stores null description when description is empty', async () => {
     const result = await handlers.get('projects:create')!({}, { name: 'No Desc', description: '' }) as { description: string | null };
     expect(result.description).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// projects:createShared / convertToShared / regenerateShared (#442)
+// ---------------------------------------------------------------------------
+
+function mockFakeSharedDb(): void {
+  const fakeSharedDb = { prepare: vi.fn(() => ({ run: vi.fn() })) };
+  vi.mocked(createSharedDb).mockReturnValue(fakeSharedDb as unknown as ReturnType<typeof createSharedDb>);
+}
+
+function mockSaveDialog(filePath: string): void {
+  vi.mocked(dialog.showSaveDialog).mockResolvedValue(
+    { canceled: false, filePath } as unknown as Awaited<ReturnType<typeof dialog.showSaveDialog>>,
+  );
+}
+
+describe('projects:createShared', () => {
+  it('creates a shared project and returns a payload', async () => {
+    mockFakeSharedDb();
+    mockSaveDialog('/tmp/new.sourcerer');
+
+    const result = await handlers.get('projects:createShared')!({}, { name: 'New Shared', description: 'desc' }) as
+      | { project: { id: string; is_shared: number }; payload: string }
+      | null;
+
+    expect(result?.project.is_shared).toBe(1);
+    expect(result?.payload).toBe('encoded-payload');
+  });
+
+  it('cleans up the shared file when the local write fails', async () => {
+    mockFakeSharedDb();
+    mockSaveDialog('/tmp/fail.sourcerer');
+    vi.spyOn(testDb, 'transaction').mockImplementation(() => { throw new Error('boom'); });
+
+    await expect(handlers.get('projects:createShared')!({}, { name: 'Fails', description: '' })).rejects.toThrow('boom');
+
+    expect(vi.mocked(closeSharedDb)).toHaveBeenCalled();
+    expect(vi.mocked(unlinkSync)).toHaveBeenCalledWith('/tmp/fail.sourcerer');
+  });
+});
+
+describe('projects:convertToShared', () => {
+  it('upgrades a local project to shared and clears sync_pushed', async () => {
+    const projId = insertProject(testDb, 'Local Project');
+    testDb.prepare(
+      'INSERT INTO sync_pushed (project_id, table_name, row_id, pushed_at) VALUES (?, ?, ?, ?)',
+    ).run(projId, 'contacts', uuidv4(), Math.floor(Date.now() / 1000));
+    mockFakeSharedDb();
+    mockSaveDialog('/tmp/conv.sourcerer');
+
+    const result = await handlers.get('projects:convertToShared')!({}, projId) as { project: { is_shared: number } } | null;
+
+    expect(result?.project.is_shared).toBe(1);
+    const remaining = testDb.prepare('SELECT * FROM sync_pushed WHERE project_id = ?').all(projId);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('cleans up the shared file when the local write fails', async () => {
+    const projId = insertProject(testDb, 'Local Project 2');
+    mockFakeSharedDb();
+    mockSaveDialog('/tmp/conv-fail.sourcerer');
+    vi.spyOn(testDb, 'transaction').mockImplementation(() => { throw new Error('boom'); });
+
+    await expect(handlers.get('projects:convertToShared')!({}, projId)).rejects.toThrow('boom');
+
+    expect(vi.mocked(closeSharedDb)).toHaveBeenCalledWith(projId);
+    expect(vi.mocked(unlinkSync)).toHaveBeenCalledWith('/tmp/conv-fail.sourcerer');
+  });
+});
+
+describe('projects:regenerateShared', () => {
+  it('creates a fresh shared file and clears sync_pushed for the project', async () => {
+    const projId = insertProject(testDb, 'Regen Project');
+    testDb.prepare(
+      'UPDATE projects SET is_shared = 1, shared_db_path = ?, shared_db_key = ? WHERE id = ?',
+    ).run('/old/path', Buffer.from('oldkey'), projId);
+    testDb.prepare(
+      'INSERT INTO sync_pushed (project_id, table_name, row_id, pushed_at) VALUES (?, ?, ?, ?)',
+    ).run(projId, 'contacts', uuidv4(), Math.floor(Date.now() / 1000));
+    mockFakeSharedDb();
+    mockSaveDialog('/tmp/regen.sourcerer');
+
+    const result = await handlers.get('projects:regenerateShared')!({}, projId) as { payload: string } | null;
+
+    expect(result?.payload).toBe('encoded-payload');
+    const remaining = testDb.prepare('SELECT * FROM sync_pushed WHERE project_id = ?').all(projId);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('cleans up the new shared file when the local write fails (#442 — previously missing)', async () => {
+    const projId = insertProject(testDb, 'Regen Project 2');
+    mockFakeSharedDb();
+    mockSaveDialog('/tmp/regen-fail.sourcerer');
+    vi.spyOn(testDb, 'transaction').mockImplementation(() => { throw new Error('boom'); });
+
+    await expect(handlers.get('projects:regenerateShared')!({}, projId)).rejects.toThrow('boom');
+
+    expect(vi.mocked(closeSharedDb)).toHaveBeenCalledWith(projId);
+    expect(vi.mocked(unlinkSync)).toHaveBeenCalledWith('/tmp/regen-fail.sourcerer');
   });
 });
 


### PR DESCRIPTION
## Summary

**#433 — Exports and shared-project conversion fail with >999 contacts (SQLite variable limit)**

`export:project`, `export:all-contacts`, and `export:vcard-all-contacts` built unchunked `IN (...)` clauses from contact-ID lists that could exceed SQLite's default `SQLITE_LIMIT_VARIABLE_NUMBER` of 999 — both from the full member/contact-ID set used for the bulk email/phone/link/handle fetches, and from the `contactIds` selection filter used for "export selected" flows.

- Bulk sub-table fetches now go through a new `fetchContactSubTables()` helper that chunks `IN` clauses at 500 (mirroring the pattern `pushAppendOnly` already uses in the sync engine), via a small generic `chunkedIn()` helper.
- The `contactIds` selection filter (which can be arbitrarily large — a user can select-all on a huge table) now filters in JS with a `Set` instead of building a SQL `IN` clause, since its size isn't bounded by anything the code controls.
- `projects:convertToShared` / `regenerateShared`'s part of this issue (an `UPDATE ... WHERE id IN (...)` over member contact IDs) turned out to already be fixed as a side effect of the #449 sync-replication-state redesign — it's now a single project-scoped `DELETE FROM sync_pushed WHERE project_id = ?` with no per-contact `IN` clause at all.

**#442 — Extract duplicated flows: shared-project creation, export bulk-fetch, sync-engine statement reuse**

Doing together with #433 since the issue calls out they touch the same lines.

- **Item 1 (shared-project creation):** `projects:createShared`, `convertToShared`, and `regenerateShared` each repeated the same ~40-line "create shared DB file → write project metadata → write local project record → compensating cleanup on failure" flow, and had drifted: `regenerateShared` was missing the compensating cleanup (evict the shared DB connection + unlink the file) that the other two had, so a failure in its local DB write left an orphaned shared file on disk. Extracted into one `createSharedProjectFile()` helper — the missing cleanup comes free.
- **Item 2 (export bulk-fetch):** the same `fetchContactSubTables()` helper above roughly halves the duplicated per-sub-table fetch/group pattern (previously repeated 8 times across the two handlers). Also extracted the identical "write rows to a temp file, atomically rename into place" tail of both handlers into `writeExportRows()`.
- **Item 3 (sync-engine statement reuse):** left out of this PR. The issue itself frames it as low priority ("first stop if sync ever feels slow") and unrelated to the #433 chunking work — didn't want to touch the sync engine without a concrete need. Can file a separate issue if it's still wanted.

Closes #433
Closes #442

## Test plan
- [x] `npm run rebuild:node && npm test` — full suite passes (519 tests)
- [x] New `src/test/export.test.ts`: exports 1200 contacts / 1200 project members without hitting "too many SQL variables" (would have thrown pre-fix); exports a filtered selection of >999 contact IDs correctly (excludes non-selected rows); sub-table data (emails/phones/handles) still round-trips correctly through the refactored fetch path
- [x] New tests in `src/test/projects.test.ts` for `createShared`/`convertToShared`/`regenerateShared`: happy-path behavior (payload returned, `sync_pushed` cleared, `is_shared` flag set), and a regression test proving `regenerateShared` now cleans up the shared file when the local DB write fails (previously missing — the mocked `closeSharedDb`/`unlinkSync` calls would not have happened on the old code)
- [x] `npx tsc --noEmit` clean on both `tsconfig.node.json` and `tsconfig.web.json`
- [x] `npx eslint .` clean (only pre-existing, unrelated `react-hooks/exhaustive-deps` warnings)
- [x] `npm run rebuild` — restored Electron-targeted native binaries after testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)