### PR TITLE
Use VACUUM INTO for consistent database snapshots in backups

### DIFF
--- a/src/main/database/index.ts
+++ b/src/main/database/index.ts
@@ -116,6 +116,12 @@ export function isDatabaseOpen(): boolean {
   return activeDb !== null;
 }
 
+/** Writes a consistent snapshot of the active database to destPath via VACUUM INTO.
+ *  destPath must not already exist. Still fully encrypted with the active key. */
+export function snapshotDatabase(destPath: string): void {
+  getDatabase().prepare('VACUUM INTO ?').run(destPath);
+}
+
 // Increment when adding a new migration block below.
 // Exported for test instrumentation only.
 export const DB_VERSION = 1;

--- a/src/main/ipc/auto-backup.ts
+++ b/src/main/ipc/auto-backup.ts
@@ -3,8 +3,9 @@ import fs from 'fs/promises';
 import { rename, unlink } from 'fs/promises';
 import { randomBytes } from 'crypto';
 import path from 'path';
+import os from 'os';
 import { getPaths } from '../utils';
-import { getDatabase, isDatabaseOpen, getPassword } from '../database';
+import { getDatabase, isDatabaseOpen, getPassword, snapshotDatabase } from '../database';
 import { writeBackupFile, createBackupEntries } from './backup-format';
 
 const BACKUP_PREFIX = 'sourcerer-auto-backup-';
@@ -29,15 +30,18 @@ export async function runAutoBackup(): Promise<{ success: boolean; error?: strin
   const destPath = user.auto_backup_dest_path;
   const maxCount = user.auto_backup_max_count ?? 10;
 
+  const tmpSnapDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sourcerer-snap-'));
+  const tmpSnapPath = path.join(tmpSnapDir, 'snapshot.db');
   try {
     // Ensure the destination folder exists (user may have moved it)
     await fs.mkdir(destPath, { recursive: true });
 
-    const { dbPath, saltPath, screenshotsPath } = getPaths();
+    const { saltPath, screenshotsPath } = getPaths();
+    snapshotDatabase(tmpSnapPath);
     const outPath = path.join(destPath, timestampedName());
     const tmpPath = path.join(destPath, `.tmp-${randomBytes(8).toString('hex')}`);
     try {
-      await writeBackupFile(createBackupEntries(dbPath, saltPath, screenshotsPath), tmpPath, getPassword());
+      await writeBackupFile(createBackupEntries(tmpSnapPath, saltPath, screenshotsPath), tmpPath, getPassword());
       await rename(tmpPath, outPath);
     } catch (err) {
       await unlink(tmpPath).catch(() => {});
@@ -57,6 +61,8 @@ export async function runAutoBackup(): Promise<{ success: boolean; error?: strin
     return { success: true };
   } catch (err) {
     return { success: false, error: String(err) };
+  } finally {
+    await fs.rm(tmpSnapDir, { recursive: true, force: true }).catch(() => {});
   }
 }
 

--- a/src/main/ipc/auto-backup.ts
+++ b/src/main/ipc/auto-backup.ts
@@ -30,13 +30,14 @@ export async function runAutoBackup(): Promise<{ success: boolean; error?: strin
   const destPath = user.auto_backup_dest_path;
   const maxCount = user.auto_backup_max_count ?? 10;
 
-  const tmpSnapDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sourcerer-snap-'));
-  const tmpSnapPath = path.join(tmpSnapDir, 'snapshot.db');
+  let tmpSnapDir: string | undefined;
   try {
     // Ensure the destination folder exists (user may have moved it)
     await fs.mkdir(destPath, { recursive: true });
 
     const { saltPath, screenshotsPath } = getPaths();
+    tmpSnapDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sourcerer-snap-'));
+    const tmpSnapPath = path.join(tmpSnapDir, 'snapshot.db');
     snapshotDatabase(tmpSnapPath);
     const outPath = path.join(destPath, timestampedName());
     const tmpPath = path.join(destPath, `.tmp-${randomBytes(8).toString('hex')}`);
@@ -62,7 +63,7 @@ export async function runAutoBackup(): Promise<{ success: boolean; error?: strin
   } catch (err) {
     return { success: false, error: String(err) };
   } finally {
-    await fs.rm(tmpSnapDir, { recursive: true, force: true }).catch(() => {});
+    if (tmpSnapDir) await fs.rm(tmpSnapDir, { recursive: true, force: true }).catch(() => {});
   }
 }
 

--- a/src/main/ipc/backup.ts
+++ b/src/main/ipc/backup.ts
@@ -5,7 +5,7 @@ import os from 'os';
 import crypto from 'crypto';
 import Database from 'better-sqlite3-multiple-ciphers';
 import { getPaths, deriveKey, filenameDateStamp } from '../utils';
-import { closeDatabase, getKeyHex, applyCipherPragmas } from '../database';
+import { closeDatabase, getKeyHex, applyCipherPragmas, snapshotDatabase } from '../database';
 import { stopPoller } from '../sync/poller';
 import { clearExtensionSession } from '../http-server';
 import { writeBackupFile, readBackupFile, createBackupEntries, MAX_BACKUP_BYTES } from './backup-format';
@@ -17,7 +17,7 @@ export function registerBackupHandlers(): void {
   ipcMain.handle(
     'backup:export',
     async (_, { password }: { password: string }): Promise<{ success: boolean; error?: string }> => {
-      const { dbPath, saltPath, screenshotsPath } = getPaths();
+      const { saltPath, screenshotsPath } = getPaths();
 
       const dbSalt = await fs.readFile(saltPath);
       const verifyKeyHex = await deriveKey(password, dbSalt);
@@ -37,7 +37,7 @@ export function registerBackupHandlers(): void {
       const tmpSnapPath = path.join(tmpSnapDir, 'snapshot.db');
       const tmpOutPath = path.join(path.dirname(filePath), `.sourcerer-backup-${crypto.randomBytes(8).toString('hex')}.tmp`);
       try {
-        await fs.copyFile(dbPath, tmpSnapPath);
+        snapshotDatabase(tmpSnapPath);
         await writeBackupFile(createBackupEntries(tmpSnapPath, saltPath, screenshotsPath), tmpOutPath, password);
         await fs.unlink(filePath).catch(() => {}); // pre-remove so rename works on Windows
         await fs.rename(tmpOutPath, filePath);

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import crypto from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
 import Database from 'better-sqlite3-multiple-ciphers';
-import { getDatabase, closeDatabase, getKeyHex, updateActiveKeyHex, setActivePassword } from '../database';
+import { getDatabase, closeDatabase, getKeyHex, updateActiveKeyHex, setActivePassword, snapshotDatabase } from '../database';
 import { getPaths, deriveKey, getVaultBundlePath, writeVaultConfig, clearVaultConfig, detectSyncProvider } from '../utils';
 import { autoLock } from '../auto-lock';
 import { setRssPollIntervalHours } from '../sync/poller';
@@ -271,9 +271,11 @@ export function registerSettingsHandlers(): void {
     try {
       await fs.mkdir(newBundlePath, { recursive: true });
 
-      // Safe to copy while the DB is open: DELETE journal mode keeps the file
-      // in a consistent committed state at all times (no -wal/-shm sidecars).
-      await fs.cp(dbPath, path.join(newBundlePath, 'db.sqlite'), { force: true });
+      // Snapshot via VACUUM INTO rather than copying the live file: a plain
+      // copy can catch the DB mid-write (e.g. a hot rollback journal) and
+      // capture a torn database. VACUUM INTO goes through the open connection
+      // and always produces a consistent, still-encrypted copy.
+      snapshotDatabase(path.join(newBundlePath, 'db.sqlite'));
       await fs.cp(saltPath, path.join(newBundlePath, 'salt'), { force: true });
 
       // Copy screenshots directory if it exists

--- a/src/test/database-snapshot.test.ts
+++ b/src/test/database-snapshot.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import crypto from 'crypto';
+import Database from 'better-sqlite3-multiple-ciphers';
+import { initDatabase, closeDatabase, snapshotDatabase, applyCipherPragmas, getDatabase, DB_VERSION } from '../main/database';
+
+// Guards against a future change silently producing an unencrypted backup.
+const SECRET = 'SNAPSHOT_TEST_SECRET_MARKER_9f3a';
+
+describe('snapshotDatabase', () => {
+  let tmpDir: string;
+  let keyHex: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sourcerer-snaptest-'));
+    keyHex = crypto.randomBytes(32).toString('hex');
+    initDatabase(path.join(tmpDir, 'db.sqlite'), keyHex);
+    getDatabase()
+      .prepare('INSERT INTO contacts (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)')
+      .run('test-contact-1', SECRET, 0, 0);
+  });
+
+  afterEach(async () => {
+    closeDatabase();
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('is readable with the correct key and contains the source rows', () => {
+    const destPath = path.join(tmpDir, 'snapshot.db');
+    snapshotDatabase(destPath);
+
+    const snapDb = new Database(destPath);
+    applyCipherPragmas(snapDb, keyHex);
+    const row = snapDb.prepare('SELECT name FROM contacts WHERE id = ?').get('test-contact-1') as { name: string };
+    snapDb.close();
+
+    expect(row.name).toBe(SECRET);
+  });
+
+  it('preserves user_version', () => {
+    const destPath = path.join(tmpDir, 'snapshot-version.db');
+    snapshotDatabase(destPath);
+
+    const snapDb = new Database(destPath);
+    applyCipherPragmas(snapDb, keyHex);
+    const version = snapDb.pragma('user_version', { simple: true }) as number;
+    snapDb.close();
+
+    expect(version).toBe(DB_VERSION);
+  });
+
+  it('is not a plaintext SQLite file', async () => {
+    const destPath = path.join(tmpDir, 'snapshot-secure.db');
+    snapshotDatabase(destPath);
+
+    const raw = await fs.readFile(destPath);
+    expect(raw.subarray(0, 15).toString('utf8')).not.toBe('SQLite format 3');
+    expect(raw.includes(Buffer.from(SECRET, 'utf8'))).toBe(false);
+  });
+
+  it('works when the destination path contains an apostrophe', () => {
+    const destPath = path.join(tmpDir, "Tom's Backups snap'shot.db");
+    snapshotDatabase(destPath);
+
+    const snapDb = new Database(destPath);
+    applyCipherPragmas(snapDb, keyHex);
+    const row = snapDb.prepare('SELECT name FROM contacts WHERE id = ?').get('test-contact-1') as { name: string };
+    snapDb.close();
+
+    expect(row.name).toBe(SECRET);
+  });
+});


### PR DESCRIPTION
Closes #437

Three paths copied the live, open database with plain filesystem calls while writes could be in flight, risking a torn copy: hourly auto-backup, `backup:export`, and `settings:move-vault`. A corrupt backup is discovered exactly when it's needed most.

## Approach

Adds `snapshotDatabase(destPath)` in `src/main/database/index.ts`, which runs `VACUUM INTO` through the open connection, and routes all three call sites through it.

**Note on the issue's fix sketch:** it suggested `db.backup(destPath)` *or* `VACUUM INTO`. `db.backup()` does **not** work here — it throws `backup is not supported with incompatible source and target databases` on a SQLCipher database. Only `VACUUM INTO` is viable.

Verified empirically against the repo's native module before implementing:

- the snapshot remains **fully encrypted** — no plaintext SQLite header, no plaintext row data, still requires the key
- `user_version` is preserved (migrations depend on it)
- `VACUUM INTO` refuses to write to an existing path, so every call site targets a fresh temp path
- the destination is passed as a **bound parameter**, not interpolated — a vault folder named `Tom's Backups` would otherwise break or inject

## Changes

- `src/main/database/index.ts` — new `snapshotDatabase()` helper
- `src/main/ipc/backup.ts` — `fs.copyFile` → `snapshotDatabase` (existing temp-dir plumbing reused)
- `src/main/ipc/auto-backup.ts` — snapshots to a temp dir, cleaned up in `finally`
- `src/main/ipc/settings.ts` — `fs.cp` → `snapshotDatabase`; corrected the comment claiming DELETE journal mode makes a live copy safe at all times (it's only safe *between* transactions, which is the bug)
- `src/test/database-snapshot.test.ts` — new; pins readability with the key, `user_version` preservation, the not-plaintext property, and the apostrophe-path regression

The not-plaintext assertion is the important one long-term: it guards against a future change silently producing an unencrypted backup.

## Tradeoff worth knowing

`VACUUM INTO` is synchronous and briefly blocks the main process while it runs, where the old `fs.readFile`/`copyFile` was async. This is consistent with how the rest of the codebase does DB work on the main process, and the DB is small relative to screenshots (stored separately), but it does mean an hourly pause that scales with database size. Flagging rather than pre-optimising.

## Testing

`npm run typecheck` clean; `npm test` 523 passed across 30 files.