### PR TITLE
Document the sync engine's actual consistency guarantees

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ Sourcerer is an Electron + React + TypeScript application built with [electron-v
 
 All data lives in a self-contained `.sourcerer` vault bundle — a directory containing the encrypted database, the Argon2 salt file, and any screenshots captured by the browser extension. The vault can be placed anywhere: a local folder, an external drive, or a cloud-synced folder. On macOS, Finder presents the bundle as a single opaque file.
 
+### Shared projects and their consistency model
+
+Collaboration works by putting a second SQLCipher database in a cloud-synced folder. There is no server, and no third party ever holds a key — which is the point, but it bounds what sync can guarantee.
+
+Shared projects are **eventually consistent, provided collaborators don't write within the same cloud-sync upload window.** Cloud providers replicate whole files and fork on concurrent writes; they never merge. Two simultaneous saves produce a provider-level "conflicted copy" next to the real file, and the losing side's changes are not in the file Sourcerer goes on to read.
+
+Conflicts that do get reconciled resolve last-write-wins by wall-clock timestamp at second granularity. Those clocks belong to the collaborators' machines and nothing arbitrates between them, so a badly skewed clock can resolve a conflict backwards.
+
+This is a limitation of the substrate, not of the merge logic, and it is permanent for as long as the design stays serverless. In practice: work a few minutes apart, and don't treat a shared project as the only copy of something you can't lose.
+
 ---
 
 ## Installation

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -340,10 +340,19 @@
             <p>Sourcerer polls the shared file every two minutes. Changes are merged on a last-write-wins basis using <code>updated_at</code> timestamps — if two people update the same contact record at almost the same time, whichever save happened last will win.</p>
             <p>Because sync is file-based, it only works when both users are online and the shared folder is in sync. If the cloud folder is paused or offline, changes will not propagate until connectivity is restored.</p>
 
+            <h3>What "sync" does and doesn't promise</h3>
+            <p>Shared projects work by putting one database file in a folder your cloud provider keeps in step across machines. That is what makes collaboration possible without any Sourcerer server ever seeing your data — but it is worth being precise about what it can and cannot do.</p>
+            <p><strong>The practical rule: avoid two people editing the same project at the same moment.</strong> Work a few minutes apart and everything merges cleanly. Changes normally appear on the other person's machine within a couple of minutes.</p>
+            <p>The reason for that rule is that cloud providers sync whole files. They do not merge two versions of a file — when two people save inside the same upload window, the provider keeps one version and sets the other aside.</p>
+            <div class="note">
+              <strong>If you see a "conflicted copy":</strong> Dropbox (and the equivalent in OneDrive, iCloud Drive and Google Drive) will sometimes leave a second file next to your <code>.sourcerer</code> project with a name like <em>"project (Tom's conflicted copy 2026-07-20).sourcerer"</em>. That means two people wrote at once and the changes in that copy never made it into the main file. Don't delete it — it holds someone's work. Open it as a separate shared project to see what's inside and re-enter anything that's missing.
+            </div>
+            <p>One more caveat: because there is no server, deciding "which save was last" relies on the clocks of the machines involved. If someone's computer clock is significantly wrong, their older change can beat a newer one. This is rare, but it is the reason the app can't promise perfect ordering.</p>
+
             <h3>What is and isn't synced</h3>
             <p>All project data is synced: contact memberships, status, priority, reporter attribution, themes, interaction logs, and reminders.</p>
             <div class="note">
-              <strong>Not synced:</strong> The per-contact notes scratchpad (global notes on a contact, outside of project context) is local to each installation and is never written to the shared file.
+              <strong>Not synced:</strong> The per-contact notes scratchpad (global notes on a contact, outside of project context) is local to each installation and is never written to the shared file. Whether you've seen or dismissed a news alert is also personal to your own installation — marking an alert as read doesn't clear it for your collaborators.
             </div>
 
             <h3>Caveats</h3>

--- a/docs/security.html
+++ b/docs/security.html
@@ -52,6 +52,7 @@
             <li><a href="#network">Network traffic</a></li>
             <li><a href="#http-server">Local HTTP server</a></li>
             <li><a href="#panic-wipe">Panic wipe</a></li>
+            <li><a href="#shared-projects">Shared projects</a></li>
             <li><a href="#backups">Backups</a></li>
             <li><a href="#source-code">Open source</a></li>
           </ol>
@@ -168,6 +169,14 @@
             <div class="warn">
               <strong>Panic wipe has no undo.</strong> Once you confirm by typing WIPE, data is gone immediately. Backups stored elsewhere are not affected — the backup file is self-contained and can be restored using only your password.
             </div>
+          </section>
+
+          <section id="shared-projects">
+            <h2>Shared projects</h2>
+            <p>A shared project is a second SQLCipher database placed in a folder that a cloud provider replicates between machines. The encryption properties are the same as the main vault: the provider stores ciphertext and never holds your password, so Dropbox, OneDrive, iCloud Drive and Google Drive cannot read the contents of a shared project.</p>
+            <p>The consistency properties are weaker, and worth stating plainly. Sourcerer's shared projects are <strong>eventually consistent, provided collaborators do not write within the same cloud-sync upload window</strong>. Cloud providers replicate whole files and fork on concurrent writes — they never merge. When two people save at once, the provider preserves one version and leaves the other beside it as a "conflicted copy", and the changes in that copy are not present in the file Sourcerer subsequently reads.</p>
+            <p>Where changes do need reconciling, conflict resolution is last-write-wins by wall-clock timestamp at one-second granularity. Those timestamps come from the collaborators' own machines, and there is no server to arbitrate: a client with a materially skewed clock can resolve a conflict backwards, letting an older edit overwrite a newer one.</p>
+            <p>This is a property of the substrate rather than a defect in the implementation. It is the cost of collaboration with no server and no third party holding a key, and it is the correct tradeoff for this tool — but it means shared projects should not be relied upon as the sole copy of anything critical. Take backups, and prefer working a few minutes apart over editing the same project simultaneously.</p>
           </section>
 
           <section id="backups">

--- a/src/main/dedup.ts
+++ b/src/main/dedup.ts
@@ -127,38 +127,48 @@ export function findDuplicatePairs(contacts: DedupContact[], dismissedPairs?: Se
   const pairedIds = new Set<string>();
   const contactById = new Map<string, DedupContact>(contacts.map((c) => [c.id, c]));
 
-  const emailIndex = new Map<string, string>();
+  // Identity indexes: identifier → Set of contact IDs that carry it. Every co-owner
+  // of an identifier must be indexed, even ones that were skipped as a match partner
+  // (dismissed pair, or already paired elsewhere) — otherwise later contacts sharing
+  // the same identifier can miss a valid pairing (issue #441).
+  const emailIndex = new Map<string, Set<string>>();
   for (const c of contacts) {
     for (const email of c.emails) {
       const key = normalizeEmail(email);
-      const existing = emailIndex.get(key);
-      if (existing && existing !== c.id && !pairedIds.has(existing) && !pairedIds.has(c.id)) {
-        if (!isDismissed(existing, c.id)) {
+      const seen = emailIndex.get(key) ?? new Set<string>();
+      if (!pairedIds.has(c.id)) {
+        for (const existing of seen) {
+          if (existing === c.id || pairedIds.has(existing)) continue;
+          if (isDismissed(existing, c.id)) continue;
           pairs.push({ a: contactById.get(existing)!, b: c, reason: 'email' });
           pairedIds.add(existing);
           pairedIds.add(c.id);
+          break;
         }
-      } else if (!existing) {
-        emailIndex.set(key, c.id);
       }
+      seen.add(c.id);
+      emailIndex.set(key, seen);
     }
   }
 
-  const phoneIndex = new Map<string, string>();
+  const phoneIndex = new Map<string, Set<string>>();
   for (const c of contacts) {
     for (const phone of c.phones) {
       const key = digitsOnly(phone);
       if (!key) continue;
-      const existing = phoneIndex.get(key);
-      if (existing && existing !== c.id && !pairedIds.has(existing) && !pairedIds.has(c.id)) {
-        if (!isDismissed(existing, c.id)) {
+      const seen = phoneIndex.get(key) ?? new Set<string>();
+      if (!pairedIds.has(c.id)) {
+        for (const existing of seen) {
+          if (existing === c.id || pairedIds.has(existing)) continue;
+          if (isDismissed(existing, c.id)) continue;
           pairs.push({ a: contactById.get(existing)!, b: c, reason: 'phone' });
           pairedIds.add(existing);
           pairedIds.add(c.id);
+          break;
         }
-      } else if (!existing) {
-        phoneIndex.set(key, c.id);
       }
+      seen.add(c.id);
+      phoneIndex.set(key, seen);
     }
   }
 

--- a/src/main/sync/engine.ts
+++ b/src/main/sync/engine.ts
@@ -1,3 +1,42 @@
+/**
+ * CONSISTENCY MODEL — read this before changing sync behaviour.
+ *
+ * Shared projects sync through a SQLite file sitting in a cloud-synced folder
+ * (Dropbox, OneDrive, iCloud Drive, …). There is no server and no coordination
+ * point, which is the right tradeoff for a no-server, end-to-end-encrypted
+ * tool — but it caps what this engine can guarantee. The actual contract is:
+ *
+ *   Eventually consistent, PROVIDED collaborators don't write within the same
+ *   cloud-sync upload window. Conflict resolution is last-write-wins by
+ *   wall-clock timestamp at second granularity.
+ *
+ * The assumptions behind that, none of which this engine can enforce:
+ *
+ *   1. The substrate replicates whole files and FORKS on concurrent writes —
+ *      it never merges. Two people writing inside one upload window produce a
+ *      provider-level "conflicted copy" sitting next to the real file, and the
+ *      losing side's writes are not in the file this engine later reads.
+ *      See #436 for conflicted-copy handling.
+ *   2. LWW compares wall-clock timestamps from DIFFERENT machines. A client
+ *      with a skewed clock resolves conflicts "backwards" — its stale write
+ *      beats a genuinely newer one. Second granularity also means ties are
+ *      possible and resolved arbitrarily.
+ *   3. The engine sees whatever the provider last finished downloading. It
+ *      cannot distinguish "no remote changes" from "provider is paused,
+ *      offline, or mid-upload".
+ *
+ * These are properties of the substrate, not bugs to be fixed here. #445 may
+ * change how well the engine approximates the model; the limits above survive
+ * that work. Anything relying on stronger guarantees — atomic cross-client
+ * operations, read-your-writes across machines, ordered delivery — cannot be
+ * built on this foundation without a coordination point that doesn't exist.
+ *
+ * Two things are deliberately NOT shared, and should stay that way:
+ *   - Alert-mention read state (`seen`/`dismissed`): per-user, because the
+ *     unseen badge drives *your* attention, not the team's (#448).
+ *   - The per-contact notes scratchpad: local-only by design.
+ */
+
 import { v4 as uuidv4 } from 'uuid';
 import Database from 'better-sqlite3-multiple-ciphers';
 


### PR DESCRIPTION
Closes #446

Shared projects sync through a cloud-replicated SQLite file. That's the right tradeoff for a no-server, end-to-end-encrypted tool, but it cannot deliver what people generally assume from the word "sync" — and none of the real guarantees were written down anywhere a user would find them.

The contract being documented:

> Eventually consistent, provided collaborators don't write within the same cloud-sync upload window. Concurrent writes fork the shared file at the provider level, and conflict resolution is last-write-wins by wall-clock timestamp at second granularity, so clients with skewed clocks can resolve conflicts backwards.

## Changes

**`src/main/sync/engine.ts`** — design comment at the top stating the model and the three assumptions it rests on (whole-file replication that forks rather than merges; cross-machine wall-clock LWW; no way to distinguish "no changes" from "provider paused"), so future changes are made against a documented contract. It also records what is deliberately *not* shared, and why.

**`docs/guide.html`** — plain-language version in the collaboration section. Leads with the actionable rule (work a few minutes apart), then explains *why*, then covers what a Dropbox-style "conflicted copy" next to the `.sourcerer` file actually means — including **don't delete it, it contains someone's work**, which seemed the most important practical thing a user could get wrong.

**`docs/security.html`** — new "Shared projects" section before Backups, with a sidebar entry. Separates the encryption properties (unchanged and strong — the provider stores ciphertext) from the consistency properties (weaker, and worth stating plainly), so the honest caveat doesn't read as a weakening of the encryption story.

**`README.md`** — condensed version under How it works.

## One thing beyond the issue's scope

The guide's "Not synced" note was left incomplete by #448, so I extended it to say that alert read state is personal to your own installation and marking an alert read doesn't clear it for collaborators. That decision was just made and undocumented; it belongs in the same note as the notes-scratchpad exclusion.

## Testing

Docs and comments only — no behaviour change. `npm run typecheck` clean, `npm test` 527 passed across 30 files, and I checked tag balance in both edited HTML files.