### PR TITLE
Release v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The exported file is a standard unencrypted SQLite database. Delete it when you'
 - No network requests are made except: user-configured RSS feeds, optional Wayback Machine saves (requires Archive.org S3 API keys configured in Settings), and the local HTTP server that receives screenshots from the browser extension (localhost only, one-time token auth).
 - The master password cannot be recovered. Use a passphrase — four random words are easier to remember and just as strong as a complex string.
 - The browser extension communicates only with localhost and requires explicit one-time approval in the app.
+- **Sourcerer has not yet had an independent third-party security audit.** The encryption relies on standard, well-reviewed primitives (SQLCipher, Argon2id) rather than anything custom, and the source is open for inspection — but no external reviewer has examined the implementation. An external review has been applied for. See [security.html](https://tomcardoso.github.io/sourcerer/security.html) for the full picture.
 
 ---
 

--- a/docs/security.html
+++ b/docs/security.html
@@ -123,6 +123,10 @@
             <h3>Backups in insecure locations</h3>
             <p>Backup files exported from Sourcerer are encrypted with the same password as the original database. However, if you copy a backup to an unencrypted cloud drive, USB stick, or email attachment, the encrypted file could be exfiltrated and subjected to offline password attacks. Store backups carefully.</p>
 
+            <h3>Independent security review</h3>
+            <p>Sourcerer has <strong>not yet undergone an independent third-party security audit</strong>. The cryptographic design relies on standard, well-reviewed primitives rather than anything custom — SQLCipher for encryption at rest, Argon2id for key derivation — and the complete source is open for inspection. But no external reviewer has examined the implementation to date, and the claims on this page rest on the code itself rather than on anyone else's verification of it.</p>
+            <p>An external review has been applied for. This section will be updated when that status changes. If your work carries a threat model where an unaudited tool is unacceptable, treat that as the current state of affairs rather than an oversight.</p>
+
             <h3>What Sourcerer is not</h3>
             <p>Sourcerer is not a communications tool. It does not provide secure messaging, end-to-end encrypted email, or any kind of anonymity network. It protects data at rest on your local machine — nothing more.</p>
           </section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sourcerer",
-  "version": "0.1.18",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sourcerer",
-      "version": "0.1.18",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcerer",
-  "version": "0.1.18",
+  "version": "0.2.0",
   "private": true,
   "description": "Encrypted source management for journalists",
   "author": "Tom Cardoso",


### PR DESCRIPTION
Version bump 0.1.18 → 0.2.0, plus a security-transparency addition to the docs.

## What's new

This release is mostly about protecting your data. A pre-1.0 review of the whole codebase turned up several ways information could be silently lost — nothing that had necessarily gone wrong for anyone, but each a real possibility. All of them are now fixed.

**Your data is safer**

- **Merging duplicate contacts no longer discards history.** Previously, merging two records kept only one side's interaction log, tags, news mentions and screenshots — the other side's was deleted. Everything from both contacts is now preserved.
- **Backups are now guaranteed to be readable.** Backups were copied straight from the live database file, which meant a backup taken at the exact moment the app was writing could be saved in a damaged, unrestorable state. Backups are now made from a proper snapshot. This affects automatic backups, manual exports, and moving your vault to a new location.
- **Deleting things in a shared project now sticks.** Deleted contacts, project members and log entries could reappear the next time collaborators synced. Deletions now propagate properly.
- **Changes from collaborators who work offline no longer go missing.** If someone worked offline and synced later, some of their entries could be skipped permanently. All entries now arrive.
- **Interactions logged against several shared projects reach all of them,** rather than only the first.
- **Deleting a contact now removes its screenshots** instead of leaving encrypted files behind on disk.
- **Large exports work.** Exporting or converting a project with more than 999 contacts previously failed outright.

**Shared projects**

- **Two different people who share a phone number are no longer merged into one contact.** Matching a collaborator's contact against your own now requires a matching email address; a shared office or family line isn't enough on its own.
- **Whether you've seen or dismissed a news alert is now personal to you.** Marking an alert read no longer changes anything for your collaborators, and vice versa.
- **What "sync" actually promises is now written down.** The user guide and security page explain the practical rule (avoid editing the same project at the same moment), what a Dropbox-style "conflicted copy" file means, and why you shouldn't delete one if you see it. This is a documentation change — the behaviour is unchanged — but it covers a case where you could lose work without realising.

**Fixes and smaller things**

- Duplicate detection now finds pairs it previously missed when related duplicates had been dismissed earlier.
- Reminders that came due while notifications were switched off now appear once they're switched back on.
- "Date added" filters no longer select the wrong day depending on your timezone.
- The version link in Settings now shows the correct version in installed builds.
- Calendar and contact-card exports handle long lines and unusual characters correctly.
- Development builds no longer share a database with the installed app.

**Security transparency**

The security page now states plainly that **Sourcerer has not yet had an independent third-party security audit.** The encryption uses standard, well-reviewed building blocks rather than anything homegrown, and the source is open for anyone to inspect — but no outside reviewer has examined it, and that's worth knowing when deciding whether it fits your threat model. An external review has been applied for, and this will be updated when the status changes.

Dependency security updates were also applied, clearing all resolvable advisories in the build toolchain.

## Why 0.2.0 and not 1.0.0

All four issues previously designated as 1.0 blockers are closed and there are no known open bugs, so the code itself is arguably 1.0-ready. But for a tool whose users are journalists protecting sources, a 1.0 reads as a statement about assurance, not just stability — and the independent review that would back that up is still pending. 1.0.0 is being held until it's complete, so that it means something.

## Release checklist

- `preversion` gate passed: typecheck, lint (0 errors), 531 tests across 30 files
- Tag `v0.2.0` created locally and deliberately **not** pushed — it goes up after this merges, per the release process