### PR TITLE
chore: bump to v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sourcerer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sourcerer",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcerer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Encrypted source management for journalists",
   "author": "Tom Cardoso",


### PR DESCRIPTION
## What's new

- **Import contacts exported from Gmail or Outlook.** Sourcerer now recognizes a CSV file straight out of Google Contacts or Outlook and maps it to the right fields automatically — no need to reformat anything first. After an import, if your file included information Sourcerer doesn't track (like a mailing address or a spouse's name), you'll see a note listing what was skipped so nothing goes missing silently.
- **Export contacts as a Gmail or Outlook CSV.** Alongside the existing CSV/Excel and vCard export options, you can now export contacts (from All Contacts or from within a project) in a format ready to be re-imported directly into Google Contacts or Outlook.

## Test plan
- [x] `npm version patch` ran the full pre-release check (typecheck, lint, test suite — 547 tests) with no errors
- [x] Manual testing of the new import/export flows in the running app

<!-- The release workflow prepends this to the auto-generated commit list. -->