### PR TITLE
Index every co-owner of an email/phone in dedup detection

### DIFF
--- a/src/main/dedup.ts
+++ b/src/main/dedup.ts
@@ -127,38 +127,48 @@ export function findDuplicatePairs(contacts: DedupContact[], dismissedPairs?: Se
   const pairedIds = new Set<string>();
   const contactById = new Map<string, DedupContact>(contacts.map((c) => [c.id, c]));
 
-  const emailIndex = new Map<string, string>();
+  // Identity indexes: identifier → Set of contact IDs that carry it. Every co-owner
+  // of an identifier must be indexed, even ones that were skipped as a match partner
+  // (dismissed pair, or already paired elsewhere) — otherwise later contacts sharing
+  // the same identifier can miss a valid pairing (issue #441).
+  const emailIndex = new Map<string, Set<string>>();
   for (const c of contacts) {
     for (const email of c.emails) {
       const key = normalizeEmail(email);
-      const existing = emailIndex.get(key);
-      if (existing && existing !== c.id && !pairedIds.has(existing) && !pairedIds.has(c.id)) {
-        if (!isDismissed(existing, c.id)) {
+      const seen = emailIndex.get(key) ?? new Set<string>();
+      if (!pairedIds.has(c.id)) {
+        for (const existing of seen) {
+          if (existing === c.id || pairedIds.has(existing)) continue;
+          if (isDismissed(existing, c.id)) continue;
           pairs.push({ a: contactById.get(existing)!, b: c, reason: 'email' });
           pairedIds.add(existing);
           pairedIds.add(c.id);
+          break;
         }
-      } else if (!existing) {
-        emailIndex.set(key, c.id);
       }
+      seen.add(c.id);
+      emailIndex.set(key, seen);
     }
   }
 
-  const phoneIndex = new Map<string, string>();
+  const phoneIndex = new Map<string, Set<string>>();
   for (const c of contacts) {
     for (const phone of c.phones) {
       const key = digitsOnly(phone);
       if (!key) continue;
-      const existing = phoneIndex.get(key);
-      if (existing && existing !== c.id && !pairedIds.has(existing) && !pairedIds.has(c.id)) {
-        if (!isDismissed(existing, c.id)) {
+      const seen = phoneIndex.get(key) ?? new Set<string>();
+      if (!pairedIds.has(c.id)) {
+        for (const existing of seen) {
+          if (existing === c.id || pairedIds.has(existing)) continue;
+          if (isDismissed(existing, c.id)) continue;
           pairs.push({ a: contactById.get(existing)!, b: c, reason: 'phone' });
           pairedIds.add(existing);
           pairedIds.add(c.id);
+          break;
         }
-      } else if (!existing) {
-        phoneIndex.set(key, c.id);
       }
+      seen.add(c.id);
+      phoneIndex.set(key, seen);
     }
   }
 

--- a/src/test/dedup.unit.test.ts
+++ b/src/test/dedup.unit.test.ts
@@ -185,6 +185,59 @@ describe('findDuplicatePairs — empty and single-contact inputs', () => {
   });
 });
 
+describe('findDuplicatePairs — identity index skips later contacts (#441)', () => {
+  it('still detects a pair involving C when three contacts share an email and (A,B) is dismissed', () => {
+    const contacts = [
+      makeContact('a', 'Alice One', { emails: ['shared@example.com'] }),
+      makeContact('b', 'Bob Two', { emails: ['shared@example.com'] }),
+      makeContact('c', 'Carol Three', { emails: ['shared@example.com'] }),
+    ];
+    const dismissed = new Set(['a|b']);
+    const pairs = findDuplicatePairs(contacts, dismissed);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].reason).toBe('email');
+    // C must not be left unpaired.
+    expect([pairs[0].a.id, pairs[0].b.id]).toContain('c');
+  });
+
+  it('detects (B,C) by email when both (A,B) and (A,C) are dismissed', () => {
+    const contacts = [
+      makeContact('a', 'Alice One', { emails: ['shared@example.com'] }),
+      makeContact('b', 'Bob Two', { emails: ['shared@example.com'] }),
+      makeContact('c', 'Carol Three', { emails: ['shared@example.com'] }),
+    ];
+    const dismissed = new Set(['a|b', 'a|c']);
+    const pairs = findDuplicatePairs(contacts, dismissed);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].reason).toBe('email');
+    expect(new Set([pairs[0].a.id, pairs[0].b.id])).toEqual(new Set(['b', 'c']));
+  });
+
+  it('detects (B,C) by phone when both (A,B) and (A,C) are dismissed', () => {
+    const contacts = [
+      makeContact('a', 'Alice One', { phones: ['202-456-1111'] }),
+      makeContact('b', 'Bob Two', { phones: ['202-456-1111'] }),
+      makeContact('c', 'Carol Three', { phones: ['202-456-1111'] }),
+    ];
+    const dismissed = new Set(['a|b', 'a|c']);
+    const pairs = findDuplicatePairs(contacts, dismissed);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].reason).toBe('phone');
+    expect(new Set([pairs[0].a.id, pairs[0].b.id])).toEqual(new Set(['b', 'c']));
+  });
+
+  it('unaffected baseline: two contacts sharing an email with nothing dismissed still produce exactly one pair', () => {
+    const contacts = [
+      makeContact('a', 'Alice One', { emails: ['shared@example.com'] }),
+      makeContact('b', 'Bob Two', { emails: ['shared@example.com'] }),
+    ];
+    const pairs = findDuplicatePairs(contacts);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].reason).toBe('email');
+    expect(new Set([pairs[0].a.id, pairs[0].b.id])).toEqual(new Set(['a', 'b']));
+  });
+});
+
 describe('findDuplicatePairs — empty-digit phone string (#291 / dedup edge case)', () => {
   it('does not crash when a phone contains only non-digit characters', () => {
     const contacts = [


### PR DESCRIPTION
Closes #441

`findDuplicatePairs` kept its email and phone indexes as `Map<identifier, contactId>` — one contact per identifier — and only registered a contact when no entry existed yet. So when an identifier hit an existing entry but the pair was *skipped* (previously dismissed, or one side already paired), the current contact was never indexed under its own ID.

With A, B, C sharing an email and (A,B) dismissed, B never enters the index. (B,C) is then only found if C happens to collide with A's entry — and if (A,C) is also dismissed, C's duplicate relationship to B is missed entirely.

## Change

Both indexes become `Map<string, Set<string>>` (identifier → all contact IDs carrying it), matching the pattern the sync engine already uses for `localEmailToId` / `localPhoneToId`. For each identifier the code scans the full set for the first eligible partner, then adds the current contact's ID **unconditionally** — that last part is the actual fix.

Pair-recording semantics, `reason` values, email-before-phone ordering, and the name-similarity pass are all unchanged. One pre-existing edge case is deliberately preserved: a contact already in `pairedIds` still gets indexed, matching the old `else if (!existing)` path.

## Testing

Four unit tests added. I verified the teeth independently rather than relying on a green suite — against unmodified `dedup.ts`:

- **email, (A,B) + (A,C) dismissed → (B,C)** — FAILS without the fix ✓
- **phone, same shape** — FAILS without the fix ✓
- the (A,B)-only-dismissed case and the two-contact baseline pass either way; they're guards against over-correcting, not regressions

`npm run typecheck` clean; `npm test` 527 passed across 30 files.