### PR TITLE
Add Gmail/Outlook CSV contact import and export

### DIFF
--- a/src/main/ipc/export.ts
+++ b/src/main/ipc/export.ts
@@ -67,7 +67,7 @@ type ExportFormat = 'sourcerer' | 'gmail' | 'outlook';
 
 // Fields common to every contact row, independent of export format. Link
 // columns keep raw per-type URL arrays (rather than a pre-joined string) so
-// gmail/outlook mapping can cap them to a fixed number of slots.
+// the gmail/outlook builders can slot them into per-format URL columns.
 interface NormalizedContactCore {
   name: string;
   organization: string;
@@ -85,36 +85,6 @@ interface NormalizedContactCore {
   other: string[];
 }
 
-interface GmailCsvRow {
-  Name: string;
-  'Given Name': string;
-  'Family Name': string;
-  'E-mail 1 - Value': string;
-  'E-mail 2 - Value': string;
-  'Phone 1 - Value': string;
-  'Phone 2 - Value': string;
-  'Organization 1 - Name': string;
-  'Organization 1 - Title': string;
-  'Website 1 - Value': string;
-  'Website 2 - Value': string;
-  Birthday: string;
-  Notes: string;
-}
-
-interface OutlookCsvRow {
-  'First Name': string;
-  'Last Name': string;
-  'E-mail Address': string;
-  'E-mail 2 Address': string;
-  'Business Phone': string;
-  'Mobile Phone': string;
-  Company: string;
-  'Job Title': string;
-  'Web Page': string;
-  Birthday: string;
-  Notes: string;
-}
-
 // Gmail/Outlook only have one free-text "name" field split into given/family
 // (or first/last) parts, unlike Sourcerer's single display name — split on
 // the first space as a best effort.
@@ -125,45 +95,58 @@ function splitName(name: string): { first: string; last: string } {
 }
 
 // Sourcerer's LinkedIn/Facebook/Instagram/X/Website/Other link types have no
-// equivalent in Gmail/Outlook's schemas, which each expose only 1-2 generic
-// URL slots. Flatten every link into that fixed slot count, prioritizing
-// LinkedIn and X since those are the profiles reporters look up most.
-function toGmailCsvRow(c: NormalizedContactCore): GmailCsvRow {
-  const { first, last } = splitName(c.name);
-  const websites = [...c.linkedin, ...c.x, ...c.website, ...c.facebook, ...c.instagram, ...c.other];
-  return {
-    Name: c.name,
-    'Given Name': first,
-    'Family Name': last,
-    'E-mail 1 - Value': c.emails[0] ?? '',
-    'E-mail 2 - Value': c.emails[1] ?? '',
-    'Phone 1 - Value': c.phones[0] ?? '',
-    'Phone 2 - Value': c.phones[1] ?? '',
-    'Organization 1 - Name': c.organization,
-    'Organization 1 - Title': c.title,
-    'Website 1 - Value': websites[0] ?? '',
-    'Website 2 - Value': websites[1] ?? '',
-    Birthday: c.dob,
-    Notes: c.notes,
-  };
+// equivalent in Gmail/Outlook's schemas, which each expose only generic URL
+// slots. Flatten every link into that slot list, prioritizing LinkedIn and X
+// since those are the profiles reporters look up most.
+function combinedWebsites(c: NormalizedContactCore): string[] {
+  return [...c.linkedin, ...c.x, ...c.website, ...c.facebook, ...c.instagram, ...c.other];
 }
 
-function toOutlookCsvRow(c: NormalizedContactCore): OutlookCsvRow {
-  const { first, last } = splitName(c.name);
-  const websites = [...c.linkedin, ...c.x, ...c.website, ...c.facebook, ...c.instagram, ...c.other];
-  return {
-    'First Name': first,
-    'Last Name': last,
-    'E-mail Address': c.emails[0] ?? '',
-    'E-mail 2 Address': c.emails[1] ?? '',
-    'Business Phone': c.phones[0] ?? '',
-    'Mobile Phone': c.phones[1] ?? '',
-    Company: c.organization,
-    'Job Title': c.title,
-    'Web Page': websites[0] ?? '',
-    Birthday: c.dob,
-    Notes: c.notes,
-  };
+// Google's contacts CSV supports an arbitrary number of "E-mail N - Value" /
+// "Phone N - Value" / "Website N - Value" columns, so widen to however many
+// slots the widest contact in this export actually needs, rather than a
+// fixed cap that would silently drop data.
+function buildGmailCsvRows(contacts: NormalizedContactCore[]): Record<string, string>[] {
+  const emailCount = Math.max(1, ...contacts.map((c) => c.emails.length));
+  const phoneCount = Math.max(1, ...contacts.map((c) => c.phones.length));
+  const websiteCount = Math.max(1, ...contacts.map((c) => combinedWebsites(c).length));
+
+  return contacts.map((c) => {
+    const { first, last } = splitName(c.name);
+    const websites = combinedWebsites(c);
+    const row: Record<string, string> = { Name: c.name, 'Given Name': first, 'Family Name': last };
+    for (let i = 0; i < emailCount; i++) row[`E-mail ${i + 1} - Value`] = c.emails[i] ?? '';
+    for (let i = 0; i < phoneCount; i++) row[`Phone ${i + 1} - Value`] = c.phones[i] ?? '';
+    row['Organization Name'] = c.organization;
+    row['Organization Title'] = c.title;
+    for (let i = 0; i < websiteCount; i++) row[`Website ${i + 1} - Value`] = websites[i] ?? '';
+    row['Birthday'] = c.dob;
+    row['Notes'] = c.notes;
+    return row;
+  });
+}
+
+// Unlike Gmail, Outlook's contact schema is a fixed set of named fields, not
+// a numbered/expandable one — it has no way to represent a 4th email or a
+// 7th phone number, so those columns are simply all the slots it has.
+const OUTLOOK_PHONE_HEADERS = ['Business Phone', 'Business Phone 2', 'Home Phone', 'Home Phone 2', 'Mobile Phone', 'Other Phone'];
+const OUTLOOK_EMAIL_HEADERS = ['E-mail Address', 'E-mail 2 Address', 'E-mail 3 Address'];
+const OUTLOOK_WEB_HEADERS = ['Web Page', 'Personal Web Page'];
+
+function buildOutlookCsvRows(contacts: NormalizedContactCore[]): Record<string, string>[] {
+  return contacts.map((c) => {
+    const { first, last } = splitName(c.name);
+    const websites = combinedWebsites(c);
+    const row: Record<string, string> = { 'First Name': first, 'Last Name': last };
+    OUTLOOK_EMAIL_HEADERS.forEach((header, i) => { row[header] = c.emails[i] ?? ''; });
+    OUTLOOK_PHONE_HEADERS.forEach((header, i) => { row[header] = c.phones[i] ?? ''; });
+    row['Company'] = c.organization;
+    row['Job Title'] = c.title;
+    OUTLOOK_WEB_HEADERS.forEach((header, i) => { row[header] = websites[i] ?? ''; });
+    row['Birthday'] = c.dob;
+    row['Notes'] = c.notes;
+    return row;
+  });
 }
 
 // SQLite's SQLITE_LIMIT_VARIABLE_NUMBER defaults to 999. Chunk IN-clause lookups
@@ -422,8 +405,8 @@ export function registerExportHandlers(): void {
         }
       }
 
-      if (format === 'gmail') return writeExportRows(normalizedRows.map(toGmailCsvRow), filePath, false);
-      if (format === 'outlook') return writeExportRows(normalizedRows.map(toOutlookCsvRow), filePath, false);
+      if (format === 'gmail') return writeExportRows(buildGmailCsvRows(normalizedRows), filePath, false);
+      if (format === 'outlook') return writeExportRows(buildOutlookCsvRows(normalizedRows), filePath, false);
 
       const rows: ExportRow[] = normalizedRows.map((r) => ({
         Name: r.name,
@@ -547,8 +530,8 @@ export function registerExportHandlers(): void {
         }
       }
 
-      if (format === 'gmail') return writeExportRows(normalizedRows.map(toGmailCsvRow), filePath, false);
-      if (format === 'outlook') return writeExportRows(normalizedRows.map(toOutlookCsvRow), filePath, false);
+      if (format === 'gmail') return writeExportRows(buildGmailCsvRows(normalizedRows), filePath, false);
+      if (format === 'outlook') return writeExportRows(buildOutlookCsvRows(normalizedRows), filePath, false);
 
       const rows: AllContactsRow[] = normalizedRows.map((r) => ({
         Name: r.name,

--- a/src/main/ipc/export.ts
+++ b/src/main/ipc/export.ts
@@ -63,6 +63,109 @@ interface AllContactsRow {
   'Interaction log': string;
 }
 
+type ExportFormat = 'sourcerer' | 'gmail' | 'outlook';
+
+// Fields common to every contact row, independent of export format. Link
+// columns keep raw per-type URL arrays (rather than a pre-joined string) so
+// gmail/outlook mapping can cap them to a fixed number of slots.
+interface NormalizedContactCore {
+  name: string;
+  organization: string;
+  title: string;
+  dob: string;
+  notes: string;
+  emails: string[];
+  phones: string[];
+  handles: string;
+  linkedin: string[];
+  facebook: string[];
+  instagram: string[];
+  x: string[];
+  website: string[];
+  other: string[];
+}
+
+interface GmailCsvRow {
+  Name: string;
+  'Given Name': string;
+  'Family Name': string;
+  'E-mail 1 - Value': string;
+  'E-mail 2 - Value': string;
+  'Phone 1 - Value': string;
+  'Phone 2 - Value': string;
+  'Organization 1 - Name': string;
+  'Organization 1 - Title': string;
+  'Website 1 - Value': string;
+  'Website 2 - Value': string;
+  Birthday: string;
+  Notes: string;
+}
+
+interface OutlookCsvRow {
+  'First Name': string;
+  'Last Name': string;
+  'E-mail Address': string;
+  'E-mail 2 Address': string;
+  'Business Phone': string;
+  'Mobile Phone': string;
+  Company: string;
+  'Job Title': string;
+  'Web Page': string;
+  Birthday: string;
+  Notes: string;
+}
+
+// Gmail/Outlook only have one free-text "name" field split into given/family
+// (or first/last) parts, unlike Sourcerer's single display name — split on
+// the first space as a best effort.
+function splitName(name: string): { first: string; last: string } {
+  const spaceIdx = name.indexOf(' ');
+  if (spaceIdx < 0) return { first: name, last: '' };
+  return { first: name.slice(0, spaceIdx), last: name.slice(spaceIdx + 1) };
+}
+
+// Sourcerer's LinkedIn/Facebook/Instagram/X/Website/Other link types have no
+// equivalent in Gmail/Outlook's schemas, which each expose only 1-2 generic
+// URL slots. Flatten every link into that fixed slot count, prioritizing
+// LinkedIn and X since those are the profiles reporters look up most.
+function toGmailCsvRow(c: NormalizedContactCore): GmailCsvRow {
+  const { first, last } = splitName(c.name);
+  const websites = [...c.linkedin, ...c.x, ...c.website, ...c.facebook, ...c.instagram, ...c.other];
+  return {
+    Name: c.name,
+    'Given Name': first,
+    'Family Name': last,
+    'E-mail 1 - Value': c.emails[0] ?? '',
+    'E-mail 2 - Value': c.emails[1] ?? '',
+    'Phone 1 - Value': c.phones[0] ?? '',
+    'Phone 2 - Value': c.phones[1] ?? '',
+    'Organization 1 - Name': c.organization,
+    'Organization 1 - Title': c.title,
+    'Website 1 - Value': websites[0] ?? '',
+    'Website 2 - Value': websites[1] ?? '',
+    Birthday: c.dob,
+    Notes: c.notes,
+  };
+}
+
+function toOutlookCsvRow(c: NormalizedContactCore): OutlookCsvRow {
+  const { first, last } = splitName(c.name);
+  const websites = [...c.linkedin, ...c.x, ...c.website, ...c.facebook, ...c.instagram, ...c.other];
+  return {
+    'First Name': first,
+    'Last Name': last,
+    'E-mail Address': c.emails[0] ?? '',
+    'E-mail 2 Address': c.emails[1] ?? '',
+    'Business Phone': c.phones[0] ?? '',
+    'Mobile Phone': c.phones[1] ?? '',
+    Company: c.organization,
+    'Job Title': c.title,
+    'Web Page': websites[0] ?? '',
+    Birthday: c.dob,
+    Notes: c.notes,
+  };
+}
+
 // SQLite's SQLITE_LIMIT_VARIABLE_NUMBER defaults to 999. Chunk IN-clause lookups
 // to stay safely below that limit; concatenates results across chunks.
 const SQLITE_IN_CHUNK_SIZE = 500;
@@ -182,7 +285,7 @@ export function registerExportHandlers(): void {
     'export:project',
     async (
       event,
-      { projectId, mode, contactIds: filterIds }: { projectId: string; mode: ExportMode; contactIds?: string[] },
+      { projectId, mode, contactIds: filterIds, format = 'sourcerer' }: { projectId: string; mode: ExportMode; contactIds?: string[]; format?: ExportFormat },
     ): Promise<{ success: boolean; error?: string }> => {
       const win = BrowserWindow.fromWebContents(event.sender);
       const db = getDatabase();
@@ -192,14 +295,22 @@ export function registerExportHandlers(): void {
         | undefined;
       if (!project) return { success: false, error: 'Project not found.' };
 
-      const saveResult = await dialog.showSaveDialog(win ?? BrowserWindow.getFocusedWindow()!, {
-        title: 'Export project contacts',
-        defaultPath: `${project.name.replace(/[^a-z0-9]/gi, '-').toLowerCase()}-contacts-${filenameDateStamp()}`,
-        filters: [
-          { name: 'CSV', extensions: ['csv'] },
-          { name: 'Excel', extensions: ['xlsx'] },
-        ],
-      });
+      const safeProjectName = project.name.replace(/[^a-z0-9]/gi, '-').toLowerCase();
+      // Gmail/Outlook only import from CSV, not XLSX, so skip the format choice.
+      const saveResult = format === 'sourcerer'
+        ? await dialog.showSaveDialog(win ?? BrowserWindow.getFocusedWindow()!, {
+            title: 'Export project contacts',
+            defaultPath: `${safeProjectName}-contacts-${filenameDateStamp()}`,
+            filters: [
+              { name: 'CSV', extensions: ['csv'] },
+              { name: 'Excel', extensions: ['xlsx'] },
+            ],
+          })
+        : await dialog.showSaveDialog(win ?? BrowserWindow.getFocusedWindow()!, {
+            title: `Export project contacts (${format === 'gmail' ? 'Gmail' : 'Outlook'} CSV)`,
+            defaultPath: `${safeProjectName}-contacts-${format}-${filenameDateStamp()}.csv`,
+            filters: [{ name: 'CSV', extensions: ['csv'] }],
+          });
       if (saveResult.canceled || !saveResult.filePath) return { success: false };
 
       const filePath = saveResult.filePath;
@@ -241,7 +352,9 @@ export function registerExportHandlers(): void {
       const { emails: emailsByContact, phones: phonesByContact, links: linksByContact, handles: handlesByContact } = fetchContactSubTables(db, contactIds);
 
       type LogRow = { id: string; membership_id: string; reporter_name: string; body: string; created_at: number };
-      const rows: ExportRow[] = [];
+      const normalizedRows: (NormalizedContactCore & {
+        reporter: string; theme: string; priority: string; status: string; firstOutreach: string; interactionLog: string;
+      })[] = [];
 
       for (let ci = 0; ci < memberships.length; ci += EXPORT_CHUNK_SIZE) {
         const chunk = memberships.slice(ci, ci + EXPORT_CHUNK_SIZE);
@@ -274,40 +387,66 @@ export function registerExportHandlers(): void {
         }
 
         for (const m of chunk) {
-          const emails = (emailsByContact.get(m.contact_id) ?? []).join('; ');
-          const phones = (phonesByContact.get(m.contact_id) ?? []).join('; ');
+          const emails = emailsByContact.get(m.contact_id) ?? [];
+          const phones = phonesByContact.get(m.contact_id) ?? [];
           const handles = (handlesByContact.get(m.contact_id) ?? []).map((h) => `${h.type}: ${h.handle}`).join('; ');
           const links = linksByContact.get(m.contact_id) ?? [];
-          const byType = (type: string) => links.filter((l) => l.type === type).map((l) => l.url).join('; ');
+          const byType = (type: string) => links.filter((l) => l.type === type).map((l) => l.url);
           const logStrings = logsByMembership.get(m.membership_id) ?? [];
           const interactionLog = mode === 'full' ? logStrings.join('\n') : '';
           logsByMembership.delete(m.membership_id);
-          rows.push({
-            Name: m.name,
-            Organization: m.organization ?? '',
-            Title: m.title ?? '',
-            DOB: m.dob ?? '',
-            Emails: emails,
-            Phones: phones,
-            Handles: handles,
-            LinkedIn: byType('linkedin'),
-            Facebook: byType('facebook'),
-            Instagram: byType('instagram'),
-            X: byType('x'),
-            Website: byType('website'),
-            'Other links': byType('other'),
-            Notes: mode === 'full' ? (m.notes ?? '') : '',
-            Reporter: m.reporter_name,
-            Theme: m.theme ?? '',
-            Priority: m.priority ?? '',
-            Status: m.status ?? '',
-            'First outreach': m.first_log_at
+          normalizedRows.push({
+            name: m.name,
+            organization: m.organization ?? '',
+            title: m.title ?? '',
+            dob: m.dob ?? '',
+            emails,
+            phones,
+            handles,
+            linkedin: byType('linkedin'),
+            facebook: byType('facebook'),
+            instagram: byType('instagram'),
+            x: byType('x'),
+            website: byType('website'),
+            other: byType('other'),
+            notes: mode === 'full' ? (m.notes ?? '') : '',
+            reporter: m.reporter_name,
+            theme: m.theme ?? '',
+            priority: m.priority ?? '',
+            status: m.status ?? '',
+            firstOutreach: m.first_log_at
               ? new Date(m.first_log_at * 1000).toLocaleDateString()
               : '',
-            'Interaction log': interactionLog,
+            interactionLog,
           });
         }
       }
+
+      if (format === 'gmail') return writeExportRows(normalizedRows.map(toGmailCsvRow), filePath, false);
+      if (format === 'outlook') return writeExportRows(normalizedRows.map(toOutlookCsvRow), filePath, false);
+
+      const rows: ExportRow[] = normalizedRows.map((r) => ({
+        Name: r.name,
+        Organization: r.organization,
+        Title: r.title,
+        DOB: r.dob,
+        Emails: r.emails.join('; '),
+        Phones: r.phones.join('; '),
+        Handles: r.handles,
+        LinkedIn: r.linkedin.join('; '),
+        Facebook: r.facebook.join('; '),
+        Instagram: r.instagram.join('; '),
+        X: r.x.join('; '),
+        Website: r.website.join('; '),
+        'Other links': r.other.join('; '),
+        Notes: r.notes,
+        Reporter: r.reporter,
+        Theme: r.theme,
+        Priority: r.priority,
+        Status: r.status,
+        'First outreach': r.firstOutreach,
+        'Interaction log': r.interactionLog,
+      }));
 
       return writeExportRows(rows, filePath, isXlsx);
     },
@@ -315,18 +454,26 @@ export function registerExportHandlers(): void {
 
   ipcMain.handle(
     'export:all-contacts',
-    async (event, { contactIds: filterIds }: { contactIds?: string[] } = {}): Promise<{ success: boolean; error?: string }> => {
+    async (event, { contactIds: filterIds, format = 'sourcerer' }: { contactIds?: string[]; format?: ExportFormat } = {}): Promise<{ success: boolean; error?: string }> => {
       const win = BrowserWindow.fromWebContents(event.sender);
       const db = getDatabase();
 
-      const saveResult = await dialog.showSaveDialog(win ?? BrowserWindow.getFocusedWindow()!, {
-        title: 'Export contacts',
-        defaultPath: filterIds?.length ? `selected-contacts-${filenameDateStamp()}` : `all-contacts-${filenameDateStamp()}`,
-        filters: [
-          { name: 'CSV', extensions: ['csv'] },
-          { name: 'Excel', extensions: ['xlsx'] },
-        ],
-      });
+      const baseName = filterIds?.length ? 'selected-contacts' : 'all-contacts';
+      // Gmail/Outlook only import from CSV, not XLSX, so skip the format choice.
+      const saveResult = format === 'sourcerer'
+        ? await dialog.showSaveDialog(win ?? BrowserWindow.getFocusedWindow()!, {
+            title: 'Export contacts',
+            defaultPath: `${baseName}-${filenameDateStamp()}`,
+            filters: [
+              { name: 'CSV', extensions: ['csv'] },
+              { name: 'Excel', extensions: ['xlsx'] },
+            ],
+          })
+        : await dialog.showSaveDialog(win ?? BrowserWindow.getFocusedWindow()!, {
+            title: `Export contacts (${format === 'gmail' ? 'Gmail' : 'Outlook'} CSV)`,
+            defaultPath: `${baseName}-${format}-${filenameDateStamp()}.csv`,
+            filters: [{ name: 'CSV', extensions: ['csv'] }],
+          });
       if (saveResult.canceled || !saveResult.filePath) return { success: false };
 
       const filePath = saveResult.filePath;
@@ -345,7 +492,7 @@ export function registerExportHandlers(): void {
       const { emails: emailsById, phones: phonesById, links: linksById, handles: handlesById } = fetchContactSubTables(db, allContactIds);
 
       type LogRow2 = { id: string; contact_id: string; reporter_name: string; body: string; created_at: number };
-      const rows: AllContactsRow[] = [];
+      const normalizedRows: (NormalizedContactCore & { interactionLog: string })[] = [];
 
       for (let ci2 = 0; ci2 < contacts.length; ci2 += EXPORT_CHUNK_SIZE) {
         const chunk2 = contacts.slice(ci2, ci2 + EXPORT_CHUNK_SIZE);
@@ -377,28 +524,49 @@ export function registerExportHandlers(): void {
 
         for (const c of chunk2) {
           const links = linksById.get(c.id) ?? [];
-          const byType2 = (type: string) => links.filter((l) => l.type === type).map((l) => l.url).join('; ');
+          const byType2 = (type: string) => links.filter((l) => l.type === type).map((l) => l.url);
           const interactionLog = (logsByContactId.get(c.id) ?? []).join('\n');
           logsByContactId.delete(c.id);
-          rows.push({
-            Name: c.name,
-            Organization: c.organization ?? '',
-            Title: c.title ?? '',
-            DOB: c.dob ?? '',
-            Emails: (emailsById.get(c.id) ?? []).join('; '),
-            Phones: (phonesById.get(c.id) ?? []).join('; '),
-            Handles: (handlesById.get(c.id) ?? []).map((h) => `${h.type}: ${h.handle}`).join('; '),
-            LinkedIn: byType2('linkedin'),
-            Facebook: byType2('facebook'),
-            Instagram: byType2('instagram'),
-            X: byType2('x'),
-            Website: byType2('website'),
-            'Other links': byType2('other'),
-            Notes: c.notes ?? '',
-            'Interaction log': interactionLog,
+          normalizedRows.push({
+            name: c.name,
+            organization: c.organization ?? '',
+            title: c.title ?? '',
+            dob: c.dob ?? '',
+            emails: emailsById.get(c.id) ?? [],
+            phones: phonesById.get(c.id) ?? [],
+            handles: (handlesById.get(c.id) ?? []).map((h) => `${h.type}: ${h.handle}`).join('; '),
+            linkedin: byType2('linkedin'),
+            facebook: byType2('facebook'),
+            instagram: byType2('instagram'),
+            x: byType2('x'),
+            website: byType2('website'),
+            other: byType2('other'),
+            notes: c.notes ?? '',
+            interactionLog,
           });
         }
       }
+
+      if (format === 'gmail') return writeExportRows(normalizedRows.map(toGmailCsvRow), filePath, false);
+      if (format === 'outlook') return writeExportRows(normalizedRows.map(toOutlookCsvRow), filePath, false);
+
+      const rows: AllContactsRow[] = normalizedRows.map((r) => ({
+        Name: r.name,
+        Organization: r.organization,
+        Title: r.title,
+        DOB: r.dob,
+        Emails: r.emails.join('; '),
+        Phones: r.phones.join('; '),
+        Handles: r.handles,
+        LinkedIn: r.linkedin.join('; '),
+        Facebook: r.facebook.join('; '),
+        Instagram: r.instagram.join('; '),
+        X: r.x.join('; '),
+        Website: r.website.join('; '),
+        'Other links': r.other.join('; '),
+        Notes: r.notes,
+        'Interaction log': r.interactionLog,
+      }));
 
       return writeExportRows(rows, filePath, isXlsx);
     },

--- a/src/main/ipc/import.ts
+++ b/src/main/ipc/import.ts
@@ -65,6 +65,129 @@ export function parseCsv(text: string): string[][] {
   return result;
 }
 
+const REMAPPED_HEADERS = ['Name', 'Organization', 'Title', 'DOB', 'Notes', 'Email', 'Phone', 'LinkedIn', 'X', 'Website'];
+
+// Google/Outlook birthdays show up as ISO dates, Google's "year unknown" form
+// (--MM-DD), or Outlook's locale date (M/D/YYYY). Anything else is discarded,
+// same as a malformed DOB in a native Sourcerer CSV.
+function normalizeBirthday(value: string): string {
+  const v = value.trim();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(v)) return v;
+  const mdy = v.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (mdy) {
+    const [, m, d, y] = mdy;
+    return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`;
+  }
+  return '';
+}
+
+// Google/Outlook exports lump social profile URLs in with generic "website"
+// fields. Route LinkedIn/X URLs to their own columns so they land in the
+// contact_links rows processImportRows already knows how to type correctly.
+function splitSocialLinks(urls: string[]): { linkedin: string; x: string; websites: string[] } {
+  let linkedin = '';
+  let x = '';
+  const websites: string[] = [];
+  for (const url of urls) {
+    const lower = url.toLowerCase();
+    if (!linkedin && lower.includes('linkedin.com')) linkedin = url;
+    else if (!x && (lower.includes('twitter.com') || lower.includes('x.com'))) x = url;
+    else websites.push(url);
+  }
+  return { linkedin, x, websites };
+}
+
+function colsMatching(headerRow: string[], pattern: RegExp): number[] {
+  const idxs: number[] = [];
+  headerRow.forEach((h, i) => { if (pattern.test(h.trim().toLowerCase())) idxs.push(i); });
+  return idxs;
+}
+
+type CsvSource = 'gmail' | 'outlook' | 'generic';
+
+function detectCsvSource(headerRow: string[]): CsvSource {
+  const set = new Set(headerRow.map((h) => h.trim().toLowerCase()));
+  if (set.has('e-mail 1 - value')) return 'gmail';
+  if (set.has('e-mail address') && set.has('first name') && set.has('last name')) return 'outlook';
+  return 'generic';
+}
+
+function remapGmailRows(rows: string[][]): string[][] {
+  const headerRow = rows[0];
+  const header = headerRow.map((h) => h.trim().toLowerCase());
+  const idx = (name: string) => header.indexOf(name);
+  const emailIdxs = colsMatching(headerRow, /^e-mail \d+ - value$/);
+  const phoneIdxs = colsMatching(headerRow, /^phone \d+ - value$/);
+  const websiteIdxs = colsMatching(headerRow, /^website \d+ - value$/);
+
+  const nameIdx = idx('name');
+  const givenIdx = idx('given name');
+  const familyIdx = idx('family name');
+  const orgIdx = idx('organization 1 - name');
+  const titleIdx = idx('organization 1 - title');
+  const notesIdx = idx('notes');
+  const bdayIdx = idx('birthday');
+
+  const out: string[][] = [REMAPPED_HEADERS];
+  for (const row of rows.slice(1)) {
+    const get = (i: number) => (i >= 0 ? (row[i] ?? '').trim() : '');
+    const name = get(nameIdx) || [get(givenIdx), get(familyIdx)].filter(Boolean).join(' ').trim();
+    const emails = emailIdxs.map(get).filter(Boolean);
+    const phones = phoneIdxs.map(get).filter(Boolean);
+    const { linkedin, x, websites } = splitSocialLinks(websiteIdxs.map(get).filter(Boolean));
+
+    out.push([
+      name, get(orgIdx), get(titleIdx), normalizeBirthday(get(bdayIdx)), get(notesIdx),
+      emails.join(';'), phones.join(';'), linkedin, x, websites.join(';'),
+    ]);
+  }
+  return out;
+}
+
+function remapOutlookRows(rows: string[][]): string[][] {
+  const headerRow = rows[0];
+  const header = headerRow.map((h) => h.trim().toLowerCase());
+  const idx = (name: string) => header.indexOf(name);
+
+  const firstIdx = idx('first name');
+  const lastIdx = idx('last name');
+  const companyIdx = idx('company');
+  const jobTitleIdx = idx('job title');
+  const notesIdx = idx('notes');
+  const bdayIdx = idx('birthday');
+  const webIdx = idx('web page');
+  const emailIdxs = ['e-mail address', 'e-mail 2 address', 'e-mail 3 address'].map(idx).filter((i) => i >= 0);
+  const phoneIdxs = ['business phone', 'business phone 2', 'home phone', 'home phone 2', 'mobile phone', 'other phone']
+    .map(idx)
+    .filter((i) => i >= 0);
+
+  const out: string[][] = [REMAPPED_HEADERS];
+  for (const row of rows.slice(1)) {
+    const get = (i: number) => (i >= 0 ? (row[i] ?? '').trim() : '');
+    const name = [get(firstIdx), get(lastIdx)].filter(Boolean).join(' ').trim();
+    const emails = emailIdxs.map(get).filter(Boolean);
+    const phones = phoneIdxs.map(get).filter(Boolean);
+    const { linkedin, x, websites } = splitSocialLinks(webIdx >= 0 && get(webIdx) ? [get(webIdx)] : []);
+
+    out.push([
+      name, get(companyIdx), get(jobTitleIdx), normalizeBirthday(get(bdayIdx)), get(notesIdx),
+      emails.join(';'), phones.join(';'), linkedin, x, websites.join(';'),
+    ]);
+  }
+  return out;
+}
+
+// Detects Gmail's and Outlook's contact-export CSV header shapes and remaps
+// them onto Sourcerer's own column vocabulary so processImportRows doesn't
+// need to know about either format. Anything else passes through unchanged.
+export function remapKnownCsvFormat(rows: string[][]): string[][] {
+  if (rows.length === 0) return rows;
+  const source = detectCsvSource(rows[0]);
+  if (source === 'gmail') return remapGmailRows(rows);
+  if (source === 'outlook') return remapOutlookRows(rows);
+  return rows;
+}
+
 export interface VcfContact {
   name: string;
   organization: string | null;
@@ -424,7 +547,7 @@ export function registerImportHandlers(): void {
       if (stat.size > 50 * 1024 * 1024) return { imported: 0, skipped: [], cancelled: false, error: 'File too large (max 50 MB).' };
 
       const content = await fs.readFile(filePaths[0], 'utf-8');
-      const rows = parseCsv(content);
+      const rows = remapKnownCsvFormat(parseCsv(content));
       const db = getDatabase();
 
       const { phone_country } = db

--- a/src/main/ipc/import.ts
+++ b/src/main/ipc/import.ts
@@ -103,6 +103,15 @@ function colsMatching(headerRow: string[], pattern: RegExp): number[] {
   return idxs;
 }
 
+// Returns the index of the first header name (lowercase) found among candidates.
+function firstIdx(header: string[], names: string[]): number {
+  for (const name of names) {
+    const i = header.indexOf(name);
+    if (i >= 0) return i;
+  }
+  return -1;
+}
+
 type CsvSource = 'gmail' | 'outlook' | 'generic';
 
 function detectCsvSource(headerRow: string[]): CsvSource {
@@ -112,21 +121,44 @@ function detectCsvSource(headerRow: string[]): CsvSource {
   return 'generic';
 }
 
-function remapGmailRows(rows: string[][]): string[][] {
+export interface CsvRemapResult {
+  rows: string[][];
+  droppedFields: string[];
+}
+
+// Source columns that carried no data anywhere in the file don't need
+// flagging — only report columns Sourcerer actually had to throw away.
+// "- Type"/"- Label" companion columns (e.g. "Phone 1 - Type": "Mobile") are
+// excluded too: they're just a qualifier on data that *was* imported, not a
+// distinct chunk of information worth calling out on its own.
+function unusedColumnsWithData(headerRow: string[], dataRows: string[][], consumedIdxs: number[]): string[] {
+  const consumed = new Set(consumedIdxs);
+  return headerRow
+    .map((h, i) => ({ h, i }))
+    .filter(({ i }) => !consumed.has(i))
+    .filter(({ h }) => !/ - (type|label)$/i.test(h.trim()))
+    .filter(({ i }) => dataRows.some((row) => (row[i] ?? '').trim() !== ''))
+    .map(({ h }) => h.trim());
+}
+
+function remapGmailRows(rows: string[][]): CsvRemapResult {
   const headerRow = rows[0];
   const header = headerRow.map((h) => h.trim().toLowerCase());
-  const idx = (name: string) => header.indexOf(name);
   const emailIdxs = colsMatching(headerRow, /^e-mail \d+ - value$/);
   const phoneIdxs = colsMatching(headerRow, /^phone \d+ - value$/);
   const websiteIdxs = colsMatching(headerRow, /^website \d+ - value$/);
 
-  const nameIdx = idx('name');
-  const givenIdx = idx('given name');
-  const familyIdx = idx('family name');
-  const orgIdx = idx('organization 1 - name');
-  const titleIdx = idx('organization 1 - title');
-  const notesIdx = idx('notes');
-  const bdayIdx = idx('birthday');
+  // Google's current contacts CSV (both its own import template and export)
+  // uses "First Name"/"Last Name" and unprefixed "Organization Name"/"Title";
+  // an older export variant used "Given Name"/"Family Name" and
+  // "Organization 1 - Name"/"Title". Support both.
+  const nameIdx = firstIdx(header, ['name']);
+  const givenIdx = firstIdx(header, ['given name', 'first name']);
+  const familyIdx = firstIdx(header, ['family name', 'last name']);
+  const orgIdx = firstIdx(header, ['organization name', 'organization 1 - name']);
+  const titleIdx = firstIdx(header, ['organization title', 'organization 1 - title']);
+  const notesIdx = firstIdx(header, ['notes']);
+  const bdayIdx = firstIdx(header, ['birthday']);
 
   const out: string[][] = [REMAPPED_HEADERS];
   for (const row of rows.slice(1)) {
@@ -141,21 +173,24 @@ function remapGmailRows(rows: string[][]): string[][] {
       emails.join(';'), phones.join(';'), linkedin, x, websites.join(';'),
     ]);
   }
-  return out;
+
+  const consumedIdxs = [nameIdx, givenIdx, familyIdx, orgIdx, titleIdx, notesIdx, bdayIdx, ...emailIdxs, ...phoneIdxs, ...websiteIdxs];
+  const droppedFields = unusedColumnsWithData(headerRow, rows.slice(1), consumedIdxs);
+  return { rows: out, droppedFields };
 }
 
-function remapOutlookRows(rows: string[][]): string[][] {
+function remapOutlookRows(rows: string[][]): CsvRemapResult {
   const headerRow = rows[0];
   const header = headerRow.map((h) => h.trim().toLowerCase());
   const idx = (name: string) => header.indexOf(name);
 
-  const firstIdx = idx('first name');
+  const firstNameIdx = idx('first name');
   const lastIdx = idx('last name');
   const companyIdx = idx('company');
   const jobTitleIdx = idx('job title');
   const notesIdx = idx('notes');
   const bdayIdx = idx('birthday');
-  const webIdx = idx('web page');
+  const webIdxs = [idx('web page'), idx('personal web page')].filter((i) => i >= 0);
   const emailIdxs = ['e-mail address', 'e-mail 2 address', 'e-mail 3 address'].map(idx).filter((i) => i >= 0);
   const phoneIdxs = ['business phone', 'business phone 2', 'home phone', 'home phone 2', 'mobile phone', 'other phone']
     .map(idx)
@@ -164,28 +199,33 @@ function remapOutlookRows(rows: string[][]): string[][] {
   const out: string[][] = [REMAPPED_HEADERS];
   for (const row of rows.slice(1)) {
     const get = (i: number) => (i >= 0 ? (row[i] ?? '').trim() : '');
-    const name = [get(firstIdx), get(lastIdx)].filter(Boolean).join(' ').trim();
+    const name = [get(firstNameIdx), get(lastIdx)].filter(Boolean).join(' ').trim();
     const emails = emailIdxs.map(get).filter(Boolean);
     const phones = phoneIdxs.map(get).filter(Boolean);
-    const { linkedin, x, websites } = splitSocialLinks(webIdx >= 0 && get(webIdx) ? [get(webIdx)] : []);
+    const { linkedin, x, websites } = splitSocialLinks(webIdxs.map(get).filter(Boolean));
 
     out.push([
       name, get(companyIdx), get(jobTitleIdx), normalizeBirthday(get(bdayIdx)), get(notesIdx),
       emails.join(';'), phones.join(';'), linkedin, x, websites.join(';'),
     ]);
   }
-  return out;
+
+  const consumedIdxs = [firstNameIdx, lastIdx, companyIdx, jobTitleIdx, notesIdx, bdayIdx, ...webIdxs, ...emailIdxs, ...phoneIdxs];
+  const droppedFields = unusedColumnsWithData(headerRow, rows.slice(1), consumedIdxs);
+  return { rows: out, droppedFields };
 }
 
 // Detects Gmail's and Outlook's contact-export CSV header shapes and remaps
 // them onto Sourcerer's own column vocabulary so processImportRows doesn't
 // need to know about either format. Anything else passes through unchanged.
-export function remapKnownCsvFormat(rows: string[][]): string[][] {
-  if (rows.length === 0) return rows;
+// droppedFields lists source columns that carried data but have no home in
+// Sourcerer's contact model (addresses, spouse, custom fields, etc.).
+export function remapKnownCsvFormat(rows: string[][]): CsvRemapResult {
+  if (rows.length === 0) return { rows, droppedFields: [] };
   const source = detectCsvSource(rows[0]);
   if (source === 'gmail') return remapGmailRows(rows);
   if (source === 'outlook') return remapOutlookRows(rows);
-  return rows;
+  return { rows, droppedFields: [] };
 }
 
 export interface VcfContact {
@@ -547,7 +587,7 @@ export function registerImportHandlers(): void {
       if (stat.size > 50 * 1024 * 1024) return { imported: 0, skipped: [], cancelled: false, error: 'File too large (max 50 MB).' };
 
       const content = await fs.readFile(filePaths[0], 'utf-8');
-      const rows = remapKnownCsvFormat(parseCsv(content));
+      const { rows, droppedFields } = remapKnownCsvFormat(parseCsv(content));
       const db = getDatabase();
 
       const { phone_country } = db
@@ -571,7 +611,8 @@ export function registerImportHandlers(): void {
         }
       }
 
-      return processImportRows(rows, db, { projectId, phoneCountry: phone_country, reporterEmail, reporterName });
+      const result = processImportRows(rows, db, { projectId, phoneCountry: phone_country, reporterEmail, reporterName });
+      return droppedFields.length ? { ...result, droppedFields } : result;
     },
   );
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -225,8 +225,8 @@ const sourcererApi = {
   setTheme: (mode: ThemeMode): Promise<User> => ipcRenderer.invoke('settings:set-theme', mode),
 
   // Export
-  exportProject: (projectId: string, mode: 'full' | 'sanitized', contactIds?: string[]): Promise<{ success: boolean; error?: string }> =>
-    ipcRenderer.invoke('export:project', { projectId, mode, contactIds }),
+  exportProject: (projectId: string, mode: 'full' | 'sanitized', contactIds?: string[], format?: 'sourcerer' | 'gmail' | 'outlook'): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('export:project', { projectId, mode, contactIds, format }),
   exportBackup: (password: string): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('backup:export', { password }),
   restoreBackup: (password: string): Promise<{ success: boolean; canceled?: boolean; error?: string }> =>
@@ -342,8 +342,8 @@ const sourcererApi = {
     ipcRenderer.invoke('export:vcard-project', { projectId, contactIds }),
   exportVCardAllContacts: (contactIds?: string[]): Promise<void> =>
     ipcRenderer.invoke('export:vcard-all-contacts', { contactIds }),
-  exportAllContacts: (contactIds?: string[]): Promise<{ success: boolean; error?: string }> =>
-    ipcRenderer.invoke('export:all-contacts', { contactIds }),
+  exportAllContacts: (contactIds?: string[], format?: 'sourcerer' | 'gmail' | 'outlook'): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('export:all-contacts', { contactIds, format }),
 
   // CSV / vCard import
   importCsv: (data: { projectId?: string }): Promise<ImportResult> =>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -151,7 +151,7 @@ declare global {
       setTheme: (mode: ThemeMode) => Promise<User>;
 
       // Export
-      exportProject: (projectId: string, mode: 'full' | 'sanitized', contactIds?: string[]) => Promise<{ success: boolean; error?: string }>;
+      exportProject: (projectId: string, mode: 'full' | 'sanitized', contactIds?: string[], format?: 'sourcerer' | 'gmail' | 'outlook') => Promise<{ success: boolean; error?: string }>;
 
       // Sync
       triggerSync: (projectId: string) => Promise<SyncStatusEvent>;
@@ -195,7 +195,7 @@ declare global {
       exportVCardContact: (contactId: string) => Promise<void>;
       exportVCardProject: (projectId: string, contactIds?: string[]) => Promise<void>;
       exportVCardAllContacts: (contactIds?: string[]) => Promise<void>;
-      exportAllContacts: (contactIds?: string[]) => Promise<{ success: boolean; error?: string }>;
+      exportAllContacts: (contactIds?: string[], format?: 'sourcerer' | 'gmail' | 'outlook') => Promise<{ success: boolean; error?: string }>;
 
       // CSV / vCard import
       importCsv: (data: { projectId?: string }) => Promise<ImportResult>;

--- a/src/renderer/src/views/AllContacts.tsx
+++ b/src/renderer/src/views/AllContacts.tsx
@@ -84,10 +84,10 @@ export default function AllContacts({ projects, user, openContactId, onOpenConta
   useClickOutside(bulkProjectMenuRef, handleCloseBulkProjectMenu, { isOpen: bulkProjectMenuOpen });
   useClickOutside(exportMenuRef, handleCloseExportMenu, { isOpen: showExportMenu });
 
-  async function handleExportAll() {
+  async function handleExportAll(format?: 'gmail' | 'outlook') {
     setShowExportMenu(false);
     setExporting(true);
-    await window.sourcerer.exportAllContacts(checkedIds.size > 0 ? [...checkedIds] : undefined);
+    await window.sourcerer.exportAllContacts(checkedIds.size > 0 ? [...checkedIds] : undefined, format);
     setExporting(false);
   }
 
@@ -330,7 +330,7 @@ export default function AllContacts({ projects, user, openContactId, onOpenConta
               </button>
               {showExportMenu && (
                 <div className="export-menu">
-                  <button className="export-menu-item" onClick={handleExportAll}>
+                  <button className="export-menu-item" onClick={() => handleExportAll()}>
                     <span className="export-menu-label">Export as CSV / Excel</span>
                     <span className="export-menu-desc">Name, organization, emails, phones, notes</span>
                   </button>
@@ -340,6 +340,14 @@ export default function AllContacts({ projects, user, openContactId, onOpenConta
                   >
                     <span className="export-menu-label">Export as vCard</span>
                     <span className="export-menu-desc">All contacts as a .vcf file for address books</span>
+                  </button>
+                  <button className="export-menu-item" onClick={() => handleExportAll('gmail')}>
+                    <span className="export-menu-label">Export as Gmail CSV</span>
+                    <span className="export-menu-desc">Ready to re-import into Google Contacts</span>
+                  </button>
+                  <button className="export-menu-item" onClick={() => handleExportAll('outlook')}>
+                    <span className="export-menu-label">Export as Outlook CSV</span>
+                    <span className="export-menu-desc">Ready to re-import into Outlook contacts</span>
                   </button>
                 </div>
               )}

--- a/src/renderer/src/views/ImportCsvModal.tsx
+++ b/src/renderer/src/views/ImportCsvModal.tsx
@@ -57,8 +57,9 @@ export default function ImportCsvModal({ projects, preselectedProjectId, onCompl
         {format === 'csv' ? (
           <>
             <p className="form-description">
-              Import a spreadsheet of contacts. Your file must use the following column headers
-              (extra columns are ignored):
+              Import a spreadsheet of contacts. CSV files exported from Gmail or Outlook contacts
+              are detected automatically. Otherwise, your file must use the following column
+              headers (extra columns are ignored):
             </p>
 
             <div className="icm-columns">

--- a/src/renderer/src/views/ImportResultModal.css
+++ b/src/renderer/src/views/ImportResultModal.css
@@ -69,3 +69,10 @@
   color: var(--color-danger);
   margin: 0 0 10px;
 }
+
+.ir-dropped-note {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  line-height: 1.55;
+  margin: 0;
+}

--- a/src/renderer/src/views/ImportResultModal.tsx
+++ b/src/renderer/src/views/ImportResultModal.tsx
@@ -62,6 +62,14 @@ export default function ImportResultModal({ result, onClose }: Props) {
               )}
             </div>
           )}
+
+          {!!result.droppedFields?.length && (
+            <p className="ir-dropped-note">
+              Your file included {result.droppedFields.length === 1 ? 'a field' : 'fields'} Sourcerer
+              doesn&apos;t track, so {result.droppedFields.length === 1 ? 'it wasn\'t' : 'they weren\'t'} imported:{' '}
+              {result.droppedFields.join(', ')}.
+            </p>
+          )}
         </>
       )}
 

--- a/src/renderer/src/views/ProjectView.tsx
+++ b/src/renderer/src/views/ProjectView.tsx
@@ -199,11 +199,11 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
     handleSyncNow();
   }
 
-  async function handleExport(mode: 'full' | 'sanitized') {
+  async function handleExport(mode: 'full' | 'sanitized', format?: 'gmail' | 'outlook') {
     if (!project) return;
     setShowExportMenu(false);
     setExporting(true);
-    await window.sourcerer.exportProject(project.id, mode, checkedIds.size > 0 ? [...checkedIds] : undefined);
+    await window.sourcerer.exportProject(project.id, mode, checkedIds.size > 0 ? [...checkedIds] : undefined, format);
     setExporting(false);
   }
 
@@ -465,6 +465,14 @@ export default function ProjectView({ project, user, onProjectUpdated, refreshTr
                 >
                   <span className="export-menu-label">Export as vCard</span>
                   <span className="export-menu-desc">All contacts as a .vcf file for address books</span>
+                </button>
+                <button className="export-menu-item" onClick={() => handleExport('full', 'gmail')}>
+                  <span className="export-menu-label">Export as Gmail CSV</span>
+                  <span className="export-menu-desc">Ready to re-import into Google Contacts</span>
+                </button>
+                <button className="export-menu-item" onClick={() => handleExport('full', 'outlook')}>
+                  <span className="export-menu-label">Export as Outlook CSV</span>
+                  <span className="export-menu-desc">Ready to re-import into Outlook contacts</span>
                 </button>
               </div>
             )}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -339,6 +339,7 @@ export interface ImportResult {
   skipped: Array<{ name: string; reason: 'name' | 'email' | 'missing-name' }>;
   cancelled: boolean;
   error?: string;
+  droppedFields?: string[];
 }
 
 export interface ContactAlertRss {

--- a/src/test/csv-format-detection.test.ts
+++ b/src/test/csv-format-detection.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, it, expect } from 'vitest';
+import { createTestDb, insertProject } from './vitest.setup';
+import { remapKnownCsvFormat, processImportRows } from '../main/ipc/import';
+import type { ProcessImportOptions } from '../main/ipc/import';
+import type Database from 'better-sqlite3-multiple-ciphers';
+
+let db: Database.Database;
+let projectId: string;
+
+const BASE_OPTS: ProcessImportOptions = {
+  phoneCountry: 'US',
+  reporterEmail: 'reporter@example.com',
+  reporterName: 'Test Reporter',
+};
+
+beforeEach(() => {
+  db = createTestDb();
+  projectId = insertProject(db, 'Test Project');
+});
+
+const GMAIL_HEADER = [
+  'Name', 'Given Name', 'Family Name', 'Birthday', 'Notes',
+  'E-mail 1 - Type', 'E-mail 1 - Value', 'E-mail 2 - Type', 'E-mail 2 - Value',
+  'Phone 1 - Type', 'Phone 1 - Value',
+  'Organization 1 - Type', 'Organization 1 - Name', 'Organization 1 - Title',
+  'Website 1 - Type', 'Website 1 - Value',
+];
+
+const OUTLOOK_HEADER = [
+  'First Name', 'Last Name', 'E-mail Address', 'E-mail 2 Address',
+  'Business Phone', 'Mobile Phone', 'Company', 'Job Title', 'Web Page', 'Birthday', 'Notes',
+];
+
+describe('remapKnownCsvFormat — Gmail', () => {
+  it('detects a Gmail export and remaps it to Sourcerer columns', () => {
+    const row = [
+      'Alice Smith', 'Alice', 'Smith', '1990-05-14', 'VIP source',
+      '* ', 'alice@example.com', '', 'alicework@example.com',
+      'Mobile', '+15551234567',
+      '', 'Acme Corp', 'Reporter',
+      '', 'https://linkedin.com/in/alicesmith',
+    ];
+    const [header, ...rows] = remapKnownCsvFormat([GMAIL_HEADER, row]);
+    expect(header.map((h) => h.toLowerCase())).toEqual(
+      ['name', 'organization', 'title', 'dob', 'notes', 'email', 'phone', 'linkedin', 'x', 'website'],
+    );
+    expect(rows).toEqual([[
+      'Alice Smith', 'Acme Corp', 'Reporter', '1990-05-14', 'VIP source',
+      'alice@example.com;alicework@example.com', '+15551234567',
+      'https://linkedin.com/in/alicesmith', '', '',
+    ]]);
+  });
+
+  it('falls back to Given Name + Family Name when Name is blank', () => {
+    const row = ['', 'Alice', 'Smith', '', '', '', '', '', '', '', '', '', '', '', '', ''];
+    const [, remapped] = remapKnownCsvFormat([GMAIL_HEADER, row]);
+    expect(remapped[0]).toBe('Alice Smith');
+  });
+
+  it('imports end-to-end into the database', () => {
+    const row = [
+      'Alice Smith', 'Alice', 'Smith', '1990-05-14', 'VIP source',
+      '* ', 'alice@example.com', '', '',
+      'Mobile', '+15551234567',
+      '', 'Acme Corp', 'Reporter',
+      '', '',
+    ];
+    const result = processImportRows(remapKnownCsvFormat([GMAIL_HEADER, row]), db, { ...BASE_OPTS, projectId });
+    expect(result.imported).toBe(1);
+    expect(result.skipped).toHaveLength(0);
+
+    const contact = db.prepare('SELECT * FROM contacts WHERE name = ?').get('Alice Smith') as
+      | { organization: string; title: string; dob: string } | undefined;
+    expect(contact?.organization).toBe('Acme Corp');
+    expect(contact?.title).toBe('Reporter');
+    expect(contact?.dob).toBe('1990-05-14');
+  });
+});
+
+describe('remapKnownCsvFormat — Outlook', () => {
+  it('detects an Outlook export and remaps it to Sourcerer columns', () => {
+    const row = [
+      'Bob', 'Jones', 'bob@example.com', 'bob.jones@personal.com',
+      '+1 555-987-6543', '', 'Globe Media', 'Editor', 'https://x.com/bobjones', '3/22/1985', 'Contact via referral',
+    ];
+    const [header, ...rows] = remapKnownCsvFormat([OUTLOOK_HEADER, row]);
+    expect(header.map((h) => h.toLowerCase())).toEqual(
+      ['name', 'organization', 'title', 'dob', 'notes', 'email', 'phone', 'linkedin', 'x', 'website'],
+    );
+    expect(rows).toEqual([[
+      'Bob Jones', 'Globe Media', 'Editor', '1985-03-22', 'Contact via referral',
+      'bob@example.com;bob.jones@personal.com', '+1 555-987-6543',
+      '', 'https://x.com/bobjones', '',
+    ]]);
+  });
+
+  it('imports end-to-end into the database', () => {
+    const row = [
+      'Bob', 'Jones', 'bob@example.com', '',
+      '+15559876543', '', 'Globe Media', 'Editor', '', '', '',
+    ];
+    const result = processImportRows(remapKnownCsvFormat([OUTLOOK_HEADER, row]), db, BASE_OPTS);
+    expect(result.imported).toBe(1);
+
+    const contact = db.prepare('SELECT * FROM contacts WHERE name = ?').get('Bob Jones') as
+      | { organization: string; title: string } | undefined;
+    expect(contact?.organization).toBe('Globe Media');
+    expect(contact?.title).toBe('Editor');
+
+    const email = db.prepare(
+      'SELECT email FROM contact_emails WHERE contact_id = (SELECT id FROM contacts WHERE name = ?)',
+    ).get('Bob Jones') as { email: string } | undefined;
+    expect(email?.email).toBe('bob@example.com');
+  });
+});
+
+describe('remapKnownCsvFormat — generic CSV', () => {
+  it('leaves a plain Sourcerer-format CSV unchanged', () => {
+    const rows = [
+      ['Name', 'Email'],
+      ['Carol Diaz', 'carol@example.com'],
+    ];
+    expect(remapKnownCsvFormat(rows)).toEqual(rows);
+  });
+
+  it('leaves an empty rows array unchanged', () => {
+    expect(remapKnownCsvFormat([])).toEqual([]);
+  });
+});

--- a/src/test/csv-format-detection.test.ts
+++ b/src/test/csv-format-detection.test.ts
@@ -40,21 +40,23 @@ describe('remapKnownCsvFormat — Gmail', () => {
       '', 'Acme Corp', 'Reporter',
       '', 'https://linkedin.com/in/alicesmith',
     ];
-    const [header, ...rows] = remapKnownCsvFormat([GMAIL_HEADER, row]);
+    const { rows: remapped, droppedFields } = remapKnownCsvFormat([GMAIL_HEADER, row]);
+    const [header, ...dataRows] = remapped;
     expect(header.map((h) => h.toLowerCase())).toEqual(
       ['name', 'organization', 'title', 'dob', 'notes', 'email', 'phone', 'linkedin', 'x', 'website'],
     );
-    expect(rows).toEqual([[
+    expect(dataRows).toEqual([[
       'Alice Smith', 'Acme Corp', 'Reporter', '1990-05-14', 'VIP source',
       'alice@example.com;alicework@example.com', '+15551234567',
       'https://linkedin.com/in/alicesmith', '', '',
     ]]);
+    expect(droppedFields).toEqual([]);
   });
 
   it('falls back to Given Name + Family Name when Name is blank', () => {
     const row = ['', 'Alice', 'Smith', '', '', '', '', '', '', '', '', '', '', '', '', ''];
-    const [, remapped] = remapKnownCsvFormat([GMAIL_HEADER, row]);
-    expect(remapped[0]).toBe('Alice Smith');
+    const { rows: remapped } = remapKnownCsvFormat([GMAIL_HEADER, row]);
+    expect(remapped[1][0]).toBe('Alice Smith');
   });
 
   it('imports end-to-end into the database', () => {
@@ -65,7 +67,8 @@ describe('remapKnownCsvFormat — Gmail', () => {
       '', 'Acme Corp', 'Reporter',
       '', '',
     ];
-    const result = processImportRows(remapKnownCsvFormat([GMAIL_HEADER, row]), db, { ...BASE_OPTS, projectId });
+    const { rows: remapped } = remapKnownCsvFormat([GMAIL_HEADER, row]);
+    const result = processImportRows(remapped, db, { ...BASE_OPTS, projectId });
     expect(result.imported).toBe(1);
     expect(result.skipped).toHaveLength(0);
 
@@ -75,6 +78,82 @@ describe('remapKnownCsvFormat — Gmail', () => {
     expect(contact?.title).toBe('Reporter');
     expect(contact?.dob).toBe('1990-05-14');
   });
+
+  it('reports source columns that carried data but have no home in Sourcerer', () => {
+    const header = [...GMAIL_HEADER, 'Address 1 - Street', 'Nickname'];
+    const row = [
+      'Alice Smith', 'Alice', 'Smith', '', '', '', '', '', '', '', '', '', '', '', '', '',
+      '123 Main St', '',
+    ];
+    const { droppedFields } = remapKnownCsvFormat([header, row]);
+    expect(droppedFields).toEqual(['Address 1 - Street']);
+  });
+
+  it('does not report unused columns when every row leaves them blank', () => {
+    const header = [...GMAIL_HEADER, 'Address 1 - Street'];
+    const row = ['Alice Smith', 'Alice', 'Smith', '', '', '', '', '', '', '', '', '', '', '', '', '', ''];
+    const { droppedFields } = remapKnownCsvFormat([header, row]);
+    expect(droppedFields).toEqual([]);
+  });
+});
+
+// Google's current contacts CSV schema (its own official import template,
+// and what a fresh Google Contacts export produces) — First/Last Name and
+// unprefixed Organization Name/Title, not the legacy Given/Family Name +
+// "Organization 1 -" variant covered above.
+const GMAIL_REAL_HEADER = [
+  'Name Prefix', 'First Name', 'Middle Name', 'Last Name', 'Name Suffix',
+  'Phonetic First Name', 'Phonetic Middle Name', 'Phonetic Last Name', 'Nickname', 'File As',
+  'E-mail 1 - Label', 'E-mail 1 - Value', 'Phone 1 - Label', 'Phone 1 - Value',
+  'Address 1 - Label', 'Address 1 - Country', 'Address 1 - Street', 'Address 1 - Extended Address',
+  'Address 1 - City', 'Address 1 - Region', 'Address 1 - Postal Code', 'Address 1 - PO Box',
+  'Organization Name', 'Organization Title', 'Organization Department', 'Birthday',
+  'Event 1 - Label', 'Event 1 - Value', 'Relation 1 - Label', 'Relation 1 - Value',
+  'Website 1 - Label', 'Website 1 - Value', 'Custom Field 1 - Label', 'Custom Field 1 - Value',
+  'Notes', 'Labels',
+];
+
+describe('remapKnownCsvFormat — Gmail (current real-world schema)', () => {
+  it('remaps First/Last Name and unprefixed Organization Name/Title', () => {
+    const row = GMAIL_REAL_HEADER.map((h) => {
+      switch (h) {
+        case 'First Name': return 'Alice';
+        case 'Last Name': return 'Smith';
+        case 'E-mail 1 - Value': return 'alice@example.com';
+        case 'Phone 1 - Value': return '+15551234567';
+        case 'Organization Name': return 'Acme Corp';
+        case 'Organization Title': return 'Reporter';
+        case 'Birthday': return '1990-05-14';
+        case 'Website 1 - Value': return 'https://example.com/alice';
+        case 'Notes': return 'VIP source';
+        default: return '';
+      }
+    });
+    const { rows: remapped } = remapKnownCsvFormat([GMAIL_REAL_HEADER, row]);
+    expect(remapped[1]).toEqual([
+      'Alice Smith', 'Acme Corp', 'Reporter', '1990-05-14', 'VIP source',
+      'alice@example.com', '+15551234567', '', '', 'https://example.com/alice',
+    ]);
+  });
+
+  it('flags populated address/relation/custom fields as dropped', () => {
+    const row = GMAIL_REAL_HEADER.map((h) => {
+      switch (h) {
+        case 'First Name': return 'Alice';
+        case 'Last Name': return 'Smith';
+        case 'Address 1 - Street': return '123 Main St';
+        case 'Relation 1 - Value': return 'Jane Smith';
+        case 'Custom Field 1 - Value': return 'Editor pref';
+        default: return '';
+      }
+    });
+    const { droppedFields } = remapKnownCsvFormat([GMAIL_REAL_HEADER, row]);
+    expect(droppedFields).toContain('Address 1 - Street');
+    expect(droppedFields).toContain('Relation 1 - Value');
+    expect(droppedFields).toContain('Custom Field 1 - Value');
+    // Populated label columns paired with those values are dropped too.
+    expect(droppedFields).not.toContain('Name Prefix');
+  });
 });
 
 describe('remapKnownCsvFormat — Outlook', () => {
@@ -83,15 +162,17 @@ describe('remapKnownCsvFormat — Outlook', () => {
       'Bob', 'Jones', 'bob@example.com', 'bob.jones@personal.com',
       '+1 555-987-6543', '', 'Globe Media', 'Editor', 'https://x.com/bobjones', '3/22/1985', 'Contact via referral',
     ];
-    const [header, ...rows] = remapKnownCsvFormat([OUTLOOK_HEADER, row]);
+    const { rows: remapped, droppedFields } = remapKnownCsvFormat([OUTLOOK_HEADER, row]);
+    const [header, ...dataRows] = remapped;
     expect(header.map((h) => h.toLowerCase())).toEqual(
       ['name', 'organization', 'title', 'dob', 'notes', 'email', 'phone', 'linkedin', 'x', 'website'],
     );
-    expect(rows).toEqual([[
+    expect(dataRows).toEqual([[
       'Bob Jones', 'Globe Media', 'Editor', '1985-03-22', 'Contact via referral',
       'bob@example.com;bob.jones@personal.com', '+1 555-987-6543',
       '', 'https://x.com/bobjones', '',
     ]]);
+    expect(droppedFields).toEqual([]);
   });
 
   it('imports end-to-end into the database', () => {
@@ -99,7 +180,8 @@ describe('remapKnownCsvFormat — Outlook', () => {
       'Bob', 'Jones', 'bob@example.com', '',
       '+15559876543', '', 'Globe Media', 'Editor', '', '', '',
     ];
-    const result = processImportRows(remapKnownCsvFormat([OUTLOOK_HEADER, row]), db, BASE_OPTS);
+    const { rows: remapped } = remapKnownCsvFormat([OUTLOOK_HEADER, row]);
+    const result = processImportRows(remapped, db, BASE_OPTS);
     expect(result.imported).toBe(1);
 
     const contact = db.prepare('SELECT * FROM contacts WHERE name = ?').get('Bob Jones') as
@@ -112,18 +194,32 @@ describe('remapKnownCsvFormat — Outlook', () => {
     ).get('Bob Jones') as { email: string } | undefined;
     expect(email?.email).toBe('bob@example.com');
   });
+
+  it('reports populated Outlook fields Sourcerer has no home for', () => {
+    const header = [...OUTLOOK_HEADER, 'Home Street', 'Spouse', 'Anniversary'];
+    const row = [
+      'Bob', 'Jones', 'bob@example.com', '', '', '', 'Globe Media', 'Editor', '', '', '',
+      '456 Oak Ave', 'Jane Jones', '',
+    ];
+    const { droppedFields } = remapKnownCsvFormat([header, row]);
+    expect(droppedFields).toEqual(['Home Street', 'Spouse']);
+  });
 });
 
 describe('remapKnownCsvFormat — generic CSV', () => {
-  it('leaves a plain Sourcerer-format CSV unchanged', () => {
+  it('leaves a plain Sourcerer-format CSV unchanged, with no dropped fields', () => {
     const rows = [
       ['Name', 'Email'],
       ['Carol Diaz', 'carol@example.com'],
     ];
-    expect(remapKnownCsvFormat(rows)).toEqual(rows);
+    const result = remapKnownCsvFormat(rows);
+    expect(result.rows).toEqual(rows);
+    expect(result.droppedFields).toEqual([]);
   });
 
   it('leaves an empty rows array unchanged', () => {
-    expect(remapKnownCsvFormat([])).toEqual([]);
+    const result = remapKnownCsvFormat([]);
+    expect(result.rows).toEqual([]);
+    expect(result.droppedFields).toEqual([]);
   });
 });

--- a/src/test/export.test.ts
+++ b/src/test/export.test.ts
@@ -151,3 +151,45 @@ describe('export:all-contacts — sub-table data (#442 refactor)', () => {
     expect(content).toContain('signal: @alice');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Gmail / Outlook CSV export formats (#463)
+// ---------------------------------------------------------------------------
+
+describe('export:all-contacts — gmail/outlook formats', () => {
+  it('writes Gmail-shaped headers and splits the name into Given/Family Name', async () => {
+    insertContact(testDb, 'Alice Smith', { org: 'Acme Corp', title: 'Reporter', emails: ['alice@example.com'], phones: ['+12025550100'] });
+    const filePath = join(dir, 'gmail.csv');
+    vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath } as unknown as Awaited<ReturnType<typeof dialog.showSaveDialog>>);
+
+    const result = await handlers.get('export:all-contacts')!({ sender: {} }, { format: 'gmail' }) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    const [header, row] = readFileSync(filePath, 'utf-8').trim().split('\n');
+    expect(header).toContain('Given Name');
+    expect(header).toContain('E-mail 1 - Value');
+    expect(header).toContain('Organization 1 - Name');
+    expect(row).toContain('Alice');
+    expect(row).toContain('Smith');
+    expect(row).toContain('alice@example.com');
+    expect(row).toContain('Acme Corp');
+  });
+
+  it('writes Outlook-shaped headers and splits the name into First/Last Name', async () => {
+    insertContact(testDb, 'Bob Jones', { org: 'Globe Media', title: 'Editor', emails: ['bob@example.com'], phones: ['+12025550100'] });
+    const filePath = join(dir, 'outlook.csv');
+    vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath } as unknown as Awaited<ReturnType<typeof dialog.showSaveDialog>>);
+
+    const result = await handlers.get('export:all-contacts')!({ sender: {} }, { format: 'outlook' }) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    const [header, row] = readFileSync(filePath, 'utf-8').trim().split('\n');
+    expect(header).toContain('First Name');
+    expect(header).toContain('E-mail Address');
+    expect(header).toContain('Company');
+    expect(row).toContain('Bob');
+    expect(row).toContain('Jones');
+    expect(row).toContain('bob@example.com');
+    expect(row).toContain('Globe Media');
+  });
+});

--- a/src/test/export.test.ts
+++ b/src/test/export.test.ts
@@ -168,11 +168,32 @@ describe('export:all-contacts — gmail/outlook formats', () => {
     const [header, row] = readFileSync(filePath, 'utf-8').trim().split('\n');
     expect(header).toContain('Given Name');
     expect(header).toContain('E-mail 1 - Value');
-    expect(header).toContain('Organization 1 - Name');
+    expect(header).toContain('Organization Name');
     expect(row).toContain('Alice');
     expect(row).toContain('Smith');
     expect(row).toContain('alice@example.com');
     expect(row).toContain('Acme Corp');
+  });
+
+  it('widens E-mail/Phone/Website columns to fit the contact with the most of each', async () => {
+    insertContact(testDb, 'Carol Diaz', {
+      emails: ['carol@work.com', 'carol@home.com', 'carol@other.com'],
+      phones: ['+12025550101', '+12025550102'],
+    });
+    insertContact(testDb, 'Dan Lee', { emails: ['dan@example.com'] });
+    const filePath = join(dir, 'gmail-wide.csv');
+    vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath } as unknown as Awaited<ReturnType<typeof dialog.showSaveDialog>>);
+
+    const result = await handlers.get('export:all-contacts')!({ sender: {} }, { format: 'gmail' }) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    const lines = readFileSync(filePath, 'utf-8').trim().split('\n');
+    expect(lines[0]).toContain('E-mail 3 - Value');
+    expect(lines[0]).toContain('Phone 2 - Value');
+    const carolRow = lines.find((l) => l.includes('Carol'))!;
+    expect(carolRow).toContain('carol@work.com');
+    expect(carolRow).toContain('carol@home.com');
+    expect(carolRow).toContain('carol@other.com');
   });
 
   it('writes Outlook-shaped headers and splits the name into First/Last Name', async () => {
@@ -191,5 +212,23 @@ describe('export:all-contacts — gmail/outlook formats', () => {
     expect(row).toContain('Jones');
     expect(row).toContain('bob@example.com');
     expect(row).toContain('Globe Media');
+  });
+
+  it('fills all fixed Outlook email/phone slots for a contact with several of each', async () => {
+    insertContact(testDb, 'Erin Park', {
+      emails: ['erin@work.com', 'erin@home.com', 'erin@other.com'],
+      phones: ['+12025550111', '+12025550112', '+12025550113'],
+    });
+    const filePath = join(dir, 'outlook-wide.csv');
+    vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath } as unknown as Awaited<ReturnType<typeof dialog.showSaveDialog>>);
+
+    const result = await handlers.get('export:all-contacts')!({ sender: {} }, { format: 'outlook' }) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content).toContain('E-mail 3 Address');
+    expect(content).toContain('erin@work.com');
+    expect(content).toContain('erin@home.com');
+    expect(content).toContain('erin@other.com');
   });
 });


### PR DESCRIPTION
## Summary
- CSV import now auto-detects Gmail's and Outlook's contact-export header shapes and remaps them onto Sourcerer's existing column vocabulary before the normal import logic runs. Plain Sourcerer-format CSVs are unaffected.
  - Gmail: supports both the current schema (`First Name`/`Last Name`, unprefixed `Organization Name`/`Organization Title`, numbered `E-mail N - Value`/`Phone N - Value`/`Website N - Value`) and an older export variant (`Given Name`/`Family Name`, `Organization 1 - Name`/`Title`). Verified against Google's own current contacts import template.
  - Outlook: `First Name`/`Last Name`, up to 3 emails, 6 phone types, `Web Page` + `Personal Web Page`. Verified against a real Outlook contacts export.
  - LinkedIn/X URLs found in generic website columns are routed to their own contact_links type instead of landing in "website".
- Export gains two new formats, "Export as Gmail CSV" and "Export as Outlook CSV", available from both the All Contacts view and per-project export menus, alongside the existing CSV/Excel and vCard options.
  - Gmail export dynamically widens `E-mail N - Value`/`Phone N - Value`/`Website N - Value` to fit however many the widest contact in the export actually has — nothing is dropped, matching Google's genuinely unbounded numbered-column schema.
  - Outlook export fills all of Outlook's real fixed slots (3 emails, 6 phone types, 2 web pages) — the true ceiling of that schema, since Outlook has no expandable numbering scheme the way Gmail does.
- After a CSV import, the result modal now notes any source columns that carried data but have no home in Sourcerer's contact model (e.g. physical addresses, spouse, custom fields) so nothing silently vanishes without the user knowing. Type/Label companion columns (e.g. `Phone 1 - Type`) are excluded from that note since they're just qualifiers on data that *was* imported.
- Birthdays are normalized between ISO (`YYYY-MM-DD`), Google's year-unknown form (`--MM-DD`, discarded), and Outlook's `M/D/YYYY`.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (547 tests), including `src/test/csv-format-detection.test.ts` (Gmail/Outlook detection, both schema variants, dropped-field reporting, end-to-end import) and cases in `src/test/export.test.ts` (Gmail/Outlook export shape, dynamic widening, fixed Outlook slots)
- [x] Manual testing in the running dev app against real Gmail and Outlook contact export files

Closes #463