### PR TITLE
Require email match for UUID adoption; make mention read state per-user

### DIFF
--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -363,10 +363,8 @@ function pullContacts(local: Database.Database, shared: Database.Database, tombs
       }
       // Only adopt when signals converge on exactly one local contact AND that
       // contact was matched by email (a phone-only match is never sufficient).
-      const matchedLocalId =
-        candidateIds.size === 1 && emailMatchedIds.has([...candidateIds][0])
-          ? [...candidateIds][0]
-          : undefined;
+      const soleCandidate = candidateIds.size === 1 ? [...candidateIds][0] : undefined;
+      const matchedLocalId = soleCandidate && emailMatchedIds.has(soleCandidate) ? soleCandidate : undefined;
 
       if (matchedLocalId && !adoptedIds.has(matchedLocalId)) {
         // Adopt the shared UUID so both sides agree on one primary key.

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -342,18 +342,31 @@ function pullContacts(local: Database.Database, shared: Database.Database, tombs
         .prepare('SELECT phone FROM contact_phones WHERE contact_id = ?')
         .all(sc.id) as { phone: string }[];
 
-      // Collect all candidate local IDs matching any shared email/phone.
-      // Only adopt when signals converge on exactly one local contact.
+      // Collect all candidate local IDs matching any shared email/phone, plus a
+      // separate set for email matches only. Phone numbers aren't personal identifiers
+      // (office landline, family phone), so a phone-only match must never trigger
+      // adoption on its own — but it still counts toward the ambiguity check below,
+      // so a phone match against a *different* contact than the email match still
+      // blocks adoption instead of being silently dropped.
       const candidateIds = new Set<string>();
+      const emailMatchedIds = new Set<string>();
       for (const { email } of sharedEmails) {
         const found = localEmailToId.get(email);
-        if (found) for (const id of found) candidateIds.add(id);
+        if (found) for (const id of found) {
+          candidateIds.add(id);
+          emailMatchedIds.add(id);
+        }
       }
       for (const { phone } of sharedPhones) {
         const found = localPhoneToId.get(phone);
         if (found) for (const id of found) candidateIds.add(id);
       }
-      const matchedLocalId = candidateIds.size === 1 ? [...candidateIds][0] : undefined;
+      // Only adopt when signals converge on exactly one local contact AND that
+      // contact was matched by email (a phone-only match is never sufficient).
+      const matchedLocalId =
+        candidateIds.size === 1 && emailMatchedIds.has([...candidateIds][0])
+          ? [...candidateIds][0]
+          : undefined;
 
       if (matchedLocalId && !adoptedIds.has(matchedLocalId)) {
         // Adopt the shared UUID so both sides agree on one primary key.
@@ -739,16 +752,18 @@ function pullAppendOnly(
     published_at: number | null;
     fetched_at: number;
     guid: string;
-    seen: number;
   }[]) {
     if (!localContactIds.has(sm.contact_id)) continue;
+    // seen/dismissed are per-user read state (issue #448) — never synced, so
+    // pulled mentions always land locally as unseen regardless of the shared
+    // row's state.
     const { changes } = local
       .prepare(
         `INSERT OR IGNORE INTO contact_alert_mentions
-           (id, contact_id, headline, source_url, published_at, fetched_at, guid, seen)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+           (id, contact_id, headline, source_url, published_at, fetched_at, guid)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(sm.id, sm.contact_id, sm.headline, sm.source_url, sm.published_at, sm.fetched_at, sm.guid, sm.seen);
+      .run(sm.id, sm.contact_id, sm.headline, sm.source_url, sm.published_at, sm.fetched_at, sm.guid);
     if (changes > 0) stampMention.run(projectId, sm.id, now);
   }
 
@@ -1007,15 +1022,16 @@ function pushAppendOnly(
         published_at: number | null;
         fetched_at: number;
         guid: string;
-        seen: number;
       }[]) {
+        // seen/dismissed are per-user read state (issue #448) — never pushed, so
+        // the shared row always lands as unseen regardless of the local state.
         shared
           .prepare(
             `INSERT OR IGNORE INTO contact_alert_mentions
-               (id, contact_id, headline, source_url, published_at, fetched_at, guid, seen)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+               (id, contact_id, headline, source_url, published_at, fetched_at, guid)
+             VALUES (?, ?, ?, ?, ?, ?, ?)`,
           )
-          .run(m.id, m.contact_id, m.headline, m.source_url, m.published_at, m.fetched_at, m.guid, m.seen);
+          .run(m.id, m.contact_id, m.headline, m.source_url, m.published_at, m.fetched_at, m.guid);
         mentionIds.push(m.id);
       }
     }

--- a/src/test/sync-engine.test.ts
+++ b/src/test/sync-engine.test.ts
@@ -79,7 +79,9 @@ describe('syncProject — contact identity matching', () => {
     expect(contacts[0].id).toBe(sharedContactId);
   });
 
-  it('adopts shared UUID when local contact matches by phone, no duplicate', () => {
+  it('does not adopt shared UUID on a phone-only match, even with distinct names (#447)', () => {
+    // A phone number is not a personal identifier (office landline, family phone),
+    // so a phone-only match must never trigger automatic adoption on its own.
     const localDb = createTestDb();
     const sharedDb = createSharedDb();
     const projectId = insertProject(localDb, 'Test Project');
@@ -88,15 +90,69 @@ describe('syncProject — contact identity matching', () => {
     localInsertMembership(localDb, localContactId, projectId);
 
     const sharedContactId = uuidv4();
-    sharedInsertContact(sharedDb, sharedContactId, 'Bob', { phones: ['+15551234567'], updatedAt: NOW });
+    sharedInsertContact(sharedDb, sharedContactId, 'Someone Else', { phones: ['+15551234567'], updatedAt: NOW });
     sharedInsertMembership(sharedDb, uuidv4(), sharedContactId);
 
     const result = syncProject(localDb, sharedDb, projectId);
     expect(result.success).toBe(true);
 
-    const contacts = localDb.prepare('SELECT id FROM contacts WHERE name = ?').all('Bob') as { id: string }[];
+    // Both contacts should exist as distinct rows — no adoption/merge occurred.
+    const all = localDb.prepare('SELECT id FROM contacts').all() as { id: string }[];
+    expect(all.map((r) => r.id)).toContain(localContactId);
+    expect(all.map((r) => r.id)).toContain(sharedContactId);
+    expect(all).toHaveLength(2);
+  });
+
+  it('still adopts shared UUID on an email match (#447 guard against over-correcting)', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Test Project');
+
+    const localContactId = insertContact(localDb, 'Carol', { emails: ['carol-adopt@example.com'] });
+    localInsertMembership(localDb, localContactId, projectId);
+
+    const sharedContactId = uuidv4();
+    sharedInsertContact(sharedDb, sharedContactId, 'Carol', { emails: ['carol-adopt@example.com'], updatedAt: NOW });
+    sharedInsertMembership(sharedDb, uuidv4(), sharedContactId);
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+
+    const contacts = localDb.prepare('SELECT id FROM contacts WHERE name = ?').all('Carol') as { id: string }[];
     expect(contacts).toHaveLength(1);
     expect(contacts[0].id).toBe(sharedContactId);
+  });
+
+  it('blocks adoption when the shared email matches one local contact and the shared phone matches a different one (#447)', () => {
+    // Regression guard: if phones were dropped from the candidate set entirely
+    // instead of just from the adoption check, this case would collapse from
+    // candidateIds.size === 2 to size === 1 and incorrectly adopt.
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Test Project');
+
+    const localA = insertContact(localDb, 'Alice', { emails: ['alice-ambig@example.com'] });
+    const localB = insertContact(localDb, 'Bob', { phones: ['+15559876543'] });
+    localInsertMembership(localDb, localA, projectId);
+    localInsertMembership(localDb, localB, projectId);
+
+    const sharedContactId = uuidv4();
+    sharedInsertContact(sharedDb, sharedContactId, 'Ambiguous', {
+      emails: ['alice-ambig@example.com'],
+      phones: ['+15559876543'],
+      updatedAt: NOW,
+    });
+    sharedInsertMembership(sharedDb, uuidv4(), sharedContactId);
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+
+    // No adoption: all three contacts (Alice, Bob, and the new shared "Ambiguous") exist.
+    const all = localDb.prepare('SELECT id FROM contacts').all() as { id: string }[];
+    expect(all).toHaveLength(3);
+    expect(all.map((r) => r.id)).toContain(localA);
+    expect(all.map((r) => r.id)).toContain(localB);
+    expect(all.map((r) => r.id)).toContain(sharedContactId);
   });
 
   it('adopts correct UUIDs when two shared contacts each match a different local contact', () => {
@@ -1340,5 +1396,53 @@ describe('per-project push tracking (#431)', () => {
     expect(syncProject(localDb, sharedA, projectA).success).toBe(true);
     const inA = sharedA.prepare('SELECT name FROM contacts WHERE id = ?').get(contactId) as { name: string };
     expect(inA.name).toBe('Edit Emma II');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Alert-mention read state is per-user, not synced (#448)
+// ---------------------------------------------------------------------------
+
+describe('contact_alert_mentions — seen is per-user, not synced (#448)', () => {
+  it('a mention marked seen=1 in the shared DB arrives locally as seen=0', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Seen Pull Test');
+
+    const contactId = insertContact(localDb, 'Alice', { emails: ['alice@example.com'] });
+    localInsertMembership(localDb, contactId, projectId);
+    sharedInsertContact(sharedDb, contactId, 'Alice', { emails: ['alice@example.com'] });
+    sharedInsertMembership(sharedDb, uuidv4(), contactId);
+
+    const mentionId = uuidv4();
+    sharedDb
+      .prepare('INSERT INTO contact_alert_mentions (id, contact_id, headline, source_url, fetched_at, guid, seen) VALUES (?, ?, ?, ?, ?, ?, 1)')
+      .run(mentionId, contactId, 'Headline', 'http://x.com', NOW, 'guid-seen');
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+
+    const local = localDb.prepare('SELECT seen FROM contact_alert_mentions WHERE id = ?').get(mentionId) as { seen: number } | undefined;
+    expect(local?.seen).toBe(0);
+  });
+
+  it('a local mention marked seen=1 does not carry seen=1 across when pushed to shared', () => {
+    const localDb = createTestDb();
+    const sharedDb = createSharedDb();
+    const projectId = insertProject(localDb, 'Seen Push Test');
+
+    const contactId = insertContact(localDb, 'Bob', { emails: ['bob@example.com'] });
+    localInsertMembership(localDb, contactId, projectId);
+
+    const mentionId = uuidv4();
+    localDb
+      .prepare('INSERT INTO contact_alert_mentions (id, contact_id, headline, source_url, fetched_at, guid, seen) VALUES (?, ?, ?, ?, ?, ?, 1)')
+      .run(mentionId, contactId, 'Headline', 'http://y.com', NOW, 'guid-push-seen');
+
+    const result = syncProject(localDb, sharedDb, projectId);
+    expect(result.success).toBe(true);
+
+    const shared = sharedDb.prepare('SELECT seen FROM contact_alert_mentions WHERE id = ?').get(mentionId) as { seen: number } | undefined;
+    expect(shared?.seen).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #447
Closes #448

Two sync-semantics decisions, both previously accidental, now made deliberate and pinned with tests.

## #447 — adoption requires an email match

`pullContacts` matched incoming shared contacts against local ones by email **or** phone, and a single candidate triggered `adoptSharedUuid` — an irreversible primary-key rename plus sub-table merge, with no undo and no user visibility. Two different people sharing a phone number (office landline, family phone) were silently merged into one contact.

Implements **Option 1**: emails are effectively personal identifiers, phone numbers are not, so a phone-only match is never sufficient on its own.

**Important subtlety:** phone matches still contribute to the *ambiguity* check. If the shared contact's email matches local A while its phone matches a different local B, that's two candidates and adoption is blocked. Dropping phones from the candidate set entirely would have collapsed that to a single candidate and started adopting — strictly *more* eager than the current behaviour, the opposite of the issue's intent. There's a dedicated regression test for exactly this case.

## #448 — alert-mention read state is per-user

`seen` was copied once at first pull/push while `dismissed` was never synced, and since these tables are append-only, later changes to either never propagated. Read state was semi-shared in a timing-dependent way that nobody chose.

Implements **Option A**: read state is personal. `seen` is dropped from the `INSERT OR IGNORE` column lists in both `pullAppendOnly` and `pushAppendOnly`; both schemas declare `seen INTEGER NOT NULL DEFAULT 0`, so each client now tracks its own with no migration. This makes `seen` consistent with `dismissed`, which was already per-user.

The `seen` column is deliberately **left in `shared-schema.ts`** even though it's now vestigial (always 0) — older clients still expect a `NOT NULL` column there, and dropping it would break cross-version compatibility.

## Testing

Five tests added; one pre-existing test (`adopts shared UUID when local contact matches by phone`) was repurposed in place, since it asserted precisely the behaviour #447 says must stop.

I verified each new test **fails against the unfixed engine** rather than trusting that they pass — the phone-only adoption test and both `seen` tests all fail on `main` and pass with this change. The email-adoption and ambiguity tests pass either way by design; they're guards against over-correcting, not regressions.

`npm run typecheck` clean; `npm test` 527 passed across 30 files, rebased on current `main`.