### PR TITLE
Give the SQLCipher-heavy test suites room on Windows CI

### DIFF
--- a/src/test/database-snapshot.test.ts
+++ b/src/test/database-snapshot.test.ts
@@ -9,7 +9,9 @@ import { initDatabase, closeDatabase, snapshotDatabase, applyCipherPragmas, getD
 // Guards against a future change silently producing an unencrypted backup.
 const SECRET = 'SNAPSHOT_TEST_SECRET_MARKER_9f3a';
 
-describe('snapshotDatabase', () => {
+// Each test builds a real file-backed encrypted database (KDF + migrations) and
+// snapshots it, so this suite is I/O and crypto heavy — ~4.4s on Windows CI.
+describe('snapshotDatabase', { timeout: 30_000 }, () => {
   let tmpDir: string;
   let keyHex: string;
 

--- a/src/test/shared-db.test.ts
+++ b/src/test/shared-db.test.ts
@@ -44,7 +44,10 @@ function tryOpen(filePath: string, keyHex: string): void {
   }
 }
 
-describe('rekeySharedDb', () => {
+// Rekeying re-encrypts every page and re-runs the PBKDF2-HMAC-SHA512 KDF, which
+// is genuinely slow — ~3s for this file on Windows CI runners even before other
+// suites compete for the same cores. The 5s default is not enough headroom there.
+describe('rekeySharedDb', { timeout: 30_000 }, () => {
   it('re-encrypts the file so the new key opens it and the old key does not', () => {
     const oldKeyHex = randomBytes(32).toString('hex');
     const newKeyHex = randomBytes(32).toString('hex');


### PR DESCRIPTION
Unblocks the v0.2.0 release build, which failed on Windows with two `rekeySharedDb` tests timing out at the 5s default.

## Diagnosis

This is **contention, not a regression** — and specifically not caused by the dependency bumps in #458:

| | v0.1.18 | v0.2.0 |
|---|---|---|
| Linux `shared-db.test.ts` | 279ms | 170ms — *faster* |
| Windows `shared-db.test.ts` | 3153ms | **15283ms** |
| Windows `database-snapshot.test.ts` | — | **4405ms** (new) |
| Windows `settings-theme.test.ts` | 25ms | 18ms — unchanged |

Unrelated Windows suites are unchanged, which rules out an unoptimized native build or a node-gyp/toolchain regression — those would have slowed everything touching SQLite.

The real cause: `shared-db.test.ts` was already running at ~3.1s on Windows against a 5s per-test ceiling — latent fragility that happened to fit. `database-snapshot.test.ts`, which I added for #437, builds a real file-backed encrypted database and snapshots it four times over (4.4s on Windows), and vitest runs test files in parallel. That extra crypto and I/O load pushed the rekey tests over the limit.

So the trigger was my own test file from the backup-snapshot work.

## Fix

An explicit 30s timeout on the two affected suites, with comments explaining why they're legitimately slow. Rekeying re-encrypts every page and re-runs PBKDF2-HMAC-SHA512; the snapshot suite does full KDF plus migrations per test. These are real costs, not hangs.

Scoped to those two suites rather than raised globally, so the 5s default stays a meaningful signal everywhere else.

## The underlying process gap

`ci.yml` runs **ubuntu-only**. Windows and macOS are exercised *only* by the release workflow, so platform-specific failures are guaranteed to surface as broken releases rather than failed PRs. This would have been caught on #459.

Not addressed here — adding Windows to CI would roughly triple CI minutes and is worth deciding deliberately. Worth filing as an issue.

## Testing

`npm test` 531 passing, `npm run typecheck` clean — both on macOS. Windows timing can't be reproduced locally, so the real verification is the next release build.